### PR TITLE
Add Additional XML Warnings to `<WarningsAsErrors>` in `Directory.Build.props`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
 		<!--CS1574: XML comment has cref attribute that could not be resolved-->
  		<!--CS1573: Parameter has no matching param tag in the XML comment -->
  		<!--CS1734: XML comment has a paramref tag, but there is no parameter by that name-->
- 		<WarningsAsErrors>nullable,CS1574,CS1573,CS137</WarningsAsErrors>
+ 		<WarningsAsErrors>nullable,CS1574,CS1573,CS1734</WarningsAsErrors>
 		<ProduceReferenceAssembly>True</ProduceReferenceAssembly>
 		<GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
 	</PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,10 @@
 	<PropertyGroup>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
-		<WarningsAsErrors>nullable,CS1574</WarningsAsErrors><!--CS1574: XML comment has cref attribute that could not be resolved-->
+		<!--CS1574: XML comment has cref attribute that could not be resolved-->
+ 		<!--CS1573: Parameter has no matching param tag in the XML comment -->
+ 		<!--CS1734: XML comment has a paramref tag, but there is no parameter by that name-->
+ 		<WarningsAsErrors>nullable,CS1574,CS1573,CS137</WarningsAsErrors>
 		<ProduceReferenceAssembly>True</ProduceReferenceAssembly>
 		<GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
 	</PropertyGroup>


### PR DESCRIPTION
## Description

This PR ensures that future PRs will continue to have properly formatted XML Documentation

## Detailed Solution

Adds the following compiler warnings to `<WarningsAsErrors>` in `DirectoryBuild.props`:
- CS1573: Parameter has no matching param tag in the XML comment 
- CS1734: XML comment has a paramref tag, but there is no parameter by that name