### PR TITLE
Color to animation extension #88

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -45,3 +45,6 @@ csharp_style_namespace_declarations = file_scoped:error
 
 # CS4014: Because this call is not awaited, execution of the current method continues before the call is completed
 dotnet_diagnostic.CS4014.severity = error
+
+# Remove explicit default access modifiers
+dotnet_style_require_accessibility_modifiers = omit_if_default:error

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -129,7 +129,7 @@ jobs:
   - job: build_macos
     displayName: Build macOS Library
     pool:
-      vmImage: macos-latest
+      vmImage: macos-11
     steps:
       # if this is a tagged build, then update the version number
       - powershell: |

--- a/samples/CommunityToolkit.Maui.Sample/CommunityToolkit.Maui.Sample.csproj
+++ b/samples/CommunityToolkit.Maui.Sample/CommunityToolkit.Maui.Sample.csproj
@@ -48,8 +48,8 @@
     <!-- Required for C# Hot Reload -->
     <UseInterpreter Condition="'$(Configuration)' == 'Debug'">True</UseInterpreter>
 
-    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-ios'">14.2</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-maccatalyst'">14.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-ios'">15.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-maccatalyst'">15.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-android'">21.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$(TargetFramework.Contains('-windows'))">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$(TargetFramework.Contains('-windows'))">10.0.17763.0</TargetPlatformMinVersion>
@@ -58,8 +58,8 @@
 
   <ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
     <!-- Required - WinUI does not yet have buildTransitive for everything -->
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0-preview3" />
-    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.0.0.29-preview3" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Graphics.Win2D" Version="1.0.0.30" />
   </ItemGroup>
 
   <PropertyGroup Condition="$(TargetFramework.Contains('-windows'))">

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ColorAnimationExtensionsPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ColorAnimationExtensionsPage.xaml
@@ -3,9 +3,17 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:pages="clr-namespace:CommunityToolkit.Maui.Sample.Pages"
+    xmlns:mct="clr-namespace:CommunityToolkit.Maui.Converters;assembly=CommunityToolkit.Maui"
     x:Class="CommunityToolkit.Maui.Sample.Pages.Extensions.ColorAnimationExtensionsPage">
+
+    <pages:BasePage.Resources>
+        <ResourceDictionary>
+            <mct:ColorToColorForTextConverter x:Key="ColorToColorForTextConverter"/>
+        </ResourceDictionary>
+    </pages:BasePage.Resources>
+
     <pages:BasePage.Content>
-        <VerticalStackLayout Margin="10, 5" Spacing="2">
+        <VerticalStackLayout Margin="10, 5" Spacing="12">
             <Label Text="The ColorTo extension method provides an easy way to have an animation to change the BackgroundColor of a VisualElement" />
 
             <Label Text="Color: " />
@@ -20,16 +28,18 @@
             <Label Text="Easing function: " />
             <Picker x:Name="EasingPicker" />
 
-            <Frame x:Name="ColorFrame" 
-                   BorderColor="Black">
-                <Label Text="Watch My Background Color Change"
-                       HeightRequest="200" 
-                       HorizontalOptions="FillAndExpand" 
-                       HorizontalTextAlignment="Center"
-                       VerticalTextAlignment="Center"/>
+            <Frame x:Name="ColorFrame"
+                   BorderColor="Black"
+                   HasShadow="False"
+                   BackgroundColor="White">
+
+                <Label TextColor="{Binding Source={x:Reference ColorFrame}, Path=BackgroundColor, Converter={StaticResource ColorToColorForTextConverter}}"
+                    Text="Watch My Background Color Change"
+                    HorizontalTextAlignment="Center"
+                    VerticalTextAlignment="Center"/>
             </Frame>
 
