### PR TITLE
Fix DateTimeOffset failed tests

### DIFF
--- a/src/CommunityToolkit.Maui.UnitTests/Converters/DateTimeOffsetConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/DateTimeOffsetConverter_Tests.cs
@@ -54,7 +54,7 @@ public class DateTimeOffsetConverter_Tests : BaseTest
 
 		var result = (DateTimeOffset)dateTimeOffsetConverter.ConvertBack(value, typeof(DateTimeOffsetConverter_Tests), null, CultureInfo.CurrentCulture);
 
-		Assert.Equal(expectedResult, result);
+		Assert.Equal(expectedResult, result, new DateTimeOffsetComparer());
 	}
 
 	[Fact]
@@ -75,5 +75,18 @@ public class DateTimeOffsetConverter_Tests : BaseTest
 		Assert.Throws<ArgumentException>(() => dateTimeOffsetConverter.ConvertBack("Not a DateTime",
 			typeof(DateTimeOffsetConverter_Tests), null,
 			CultureInfo.CurrentCulture));
+	}
+
+	class DateTimeOffsetComparer : IEqualityComparer<DateTimeOffset>
+	{
+		public bool Equals(DateTimeOffset x, DateTimeOffset y)
+		{
+			return x.Year == y.Year && x.Month == y.Month && x.Day == y.Day && x.Hour == y.Hour && x.Minute == y.Minute && x.Second == y.Second;
+		}
+
+		public int GetHashCode(DateTimeOffset obj)
+		{
+			return HashCode.Combine(obj.Year, obj.Month, obj.Day, obj.Hour, obj.Minute, obj.Second);
+		}
 	}
 }

--- a/src/CommunityToolkit.Maui/Converters/DateTimeOffsetConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/DateTimeOffsetConverter.shared.cs
@@ -32,12 +32,17 @@ public class DateTimeOffsetConverter : ValueConverterExtension, ICommunityToolki
 	/// <returns>The <see cref="DateTimeOffset"/> value.</returns>
 	[return: NotNull]
 	public object? ConvertBack([NotNull] object? value, Type? targetType, object? parameter, System.Globalization.CultureInfo? culture)
-		=> value is DateTime dateTime
-			? dateTime.Kind switch
-			{
-				DateTimeKind.Local => new DateTimeOffset(dateTime, DateTimeOffset.Now.Offset),
-				DateTimeKind.Utc => new DateTimeOffset(dateTime, DateTimeOffset.UtcNow.Offset),
-				_ => new DateTimeOffset(dateTime, TimeSpan.Zero),
-			}
-			: throw new ArgumentException("Value is not a valid DateTime", nameof(value));
+	{
+		if (value is not DateTime dateTime) throw new ArgumentException("Value is not a valid DateTime", nameof(value));
+		var offset = dateTime.Kind switch
+		{
+			DateTimeKind.Local => DateTimeOffset.Now.Offset,
+			DateTimeKind.Utc => DateTimeOffset.UtcNow.Offset,
+			_ => TimeSpan.Zero,
+		};
+		return culture is null ?  
+			new DateTimeOffset(dateTime, offset) : 
+			new DateTimeOffset(dateTime.Year, dateTime.Month, dateTime.Day, dateTime.Hour, dateTime.Minute, dateTime.Second, dateTime.Millisecond, culture.Calendar, offset);
+
+	}
 }


### PR DESCRIPTION
## Description

DateTimeOffsetConverter ConvertBack ignores current culture. For my region (Ukraine) the current offset is +3 in the summertime, and +2 in the wintertime. To fix the issue we need to pass Culture.Calendar parameter to the DateTimeOffset.

before:

![image](https://user-images.githubusercontent.com/33021114/148647888-bfcc61d0-609b-4c6b-873a-68884ee14697.png)

after:

![image](https://user-images.githubusercontent.com/33021114/148647847-0e6cb77a-8e11-49cf-bddf-4fee1f271f9d.png)
