### PR TITLE
Use Xcode 12.5

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,7 @@ variables:
   PathToSolution: 'src/CommunityToolkit.Maui.sln'
   PathToCommunityToolkitCsproj: 'src/CommunityToolkit.Maui/CommunityToolkit.Maui.csproj'
   PathToCommunityToolkitUnitTestCsproj: 'src/CommunityToolkit.Maui.UnitTests/CommunityToolkit.Maui.UnitTests.csproj'
+  XcodeVersion: '12.5'
 
 trigger:
   branches:
@@ -86,7 +87,9 @@ jobs:
       - task: CmdLine@2
         displayName: 'Build Community Toolkit'
         inputs:
-          script: 'dotnet build $(PathToCommunityToolkitCsproj) -c Release'
+          script: |
+            /bin/bash -c "sudo xcode-select -s /Applications/Xcode_$(XcodeVersion).app/Contents/Developer" #https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#xcode
+            'dotnet build $(PathToCommunityToolkitCsproj) -c Release'
       - task: CmdLine@2
         displayName: Pack Community Toolkit NuGets
         inputs:


### PR DESCRIPTION
## Fixes
Fixes the build errors caused by Azure DevOps upgrading to Xcode 13 which .NET MAUI does not yet support for MacCatalyst

> /Users/runner/hostedtoolcache/dotnet/packs/Microsoft.MacCatalyst.Sdk/15.0.101-preview.9.31/tools/msbuild/iOS/Xamarin.Shared.targets(324,3): error : Could not map the Mac Catalyst version 15.0 to a corresponding macOS version. Valid Mac Catalyst versions are: 13.3.1, 13.3, 14.2, 13.2, 14.5, 14.1, 13.5, 13.1, 14.4, 14.0, 13.4, 14.3 [/Users/runner/work/1/s/src/CommunityToolkit.Maui/CommunityToolkit.Maui.csproj]

## Description

Updates the `Build Community Toolkit` step to include `xcode-select -s /Applications/Xcode_12.5.app/Contents/Developer` 

## Detailed Solution

```yml
- task: CmdLine@2
  displayName: 'Build Community Toolkit'
  inputs:
    script: |
      /bin/bash -c "sudo xcode-select -s /Applications/Xcode_$(XcodeVersion).app/Contents/Developer" #https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#xcode
      'dotnet build $(PathToCommunityToolkitCsproj) -c Release'
```