-            <Button Text="Start ToColor Animation!" Clicked="Button_Clicked" Margin="5" BackgroundColor="Red" />
+            <Button Text="Animate" Clicked="Button_Clicked" BackgroundColor="DarkGreen" />
 
         </VerticalStackLayout>
     </pages:BasePage.Content>

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ColorAnimationExtensionsPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ColorAnimationExtensionsPage.xaml
@@ -2,20 +2,34 @@
 <pages:BasePage 
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:mct="clr-namespace:CommunityToolkit.Maui.Converters;assembly=CommunityToolkit.Maui"
     xmlns:pages="clr-namespace:CommunityToolkit.Maui.Sample.Pages"
     x:Class="CommunityToolkit.Maui.Sample.Pages.Extensions.ColorAnimationExtensionsPage">
     <pages:BasePage.Content>
         <StackLayout>
-            <Label Text="ColorTo" />
+            <Label Text="The ColorTo extension method provides an easy way to have an animation to change the BackgroundColor of a VisualElement" />
 
-            <Grid x:Name="TestPane"
+            <StackLayout Margin="10, 5">
+                <Label Text="Color: " />
+                <Picker x:Name="ColorPicker" />
+
+                <Label Text="Rate (ms):" />
+                <Entry Keyboard="Numeric" x:Name="RateInput" Text="16" />
+
+                <Label Text="Duration (ms):" />
+                <Entry Keyboard="Numeric" x:Name="DurationInput" Text="250" />
+
+                <Label Text="Easing function: " />
+                <Picker x:Name="EasingPicker" />
+
+                <Grid x:Name="TestPane"
                      Margin="10"
                      HorizontalOptions="Center"
                      HeightRequest="100"
                      WidthRequest="100" />
-            
-            <Button Text="Animate!" Clicked="Button_Clicked" />
+
+                <Button Text="Animate!" Clicked="Button_Clicked" />
+            </StackLayout>
+
         </StackLayout>
     </pages:BasePage.Content>
 </pages:BasePage>

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ColorAnimationExtensionsPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ColorAnimationExtensionsPage.xaml
@@ -5,31 +5,42 @@
     xmlns:pages="clr-namespace:CommunityToolkit.Maui.Sample.Pages"
     x:Class="CommunityToolkit.Maui.Sample.Pages.Extensions.ColorAnimationExtensionsPage">
     <pages:BasePage.Content>
-        <StackLayout>
-            <Label Text="The ColorTo extension method provides an easy way to have an animation to change the BackgroundColor of a VisualElement" />
+        <ScrollView>
+            <StackLayout>
+                <Label Text="The ColorTo extension method provides an easy way to have an animation to change the BackgroundColor of a VisualElement" />
 
-            <StackLayout Margin="10, 5">
-                <Label Text="Color: " />
-                <Picker x:Name="ColorPicker" />
+                <StackLayout Margin="10, 5" Spacing="2">
+                    <Label Text="Color: " />
+                    <Picker x:Name="ColorPicker" />
 
-                <Label Text="Rate (ms):" />
-                <Entry Keyboard="Numeric" x:Name="RateInput" Text="16" />
+                    <Label Text="Rate (ms):" />
+                    <Entry Keyboard="Numeric" x:Name="RateInput" Text="16" />
 
-                <Label Text="Duration (ms):" />
-                <Entry Keyboard="Numeric" x:Name="DurationInput" Text="250" />
+                    <Label Text="Duration (ms):" />
+                    <Entry Keyboard="Numeric" x:Name="DurationInput" Text="250" />
 
-                <Label Text="Easing function: " />
-                <Picker x:Name="EasingPicker" />
+                    <Label Text="Easing function: " />
+                    <Picker x:Name="EasingPicker" />
 
-                <Grid x:Name="TestPane"
-                     Margin="10"
-                     HorizontalOptions="Center"
-                     HeightRequest="100"
-                     WidthRequest="100" />
+                    <GridLayout ColumnDefinitions="*, *" HeightRequest="100">
+                        <Grid x:Name="TestGrid"
+                                Margin="10"
+                                HorizontalOptions="Fill"
+                                VerticalOptions="Fill" />
+                        <BoxView x:Name="TestBox" 
+                                 Margin="10" GridLayout.Column="1"
+                                 HorizontalOptions="Fill"
+                                 VerticalOptions="Fill"  />
+                    </GridLayout>
 
