### PR TITLE
Removed IPage interface

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Base/BasePage.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Base/BasePage.cs
@@ -7,7 +7,7 @@ using System;
 
 namespace CommunityToolkit.Maui.Sample.Pages
 {
-    public class BasePage : ContentPage, IPage
+    public class BasePage : ContentPage
     {
         public BasePage()
         {


### PR DESCRIPTION
For Maui preview 7 we don't have the `IPage` interface anymore.

you can see more info [here](https://github.com/dotnet/maui/pull/1875)