### PR TITLE
Add version number generation for PRs to pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,9 +66,9 @@ jobs:
       - powershell: |
           $prNumber = $env:System_PullRequest_PullRequestNumber
           $commitId = "$(Build.SourceVersion)".Substring(0, 7)
-          $fullVersionString = $(CurrentSemanticVersionBase)-build.$prNumber+$commitId")
+          $fullVersionString = $(CurrentSemanticVersionBase)-build.$prNumber+$commitId
           Write-Host("GitHub PR = $prNumber, Commit = $commitId");
-          Write-Host ("##vso[task.setvariable variable=NugetPackageVersion;]$fullVersionString
+          Write-Host ("##vso[task.setvariable variable=NugetPackageVersion;]$fullVersionString")
           Write-Host "##vso[build.updatebuildnumber]$fullVersionString"
         displayName: Set NuGet Version to PR Version
         condition: and(succeeded(), eq(variables['build.reason'], 'PullRequest'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,6 +62,14 @@ jobs:
           Write-Host ("##vso[task.setvariable variable=NugetPackageVersion;]$tagVersion")
         displayName: Set NuGet Version to Tag Number
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+      # if this is a PR build, then update the version number
+      - powershell: |
+          $prNumber = $env:System_PullRequest_PullRequestId
+          $commitId = "$(Build.SourceVersion)"
+          Write-Host("GitHub PR = $prNumber, Commit = $commitId");
+          Write-Host ("##vso[task.setvariable variable=NugetPackageVersion;]$(CurrentSemanticVersionBase)-build.$prNumber+$commitId")
+        displayName: Set NuGet Version to PR Version
+        condition: and(succeeded(), eq(variables['build.reason'], 'PullRequest'))
       # restore, build and pack the packages
       - task: CmdLine@2
         displayName: 'Build Community Toolkit'
@@ -101,6 +109,14 @@ jobs:
           Write-Host ("##vso[task.setvariable variable=NugetPackageVersion;]$tagVersion")
         displayName: Set NuGet Version to Tag Number
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
+      # if this is a PR build, then update the version number
+      - powershell: |
+          $prNumber = $env:System_PullRequest_PullRequestId
+          $commitId = "$(Build.SourceVersion)"
+          Write-Host("GitHub PR = $prNumber, Commit = $commitId");
+          Write-Host ("##vso[task.setvariable variable=NugetPackageVersion;]$(CurrentSemanticVersionBase)-build.$prNumber+$commitId")
+        displayName: Set NuGet Version to PR Version
+        condition: and(succeeded(), eq(variables['build.reason'], 'PullRequest'))
       - task: UseDotNet@2
         displayName: 'Install .NET SDK'
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,8 +64,8 @@ jobs:
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
       # if this is a PR build, then update the version number
       - powershell: |
-          $prNumber = $env:System_PullRequest_PullRequestId
-          $commitId = "$(Build.SourceVersion)"
+          $prNumber = $env:System_PullRequest_PullRequestNumber
+          $commitId = "$(Build.SourceVersion)".Substring(0, 7)
           Write-Host("GitHub PR = $prNumber, Commit = $commitId");
           Write-Host ("##vso[task.setvariable variable=NugetPackageVersion;]$(CurrentSemanticVersionBase)-build.$prNumber+$commitId")
         displayName: Set NuGet Version to PR Version
@@ -109,14 +109,6 @@ jobs:
           Write-Host ("##vso[task.setvariable variable=NugetPackageVersion;]$tagVersion")
         displayName: Set NuGet Version to Tag Number
         condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/')
-      # if this is a PR build, then update the version number
-      - powershell: |
-          $prNumber = $env:System_PullRequest_PullRequestId
-          $commitId = "$(Build.SourceVersion)"
-          Write-Host("GitHub PR = $prNumber, Commit = $commitId");
-          Write-Host ("##vso[task.setvariable variable=NugetPackageVersion;]$(CurrentSemanticVersionBase)-build.$prNumber+$commitId")
-        displayName: Set NuGet Version to PR Version
-        condition: and(succeeded(), eq(variables['build.reason'], 'PullRequest'))
       - task: UseDotNet@2
         displayName: 'Install .NET SDK'
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,8 +66,10 @@ jobs:
       - powershell: |
           $prNumber = $env:System_PullRequest_PullRequestNumber
           $commitId = "$(Build.SourceVersion)".Substring(0, 7)
+          $fullVersionString = $(CurrentSemanticVersionBase)-build.$prNumber+$commitId")
           Write-Host("GitHub PR = $prNumber, Commit = $commitId");
-          Write-Host ("##vso[task.setvariable variable=NugetPackageVersion;]$(CurrentSemanticVersionBase)-build.$prNumber+$commitId")
+          Write-Host ("##vso[task.setvariable variable=NugetPackageVersion;]$fullVersionString
+          Write-Host "##vso[build.updatebuildnumber]$fullVersionString"
         displayName: Set NuGet Version to PR Version
         condition: and(succeeded(), eq(variables['build.reason'], 'PullRequest'))
       # restore, build and pack the packages

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,7 +66,7 @@ jobs:
       - powershell: |
           $prNumber = $env:System_PullRequest_PullRequestNumber
           $commitId = "$(Build.SourceVersion)".Substring(0, 7)
-          $fullVersionString = $(CurrentSemanticVersionBase)-build.$prNumber+$commitId
+          $fullVersionString = "$(CurrentSemanticVersionBase)-build.$prNumber+$commitId"
           Write-Host("GitHub PR = $prNumber, Commit = $commitId");
           Write-Host ("##vso[task.setvariable variable=NugetPackageVersion;]$fullVersionString")
           Write-Host "##vso[build.updatebuildnumber]$fullVersionString"


### PR DESCRIPTION
For PRs I now generate a version number like `1.0.0-build.18+1a2b3c4`. The number is `{current major version}-build{GitHub PR issue number}+{commit SHA}`.

I also hooked up a release that releases PR builds, with this version number, to a special PR nuget feed so people can easily try out new changes.

Additionally, to make people find the NuGets more easily I rename the Azure DevOps build name so that it shows up in the GitHub Checks, see:

![image](https://user-images.githubusercontent.com/939291/130213380-3e82d9c9-93d5-4561-95a4-c0e5286749b9.png)

Or check the actual checks box at the bottom of this PR :)