-                <Button Text="Animate!" Clicked="Button_Clicked" />
+                    <Label Text="See my background change!"  x:Name="TestLbl"/>
+
+                    <Button Text="dummy button"  x:Name="TestBtn" />
+
+                    <Button Text="Start ToColor Animation!" Clicked="Button_Clicked" Margin="5" BackgroundColor="Red" />
+                </StackLayout>
+
             </StackLayout>
-
-        </StackLayout>
+        </ScrollView>
     </pages:BasePage.Content>
 </pages:BasePage>

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ColorAnimationExtensionsPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ColorAnimationExtensionsPage.xaml
@@ -14,7 +14,7 @@
 
     <pages:BasePage.Content>
         <VerticalStackLayout Margin="10, 5" Spacing="12">
-            <Label Text="The ColorTo extension method provides an easy way to have an animation to change the BackgroundColor of a VisualElement" />
+            <Label Text="The BackgroundColorTo extension method provides an easy way to have an animation to change the BackgroundColor of a VisualElement" />
 
             <Label Text="Color: " />
             <Picker x:Name="ColorPicker" />

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ColorAnimationExtensionsPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ColorAnimationExtensionsPage.xaml
@@ -5,42 +5,32 @@
     xmlns:pages="clr-namespace:CommunityToolkit.Maui.Sample.Pages"
     x:Class="CommunityToolkit.Maui.Sample.Pages.Extensions.ColorAnimationExtensionsPage">
     <pages:BasePage.Content>
-        <ScrollView>
-            <StackLayout>
-                <Label Text="The ColorTo extension method provides an easy way to have an animation to change the BackgroundColor of a VisualElement" />
+        <VerticalStackLayout Margin="10, 5" Spacing="2">
+            <Label Text="The ColorTo extension method provides an easy way to have an animation to change the BackgroundColor of a VisualElement" />
 
-                <StackLayout Margin="10, 5" Spacing="2">
-                    <Label Text="Color: " />
-                    <Picker x:Name="ColorPicker" />
+            <Label Text="Color: " />
+            <Picker x:Name="ColorPicker" />
 
-                    <Label Text="Rate (ms):" />
-                    <Entry Keyboard="Numeric" x:Name="RateInput" Text="16" />
+            <Label Text="Rate (ms):" />
+            <Entry Keyboard="Numeric" x:Name="RateInput" Text="16" />
 
-                    <Label Text="Duration (ms):" />
-                    <Entry Keyboard="Numeric" x:Name="DurationInput" Text="250" />
+            <Label Text="Duration (ms):" />
+            <Entry Keyboard="Numeric" x:Name="DurationInput" Text="1500" />
 
-                    <Label Text="Easing function: " />
-                    <Picker x:Name="EasingPicker" />
+            <Label Text="Easing function: " />
+            <Picker x:Name="EasingPicker" />
 
-                    <GridLayout ColumnDefinitions="*, *" HeightRequest="100">
-                        <Grid x:Name="TestGrid"
-                                Margin="10"
-                                HorizontalOptions="Fill"
-                                VerticalOptions="Fill" />
-                        <BoxView x:Name="TestBox" 
-                                 Margin="10" GridLayout.Column="1"
-                                 HorizontalOptions="Fill"
-                                 VerticalOptions="Fill"  />
-                    </GridLayout>
+            <Frame x:Name="ColorFrame" 
+                   BorderColor="Black">
+                <Label Text="Watch My Background Color Change"
+                       HeightRequest="200" 
+                       HorizontalOptions="FillAndExpand" 
+                       HorizontalTextAlignment="Center"
+                       VerticalTextAlignment="Center"/>
+            </Frame>
 
-                    <Label Text="See my background change!"  x:Name="TestLbl"/>
+            <Button Text="Start ToColor Animation!" Clicked="Button_Clicked" Margin="5" BackgroundColor="Red" />
 
