### PR TITLE
Enable iOS Builds in Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -164,13 +164,10 @@ jobs:
         displayName: 'Build Community Toolkit'
         inputs:
           script: 'dotnet build $(PathToCommunityToolkitCsproj) -c Release'
-      #Note: Building iOS Sample App Requires Provisioning Profile
       - task: CmdLine@2
         displayName: 'Build Community Toolkit Sample'
         inputs:
-          script: |
-            dotnet build $(PathToCommunityToolkitSampleCsproj) -c Release -f net6.0-android
-            dotnet build $(PathToCommunityToolkitSampleCsproj) -c Release -f net6.0-maccatalyst
+          script: 'dotnet build $(PathToCommunityToolkitSampleCsproj) -c Release'
       # `dotnet test` does not yet support optional workloads https://github.com/dotnet/sdk/issues/21845#issuecomment-943270826
       - task: CmdLine@2
         displayName: 'Run Unit Tests'

--- a/samples/CommunityToolkit.Maui.Sample/Platforms/iOS/Entitlements.plist
+++ b/samples/CommunityToolkit.Maui.Sample/Platforms/iOS/Entitlements.plist
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-    <dict>
-    </dict>
-</plist>


### PR DESCRIPTION
## Fixes
This PR allows Azure Pipelines to build the iOS Sample App in `CommunityToolkit.Maui.Samples`.

## Description

Currently, `azure-pipelines.yml` only builds the Android + MacCatalyst version of the sample app:
```yml
#Note: Building iOS Sample App Requires Provisioning Profile
- task: CmdLine@2
  displayName: 'Build Community Toolkit Sample'
  inputs:
    script: |
      dotnet build $(PathToCommunityToolkitSampleCsproj) -c Release -f net6.0-android
      dotnet build $(PathToCommunityToolkitSampleCsproj) -c Release -f net6.0-maccatalyst
```

This was done because building the iOS sample app without a Provisioning Profile would cause an error:
```bash
Build FAILED.

/Users/runner/.dotnet/packs/Microsoft.iOS.Sdk/15.0.101-preview.9.31/tools/msbuild/iOS/Xamarin.Shared.targets(1056,3): error : Could not find any available provisioning profiles
```

By removing `Entitlements.plist`, which is currently empty, we can build the iOS app in Azure Pipelines without the need for a Provisioning Profile 

## Detailed Solution

- Remove `Entitlements.plist`
  - `Entitlements.plist` requires a iOS provisioning profile + iOS signing certificate
- Update `azure-pipelines.yml` to build the entire Sample App:
  ```yml
  - task: CmdLine@2
   displayName: 'Build Community Toolkit Sample'
   inputs:
     script: 'dotnet build $(PathToCommunityToolkitSampleCsproj) -c Release'
  ```