### PR TITLE
Fix `ICommunityToolkitMultiValueConverter` name typo

### DIFF
--- a/src/CommunityToolkit.Maui.UnitTests/Converters/DateTimeOffsetConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/DateTimeOffsetConverter_Tests.cs
@@ -54,7 +54,7 @@ public class DateTimeOffsetConverter_Tests : BaseTest
 	{
 		var dateTimeOffsetConverter = new DateTimeOffsetConverter();
 
-		var result = (DateTimeOffset)dateTimeOffsetConverter.ConvertBack(value, typeof(DateTimeOffsetConverter_Tests), null,CultureInfo.CurrentCulture);
+		var result = (DateTimeOffset)dateTimeOffsetConverter.ConvertBack(value, typeof(DateTimeOffsetConverter_Tests), null, CultureInfo.CurrentCulture);
 
 		Assert.Equal(expectedResult, result);
 	}

--- a/src/CommunityToolkit.Maui/Converters/ICommunityToolkitMultiValueConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ICommunityToolkitMultiValueConverter.shared.cs
@@ -5,7 +5,7 @@ using Microsoft.Maui.Controls;
 namespace CommunityToolkit.Maui.Converters;
 
 /// <inheritdoc />
-public interface ICommunityToolkitIMultiValueConverter : IMultiValueConverter
+public interface ICommunityToolkitMultiValueConverter : IMultiValueConverter
 {
 	/// <summary>
 	/// Converts the incoming values to a different object

--- a/src/CommunityToolkit.Maui/Converters/MathExpressionConverter/MultiMathExpressionConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/MathExpressionConverter/MultiMathExpressionConverter.shared.cs
@@ -10,7 +10,7 @@ namespace CommunityToolkit.Maui.Converters;
 /// <summary>
 /// Converters for multiple math expressions
 /// </summary>
-public class MultiMathExpressionConverter : MultiValueConverterExtension, ICommunityToolkitIMultiValueConverter
+public class MultiMathExpressionConverter : MultiValueConverterExtension, ICommunityToolkitMultiValueConverter
 {
 	/// <summary>
 	/// Calculate the incoming expression string with variables.

--- a/src/CommunityToolkit.Maui/Converters/VariableMultiValueConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/VariableMultiValueConverter.shared.cs
@@ -11,7 +11,7 @@ namespace CommunityToolkit.Maui.Converters;
 /// <summary>
 /// The <see cref="VariableMultiValueConverter"/> is a converter that allows users to convert multiple <see cref="bool"/> value bindings to a single <see cref="bool"/>. It does this by enabling them to specify whether All, Any, None or a specific number of values are true as specified in <see cref="ConditionType"/>. This is useful when combined with the <see cref="MultiBinding"/>.
 /// </summary>
-public class VariableMultiValueConverter : MultiValueConverterExtension, ICommunityToolkitIMultiValueConverter
+public class VariableMultiValueConverter : MultiValueConverterExtension, ICommunityToolkitMultiValueConverter
 {
 	/// <summary>
 	/// Indicates how many values should be true out of the provided boolean values in the <see cref="MultiBinding"/>. Supports the following values: All, None, Any, GreaterThan, LessThan.

--- a/src/CommunityToolkit.Maui/Extensions/MultiValueConverterExtension.shared.cs
+++ b/src/CommunityToolkit.Maui/Extensions/MultiValueConverterExtension.shared.cs
@@ -6,12 +6,12 @@ using Microsoft.Maui.Controls.Xaml;
 namespace CommunityToolkit.Maui.Extensions.Internals;
 
 /// <inheritdoc />
-public class MultiValueConverterExtension : IMarkupExtension<ICommunityToolkitIMultiValueConverter>
+public class MultiValueConverterExtension : IMarkupExtension<ICommunityToolkitMultiValueConverter>
 {
 	/// <inheritdoc />
-	public ICommunityToolkitIMultiValueConverter ProvideValue(IServiceProvider serviceProvider)
-		=> (ICommunityToolkitIMultiValueConverter)this;
+	public ICommunityToolkitMultiValueConverter ProvideValue(IServiceProvider serviceProvider)
+		=> (ICommunityToolkitMultiValueConverter)this;
 
 	object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider)
-		=> ((IMarkupExtension<ICommunityToolkitIMultiValueConverter>)this).ProvideValue(serviceProvider);
+		=> ((IMarkupExtension<ICommunityToolkitMultiValueConverter>)this).ProvideValue(serviceProvider);
 }


### PR DESCRIPTION
## Fixes
This PR fixes a typo in the name `ICommunityToolkitMultiValueConverter`.

It was incorrectly named `ICommunityToolkitIMultiValueConverter`.