-                    <Button Text="dummy button"  x:Name="TestBtn" />
-
-                    <Button Text="Start ToColor Animation!" Clicked="Button_Clicked" Margin="5" BackgroundColor="Red" />
-                </StackLayout>
-
-            </StackLayout>
-        </ScrollView>
+        </VerticalStackLayout>
     </pages:BasePage.Content>
 </pages:BasePage>

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ColorAnimationExtensionsPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ColorAnimationExtensionsPage.xaml
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<pages:BasePage 
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:mct="clr-namespace:CommunityToolkit.Maui.Converters;assembly=CommunityToolkit.Maui"
+    xmlns:pages="clr-namespace:CommunityToolkit.Maui.Sample.Pages"
+    x:Class="CommunityToolkit.Maui.Sample.Pages.Extensions.ColorAnimationExtensionsPage">
+    <pages:BasePage.Content>
+        <StackLayout>
+            <Label Text="ColorTo" />
+
+            <Grid x:Name="TestPane"
+                     Margin="10"
+                     HorizontalOptions="Center"
+                     HeightRequest="100"
+                     WidthRequest="100" />
+            
+            <Button Text="Animate!" Clicked="Button_Clicked" />
+        </StackLayout>
+    </pages:BasePage.Content>
+</pages:BasePage>

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ColorAnimationExtensionsPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ColorAnimationExtensionsPage.xaml.cs
@@ -1,30 +1,64 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Reflection;
 using CommunityToolkit.Maui.Extensions;
+using Microsoft.Maui;
 using Microsoft.Maui.Graphics;
 
 namespace CommunityToolkit.Maui.Sample.Pages.Extensions;
 
 public partial class ColorAnimationExtensionsPage : BasePage
 {
+	readonly IReadOnlyDictionary<string, Color> _colors = typeof(Colors)
+		.GetFields(BindingFlags.Static | BindingFlags.Public)
+		.ToDictionary(c => c.Name, c => (Color)(c.GetValue(null) ?? throw new InvalidOperationException()));
+
+	readonly IReadOnlyDictionary<string, Easing> _easings = typeof(Easing)
+		.GetFields(BindingFlags.Static | BindingFlags.Public)
+		.ToDictionary(c => c.Name, c => (Easing)(c.GetValue(null) ?? throw new InvalidOperationException()));
+
 	public ColorAnimationExtensionsPage()
 	{
 		InitializeComponent();
 
 		TestPane ??= new();
+		ColorPicker ??= new();
+		DurationInput ??= new();
+		RateInput ??= new();
+		EasingPicker ??= new();
+	}
+
+	protected override void OnAppearing()
+	{
+		ColorPicker.ItemsSource = _colors.Keys.ToList();
+		EasingPicker.ItemsSource = _easings.Keys.ToList();
+		SetPickersRandomValue();
+	}
+
+	private void SetPickersRandomValue()
+	{
+		ColorPicker.SelectedIndex = new Random().Next(ColorPicker.ItemsSource.Count);
+		EasingPicker.SelectedIndex = new Random().Next(EasingPicker.ItemsSource.Count);
 	}
 
 	private async void Button_Clicked(object sender, EventArgs e)
 	{
-		var r = new Random().Next(255) / 255f;
-		var g = new Random().Next(255) / 255f;
-		var b = new Random().Next(255) / 255f;
+		var color = _colors.ElementAtOrDefault(ColorPicker.SelectedIndex).Value ?? Colors.Transparent;
 
-		var c = new Color(r, g, b);
+		uint duration, rate;
 
-		await TestPane.ColorTo(c, length: 200);
+		if (!uint.TryParse(DurationInput.Text, out duration))
+			duration = 250;
+
+		if (!uint.TryParse(RateInput.Text, out rate))
+			rate = 16;
+
+		var easing = _easings.ElementAtOrDefault(EasingPicker.SelectedIndex).Value;
+
+
+		await TestPane.ColorTo(color, rate:rate, length: duration, easing: easing);
+
+		SetPickersRandomValue();
 	}
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ColorAnimationExtensionsPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ColorAnimationExtensionsPage.xaml.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using CommunityToolkit.Maui.Extensions;
 using Microsoft.Maui;
 using Microsoft.Maui.Graphics;
@@ -22,11 +23,14 @@ public partial class ColorAnimationExtensionsPage : BasePage
 	{
 		InitializeComponent();
 
-		TestPane ??= new();
+		TestGrid ??= new();
 		ColorPicker ??= new();
 		DurationInput ??= new();
 		RateInput ??= new();
 		EasingPicker ??= new();
+		TestLbl ??= new();
+		TestBtn ??= new();
+		TestBox ??= new();
 	}
 
 	protected override void OnAppearing()
@@ -57,7 +61,12 @@ public partial class ColorAnimationExtensionsPage : BasePage
 		var easing = _easings.ElementAtOrDefault(EasingPicker.SelectedIndex).Value;
 
 
-		await TestPane.ColorTo(color, rate:rate, length: duration, easing: easing);
+		await Task.WhenAll(
+			TestGrid.ColorTo(color, rate: rate, length: duration, easing: easing),
+			TestLbl.ColorTo(color, rate: rate, length: duration, easing: easing),
+			TestBtn.ColorTo(color, rate: rate, length: duration, easing: easing),
+			TestBox.ColorTo(color, rate: rate, length: duration, easing: easing)
+			);
 
 		SetPickersRandomValue();
 	}

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ColorAnimationExtensionsPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ColorAnimationExtensionsPage.xaml.cs
@@ -23,14 +23,11 @@ public partial class ColorAnimationExtensionsPage : BasePage
 	{
 		InitializeComponent();
 
-		TestGrid ??= new();
-		ColorPicker ??= new();
-		DurationInput ??= new();
 		RateInput ??= new();
+		ColorFrame ??= new();
+		ColorPicker ??= new();
 		EasingPicker ??= new();
-		TestLbl ??= new();
-		TestBtn ??= new();
-		TestBox ??= new();
+		DurationInput ??= new();
 	}
 
 	protected override void OnAppearing()
@@ -40,33 +37,25 @@ public partial class ColorAnimationExtensionsPage : BasePage
 		SetPickersRandomValue();
 	}
 
-	private void SetPickersRandomValue()
+	void SetPickersRandomValue()
 	{
 		ColorPicker.SelectedIndex = new Random().Next(ColorPicker.ItemsSource.Count);
 		EasingPicker.SelectedIndex = new Random().Next(EasingPicker.ItemsSource.Count);
 	}
 
-	private async void Button_Clicked(object sender, EventArgs e)
+	async void Button_Clicked(object sender, EventArgs e)
 	{
 		var color = _colors.ElementAtOrDefault(ColorPicker.SelectedIndex).Value ?? Colors.Transparent;
 
-		uint duration, rate;
+		if (!uint.TryParse(DurationInput.Text, out var duration))
+			duration = 1500;
 
-		if (!uint.TryParse(DurationInput.Text, out duration))
-			duration = 250;
-
-		if (!uint.TryParse(RateInput.Text, out rate))
+		if (!uint.TryParse(RateInput.Text, out var rate))
 			rate = 16;
 
 		var easing = _easings.ElementAtOrDefault(EasingPicker.SelectedIndex).Value;
 
-
-		await Task.WhenAll(
-			TestGrid.ColorTo(color, rate: rate, length: duration, easing: easing),
-			TestLbl.ColorTo(color, rate: rate, length: duration, easing: easing),
-			TestBtn.ColorTo(color, rate: rate, length: duration, easing: easing),
-			TestBox.ColorTo(color, rate: rate, length: duration, easing: easing)
-			);
+		await ColorFrame.BackgroundColorTo(color, rate, duration, easing);
 
 		SetPickersRandomValue();
 	}

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ColorAnimationExtensionsPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ColorAnimationExtensionsPage.xaml.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CommunityToolkit.Maui.Extensions;
+using Microsoft.Maui.Graphics;
+
+namespace CommunityToolkit.Maui.Sample.Pages.Extensions;
+
+public partial class ColorAnimationExtensionsPage : BasePage
+{
+	public ColorAnimationExtensionsPage()
+	{
+		InitializeComponent();
+
+		TestPane ??= new();
+	}
+
+	private async void Button_Clicked(object sender, EventArgs e)
+	{
+		var r = new Random().Next(255) / 255f;
+		var g = new Random().Next(255) / 255f;
+		var b = new Random().Next(255) / 255f;
+
+		var c = new Color(r, g, b);
+
+		await TestPane.ColorTo(c, length: 200);
+	}
+}

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ExtensionsGalleryPage.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ExtensionsGalleryPage.cs
@@ -1,0 +1,10 @@
+﻿using CommunityToolkit.Maui.Sample.ViewModels.Converters;
+
+namespace CommunityToolkit.Maui.Sample.Pages.Extensions;
+
+public class ExtensionsGalleryPage : BaseGalleryPage<ExtensionsGalleryViewModel>
+{
+	public ExtensionsGalleryPage() : base("Extensions")
+	{
+	}
+}

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Extensions/ExtensionsGalleryViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Extensions/ExtensionsGalleryViewModel.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using CommunityToolkit.Maui.Converters;
+using CommunityToolkit.Maui.Extensions;
+using CommunityToolkit.Maui.Sample.Models;
+using CommunityToolkit.Maui.Sample.Pages.Converters;
+using CommunityToolkit.Maui.Sample.Pages.Extensions;
+
+namespace CommunityToolkit.Maui.Sample.ViewModels.Converters;
+
+public class ExtensionsGalleryViewModel : BaseGalleryViewModel
+{
+    protected override IEnumerable<SectionModel> CreateItems() => new[]
+    {
+        new SectionModel(
+            typeof(ColorAnimationExtensionsPage),
+            nameof(ColorAnimationExtensions),
+            "Extension methods that provide color animations"),
+    };
+}

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/MainViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/MainViewModel.cs
@@ -2,6 +2,7 @@
 using CommunityToolkit.Maui.Sample.Models;
 using CommunityToolkit.Maui.Sample.Pages.Behaviors;
 using CommunityToolkit.Maui.Sample.Pages.Converters;
+using CommunityToolkit.Maui.Sample.Pages.Extensions;
 using Microsoft.Maui.Graphics;
 
 namespace CommunityToolkit.Maui.Sample.ViewModels;
@@ -15,5 +16,8 @@ public class MainViewModel : BaseGalleryViewModel
 
         new SectionModel(typeof(ConvertersGalleryPage), "Converters", Color.FromArgb("#EA005E"),
             "Converters let you convert bindings of a certain type to a different value, based on custom logic"),
-    };
+
+		new SectionModel(typeof(ExtensionsGalleryPage), "Extensions", Color.FromArgb("#00EA56"),
+			"Extenions lets you add methods to existing types without creating a new derived type, recompiling, or otherwise modifying the original type."),
+	};
 }

--- a/src/CommunityToolkit.Maui/Extensions/ColorAnimationExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui/Extensions/ColorAnimationExtensions.shared.cs
@@ -20,9 +20,10 @@ public static class ColorAnimationExtensions
 	/// <param name="length">The duration, in milliseconds, of the animation</param>
 	/// <param name="easing">The easing function to be used in the animation</param>
 	/// <returns>Value indicating if the animation completed successfully or not</returns>
-	public static Task<bool> ColorTo(this VisualElement element, Color color, uint rate = 16u, uint length = 250u, Easing? easing = null)
+	public static Task<bool> BackgroundColorTo(this VisualElement element, Color color, uint rate = 16u, uint length = 250u, Easing? easing = null)
 	{
 		ArgumentNullException.ThrowIfNull(element);
+		ArgumentNullException.ThrowIfNull(color);
 
 		//Although BackgroundColor is defined as not-nullable, it CAN be null
 		//If null => set it to Transparent as Animation will crash on null BackgroundColor
@@ -33,13 +34,13 @@ public static class ColorAnimationExtensions
 		try
 		{
 			new Animation
-			{ 
-				{ 0, 1, RedTransformAnimation(element, color.Red) },
-				{ 0, 1, GreenTransformAnimation(element, color.Green) },
-				{ 0, 1, BlueTransformAnimation(element, color.Blue) },
-				{ 0, 1, AlphaTransformAnimation(element, color.Alpha) },
+			{
+				{ 0, 1, GetRedTransformAnimation(element, color.Red) },
+				{ 0, 1, GetGreenTransformAnimation(element, color.Green) },
+				{ 0, 1, GetBlueTransformAnimation(element, color.Blue) },
+				{ 0, 1, GetAlphaTransformAnimation(element, color.Alpha) },
 			}
-			.Commit(element, nameof(ColorTo), rate, length, easing, (d, b) => animationCompletionSource.SetResult(true));
+			.Commit(element, nameof(BackgroundColorTo), rate, length, easing, (d, b) => animationCompletionSource.SetResult(true));
 		}
 		catch (ArgumentException aex)
 		{
@@ -52,19 +53,15 @@ public static class ColorAnimationExtensions
 		return animationCompletionSource.Task;
 	}
 
-	private static Animation RedTransformAnimation(VisualElement element, float targetRed)
-		=> new (v => element.BackgroundColor = element.BackgroundColor.WithRed(v),
-			element.BackgroundColor.Red, targetRed);
+	static Animation GetRedTransformAnimation(VisualElement element, float targetRed) =>
+		new(v => element.BackgroundColor = element.BackgroundColor.WithRed(v), element.BackgroundColor.Red, targetRed);
 
-	private static Animation GreenTransformAnimation(VisualElement element, float targetGreen)
-		=> new (v => element.BackgroundColor = element.BackgroundColor.WithGreen(v), 
-			element.BackgroundColor.Green, targetGreen);
+	static Animation GetGreenTransformAnimation(VisualElement element, float targetGreen) =>
+		new(v => element.BackgroundColor = element.BackgroundColor.WithGreen(v), element.BackgroundColor.Green, targetGreen);
 
-	private static Animation BlueTransformAnimation(VisualElement element, float targetBlue)
-		=> new (v => element.BackgroundColor = element.BackgroundColor.WithBlue(v),
-			element.BackgroundColor.Blue, targetBlue);
+	static Animation GetBlueTransformAnimation(VisualElement element, float targetBlue) =>
+		new(v => element.BackgroundColor = element.BackgroundColor.WithBlue(v), element.BackgroundColor.Blue, targetBlue);
 
-	private static Animation AlphaTransformAnimation(VisualElement element, float targetAlpha)
-		=> new (v => element.BackgroundColor = element.BackgroundColor.WithAlpha(v),
-			element.BackgroundColor.Alpha, targetAlpha);
+	static Animation GetAlphaTransformAnimation(VisualElement element, float targetAlpha) =>
+		new(v => element.BackgroundColor = element.BackgroundColor.WithAlpha(v), element.BackgroundColor.Alpha, targetAlpha);
 }

--- a/src/CommunityToolkit.Maui/Extensions/ColorAnimationExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui/Extensions/ColorAnimationExtensions.shared.cs
@@ -9,7 +9,7 @@ namespace CommunityToolkit.Maui.Extensions;
 /// <summary>
 /// Extension methods for Microsoft.Maui.Graphics.Color animations
 /// </summary>
-public static class ColorAnmiationExtensions
+public static class ColorAnimationExtensions
 {
 	/// <summary>
 	/// Animates the BackgroundColor of a VisualElement to the given color
@@ -41,7 +41,7 @@ public static class ColorAnmiationExtensions
 		{
 			//When creating an Animation too early in the lifecycle of the Page, i.e. in the OnAppearing method,
 			//the Page might not have an 'IAnimationManager' yet, resulting in an ArgumentException.
-			System.Diagnostics.Debug.WriteLine($"{aex.GetType().Name} thrown in {typeof(ColorAnmiationExtensions).FullName}: {aex.Message}");
+			System.Diagnostics.Debug.WriteLine($"{aex.GetType().Name} thrown in {typeof(ColorAnimationExtensions).FullName}: {aex.Message}");
 			animationCompletionSource.SetResult(false);
 		}
 

--- a/src/CommunityToolkit.Maui/Extensions/ColorAnimationExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui/Extensions/ColorAnimationExtensions.shared.cs
@@ -24,6 +24,10 @@ public static class ColorAnimationExtensions
 	{
 		ArgumentNullException.ThrowIfNull(element);
 
+		//Although BackgroundColor is defined as not-nullable, it CAN be null
+		//If null => set it to Transparent as Animation will crash on null BackgroundColor
+		element.BackgroundColor ??= Colors.Transparent;
+
 		var animationCompletionSource = new TaskCompletionSource<bool>();
 
 		try

--- a/src/CommunityToolkit.Maui/Extensions/ColorAnmiationExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui/Extensions/ColorAnmiationExtensions.shared.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Maui;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+
+namespace CommunityToolkit.Maui.Extensions;
+
+/// <summary>
+/// Extension methods for Microsoft.Maui.Graphics.Color animations
+/// </summary>
+public static class ColorAnmiationExtensions
+{
+	/// <summary>
+	/// Animates the BackgroundColor of a VisualElement to the given color
+	/// </summary>
+	/// <param name="element"></param>
+	/// <param name="color">The target color to animate the VisualElement's BackgroundColor to</param>
+	/// <param name="rate">The time, in milliseconds, between the frames of the animation</param>
+	/// <param name="length">The duration, in milliseconds, of the animation</param>
+	/// <param name="easing">The easing function to be used in the animation</param>
+	/// <returns>Value indicating if the animation completed successfully or not</returns>
+	public static Task<bool> ColorTo(this VisualElement element, Color color, uint rate = 16u, uint length = 250u, Easing? easing = null)
+	{
+		ArgumentNullException.ThrowIfNull(element);
+
+		var animationCompletionSource = new TaskCompletionSource<bool>();
+
+		try
+		{
+			new Animation
+			{ 
+				{ 0, 1, RedTransformAnimation(element, color.Red) },
+				{ 0, 1, GreenTransformAnimation(element, color.Green) },
+				{ 0, 1, BlueTransformAnimation(element, color.Blue) },
+				{ 0, 1, AlphaTransformAnimation(element, color.Alpha) },
+			}
+			.Commit(element, nameof(ColorTo), rate, length, easing, (d, b) => animationCompletionSource.SetResult(true));
+		}
+		catch (ArgumentException aex)
+		{
+			//When creating an Animation too early in the lifecycle of the Page, i.e. in the OnAppearing method,
+			//the Page might not have an 'IAnimationManager' yet, resulting in an ArgumentException.
+			System.Diagnostics.Debug.WriteLine($"{aex.GetType().Name} thrown in {typeof(ColorAnmiationExtensions).FullName}: {aex.Message}");
+			animationCompletionSource.SetResult(false);
+		}
+
+		return animationCompletionSource.Task;
+	}
+
+	private static Animation RedTransformAnimation(VisualElement element, float targetRed)
+		=> new (v => element.BackgroundColor = element.BackgroundColor.WithRed(v),
+			element.BackgroundColor.Red, targetRed);
+
+	private static Animation GreenTransformAnimation(VisualElement element, float targetGreen)
+		=> new (v => element.BackgroundColor = element.BackgroundColor.WithGreen(v), 
+			element.BackgroundColor.Green, targetGreen);
+
+	private static Animation BlueTransformAnimation(VisualElement element, float targetBlue)
+		=> new (v => element.BackgroundColor = element.BackgroundColor.WithBlue(v),
+			element.BackgroundColor.Blue, targetBlue);
+
+	private static Animation AlphaTransformAnimation(VisualElement element, float targetAlpha)
+		=> new (v => element.BackgroundColor = element.BackgroundColor.WithAlpha(v),
+			element.BackgroundColor.Alpha, targetAlpha);
+}


### PR DESCRIPTION
Fixes #88 

Implemented Extension method, added Sample.

There seems to be a bug on Windows on some controls as their BackgroundColor doesn't get updated. I've filed a bug for that on the [MAUI repo](https://github.com/dotnet/maui/issues/3506).
I'm not sure if/how this can be unit tested properly. If you have any ideas about this, let me know.