### PR TITLE
Update Sample App to Remove `ContentPage` References from `BaseGalleryViewModels`

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Models/SectionModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Models/SectionModel.cs
@@ -4,25 +4,28 @@ namespace CommunityToolkit.Maui.Sample.Models;
 
 public sealed class SectionModel
 {
-	public SectionModel(in ContentPage page, in string title, in string description)
-		: this(page, title, new Color(), description)
+	// Use a private constructor to enforce the Factory Pattern
+	// This requires us to use the `Create` methods to instantiate SectionModel
+	// The Create methods allow us to 
+	SectionModel(in Type pageType, in string title, in Color color, in string description)
 	{
-	}
-
-	public SectionModel(in ContentPage page, in string title, in Color color, in string description)
-	{
-		if (string.IsNullOrWhiteSpace(page.Title))
-		{
-			page.Title = title;
-		}
-
-		Page = page;
+		PageType = pageType;
 		Title = title;
 		Description = description;
 		Color = color;
 	}
 
-	public ContentPage Page { get; }
+	// Use constrained generic to ensure TPage inherits from BasePage
+	public static SectionModel Create<TPage>(in string title, in string description) where TPage : BasePage
+		=> Create<TPage>(title, new Color(), description);
+
+	// Use constrained generic to ensure TPage inherits from BasePage
+	public static SectionModel Create<TPage>(in string title, in Color color, in string description) where TPage : BasePage
+	{
+		return new SectionModel(typeof(TPage), title, color, description);
+	}
+
+	public Type PageType { get; }
 
 	public string Title { get; }
 

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Base/BaseGalleryPage.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Base/BaseGalleryPage.cs
@@ -8,7 +8,7 @@ namespace CommunityToolkit.Maui.Sample.Pages;
 
 public abstract class BaseGalleryPage<TViewModel> : BasePage<TViewModel> where TViewModel : BaseGalleryViewModel
 {
-	public BaseGalleryPage(string title, TViewModel viewModel) : base(viewModel)
+	protected BaseGalleryPage(string title, TViewModel viewModel) : base(viewModel)
 	{
 		Title = title;
 
@@ -31,7 +31,13 @@ public abstract class BaseGalleryPage<TViewModel> : BasePage<TViewModel> where T
 
 		if (e.CurrentSelection.FirstOrDefault() is SectionModel sectionModel)
 		{
-			await Navigation.PushAsync(sectionModel.Page);
+			var page = ServiceProvider.GetRequiredService<BasePage>(sectionModel.PageType);
+			if (string.IsNullOrWhiteSpace(page.Title))
+			{
+				page.Title = sectionModel.Title;
+			}
+
+			await Navigation.PushAsync(page);
 		}
 	}
 

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Base/BasePage.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Base/BasePage.cs
@@ -8,7 +8,7 @@ namespace CommunityToolkit.Maui.Sample.Pages;
 
 public abstract class BasePage<TViewModel> : BasePage where TViewModel : BaseViewModel
 {
-	public BasePage(TViewModel viewModel) : base(viewModel)
+	protected BasePage(TViewModel viewModel) : base(viewModel)
 	{
 
 	}

--- a/samples/CommunityToolkit.Maui.Sample/Services/ServiceProvider.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Services/ServiceProvider.cs
@@ -15,4 +15,7 @@ public static class ServiceProvider
 
 	public static TService GetRequiredService<TService>() where TService : notnull
 		=> Current.GetRequiredService<TService>();
+
+	public static TService GetRequiredService<TService>(Type type)
+		=> (TService)Current.GetRequiredService(type);
 }

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Alerts/AlertsGalleryViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Alerts/AlertsGalleryViewModel.cs
@@ -8,7 +8,7 @@ public class AlertsGalleryViewModel : BaseGalleryViewModel
 	public AlertsGalleryViewModel(SnackbarPage snackbarPage)
 		: base(new[]
 		{
-			new SectionModel(snackbarPage, "Snackbar", "Show Snackbar")
+			SectionModel.Create<SnackbarPage>("Snackbar", "Show Snackbar")
 		})
 	{
 	}

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Base/BaseGalleryViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Base/BaseGalleryViewModel.cs
@@ -4,7 +4,7 @@ namespace CommunityToolkit.Maui.Sample.ViewModels;
 
 public abstract class BaseGalleryViewModel : BaseViewModel
 {
-	public BaseGalleryViewModel(IEnumerable<SectionModel> items)
+	protected BaseGalleryViewModel(IEnumerable<SectionModel> items)
 	{
 		Items = items.OrderBy(x => x.Title).ToList();
 	}

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Behaviors/BehaviorsGalleryViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Behaviors/BehaviorsGalleryViewModel.cs
@@ -6,84 +6,46 @@ namespace CommunityToolkit.Maui.Sample.ViewModels.Behaviors;
 
 public class BehaviorsGalleryViewModel : BaseGalleryViewModel
 {
-	public BehaviorsGalleryViewModel(MaskedBehaviorPage maskedBehaviorPage,
-										UriValidationBehaviorPage uriValidationBehaviorPage,
-										EventToCommandBehaviorPage eventToCommandBehaviorPage,
-										TextValidationBehaviorPage textValidationBehaviorPage,
-										EmailValidationBehaviorPage emailValidationBehaviorPage,
-										MultiValidationBehaviorPage multiValidationBehaviorPage,
-										MaxLengthReachedBehaviorPage maxLengthReachedBehaviorPage,
-										NumericValidationBehaviorPage numericValidationBehaviorPage,
-										UserStoppedTypingBehaviorPage userStoppedTypingBehaviorPage,
-										CharactersValidationBehaviorPage charactersValidationBehaviorPage,
-										ProgressBarAnimationBehaviorPage progressBarAnimationBehaviorPage,
-										SetFocusOnEntryCompletedBehaviorPage setFocusOnEntryCompletedBehaviorPage,
-										RequiredStringValidationBehaviorPage requiredStringValidationBehaviorPage)
+	public BehaviorsGalleryViewModel()
 		: base(new[]
 		{
-			new SectionModel(
-				eventToCommandBehaviorPage,
-				nameof(EventToCommandBehavior),
+			SectionModel.Create<EventToCommandBehaviorPage>(nameof(EventToCommandBehavior),
 				"Turns any event into a command that can be bound to"),
 
-			new SectionModel(
-				maskedBehaviorPage,
-				nameof(MaskedBehavior),
+			SectionModel.Create<MaskedBehaviorPage>(nameof(MaskedBehavior),
 				"Masked text in entry with specific pattern"),
 
-			new SectionModel(
-				userStoppedTypingBehaviorPage,
-				nameof(UserStoppedTypingBehavior),
+			SectionModel.Create<UserStoppedTypingBehaviorPage>(nameof(UserStoppedTypingBehavior),
 				"This behavior waits for the user to stop typing and then executes a Command"),
 
-			new SectionModel(
-				maxLengthReachedBehaviorPage,
-				nameof(MaxLengthReachedBehavior),
+			SectionModel.Create<MaxLengthReachedBehaviorPage>(nameof(MaxLengthReachedBehavior),
 				"This behavior invokes an EventHandler and executes a Command when the MaxLength of an InputView has been reached"),
 
-			new SectionModel(
-				progressBarAnimationBehaviorPage,
-				nameof(ProgressBarAnimationBehavior),
+			SectionModel.Create<ProgressBarAnimationBehaviorPage>(nameof(ProgressBarAnimationBehavior),
 				"Animate the progress for the ProgressBar"),
 
-			new SectionModel(
-				setFocusOnEntryCompletedBehaviorPage,
-				nameof(SetFocusOnEntryCompletedBehavior),
+			SectionModel.Create<SetFocusOnEntryCompletedBehaviorPage>(nameof(SetFocusOnEntryCompletedBehavior),
 				"Set focus to another element when an entry is completed"),
 
-			new SectionModel(
-				charactersValidationBehaviorPage,
-				nameof(CharactersValidationBehavior),
+			SectionModel.Create<CharactersValidationBehaviorPage>(nameof(CharactersValidationBehavior),
 				"Changes an Entry's text color when an invalid string is provided."),
 
-			new SectionModel(
-				textValidationBehaviorPage,
-				nameof(TextValidationBehavior),
+			SectionModel.Create<TextValidationBehaviorPage>(nameof(TextValidationBehavior),
 				"Changes an Entry's text color when text validation is failed (based on regex)"),
 
-			new SectionModel(
-				multiValidationBehaviorPage,
-				nameof(MultiValidationBehavior),
+			SectionModel.Create<MultiValidationBehaviorPage>(nameof(MultiValidationBehavior),
 				"Combines multiple validation behavior"),
 
-			new SectionModel(
-				uriValidationBehaviorPage,
-				nameof(UriValidationBehavior),
+			SectionModel.Create<UriValidationBehaviorPage>(nameof(UriValidationBehavior),
 				"Changes an Entry's text color when an invalid URI is provided"),
 
-			new SectionModel(
-				requiredStringValidationBehaviorPage,
-				nameof(RequiredStringValidationBehavior),
+			SectionModel.Create<RequiredStringValidationBehaviorPage>(nameof(RequiredStringValidationBehavior),
 				"Changes an Entry's text color when a required string is not provided"),
 
-			new SectionModel(
-				numericValidationBehaviorPage,
-				nameof(NumericValidationBehavior),
+			SectionModel.Create<NumericValidationBehaviorPage>(nameof(NumericValidationBehavior),
 				"Changes an Entry's text color when an invalid number is provided"),
 
-			new SectionModel(
-				emailValidationBehaviorPage,
-				nameof(EmailValidationBehavior),
+			SectionModel.Create<EmailValidationBehaviorPage>(nameof(EmailValidationBehavior),
 				"Changes an Entry's text color when an invalid e-mail address is provided"),
 			}
 		)

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Converters/ConvertersGalleryViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Converters/ConvertersGalleryViewModel.cs
@@ -6,148 +6,79 @@ namespace CommunityToolkit.Maui.Sample.ViewModels.Converters;
 
 public class ConvertersGalleryViewModel : BaseGalleryViewModel
 {
-	public ConvertersGalleryViewModel(EqualConverterPage equalConverterPage,
-										MultiConverterPage multiConverterPage,
-										ColorsConverterPage colorsConverterPage,
-										NotEqualConverterPage notEqualConverterPage,
-										TextCaseConverterPage textCaseConverterPage,
-										EnumToIntConverterPage enumToIntConverterPage,
-										IntToBoolConverterPage intToBoolConverterPage,
-										EnumToBoolConverterPage enumToBoolConverterPage,
-										ItemTappedEventArgsPage itemTappedEventArgsPage,
-										DoubleToIntConverterPage doubleToIntConverterPage,
-										BoolToObjectConverterPage boolToObjectConverterPage,
-										InvertedBoolConverterPage invertedBoolConverterPage,
-										ListToStringConverterPage listToStringConverterPage,
-										StringToListConverterPage stringToListConverterPage,
-										ImageResourceConverterPage imageResourceConverterPage,
-										IsNullOrEmptyConverterPage isNullOrEmptyConverterPage,
-										DateTimeOffsetConverterPage dateTimeOffsetConverterPage,
-										MathExpressionConverterPage mathExpressionConverterPage,
-										IsNotNullOrEmptyConverterPage isNotNullOrEmptyConverterPage,
-										IndexToArrayItemConverterPage indexToArrayItemConverterPage,
-										ListIsNullOrEmptyConverterPage listIsNullOrEmptyConverterPage,
-										VariableMultiValueConverterPage variableMultiValueConverterPage,
-										ListIsNotNullOrEmptyConverterPage listIsNotNullOrEmptyConverterPage)
+	public ConvertersGalleryViewModel()
 		: base(new[]
 		{
-			new SectionModel(
-				boolToObjectConverterPage,
-				nameof(BoolToObjectConverter),
+			SectionModel.Create<BoolToObjectConverterPage>(nameof(BoolToObjectConverter),
 				"A converter that allows users to convert a bool value binding to a specific object."),
 
-			new SectionModel(
-				isNullOrEmptyConverterPage,
-				nameof(IsNullOrEmptyConverter),
+			SectionModel.Create<IsNullOrEmptyConverterPage>(nameof(IsNullOrEmptyConverter),
 				"A converter that allows users to convert an incoming binding to a bool value. This value represents if the incoming binding value is null or empty."),
 
-			new SectionModel(
-				isNotNullOrEmptyConverterPage,
-				nameof(IsNotNullOrEmptyConverter),
+			SectionModel.Create<IsNotNullOrEmptyConverterPage>(nameof(IsNotNullOrEmptyConverter),
 				"A converter that allows users to convert an incoming binding to a bool value. This value represents if the incoming binding value is Not null or empty."),
 
-			new SectionModel(
-				invertedBoolConverterPage,
-				nameof(InvertedBoolConverter),
+			SectionModel.Create<InvertedBoolConverterPage>(nameof(InvertedBoolConverter),
 				"A converter that allows users to convert a bool value binding to its inverted value.."),
 
-			new SectionModel(
-				equalConverterPage,
-				nameof(EqualConverter),
+			SectionModel.Create<EqualConverterPage>(nameof(EqualConverter),
 				"A converter that allows users to convert any value binding to a bool depending on whether or not it is equal to a different value. "),
 
-			new SectionModel(
-				notEqualConverterPage,
-				nameof(NotEqualConverter),
+			SectionModel.Create<NotEqualConverterPage>(nameof(NotEqualConverter),
 				"A converter that allows users to convert any value binding to a bool depending on whether or not it is not equal to a different value. "),
 
-			new SectionModel(
-				doubleToIntConverterPage,
-				nameof(DoubleToIntConverter),
+			SectionModel.Create<DoubleToIntConverterPage>(nameof(DoubleToIntConverter),
 				"A converter that allows users to convert an incoming double value to an int."),
 
-			new SectionModel(
-				indexToArrayItemConverterPage,
-				nameof(IndexToArrayItemConverter),
+			SectionModel.Create<IndexToArrayItemConverterPage>(nameof(IndexToArrayItemConverter),
 				"A converter that allows users to convert a int value binding to an item in an array."),
 
-			new SectionModel(
-				intToBoolConverterPage,
-				nameof(IntToBoolConverter),
+			SectionModel.Create<IntToBoolConverterPage>(nameof(IntToBoolConverter),
 				"A converter that allows users to convert an incoming int value to a bool."),
 
-			new SectionModel(
-				itemTappedEventArgsPage,
-				nameof(ItemTappedEventArgsConverter),
+			SectionModel.Create<ItemTappedEventArgsPage>(nameof(ItemTappedEventArgsConverter),
 				"A converter that allows you to extract the value from ItemTappedEventArgs that can be used in combination with EventToCommandBehavior"),
 
-			new SectionModel(
-				textCaseConverterPage,
-				nameof(TextCaseConverter),
+			SectionModel.Create<TextCaseConverterPage>(nameof(TextCaseConverter),
 				"A converter that allows users to convert the casing of an incoming string type binding. The Type property is used to define what kind of casing will be applied to the string."),
 
-			new SectionModel(
-				multiConverterPage,
-				nameof(MultiConverter),
+			SectionModel.Create<MultiConverterPage>(nameof(MultiConverter),
 				"This sample demonstrates how to use Multibinding Converter"),
 
-			new SectionModel(
-				dateTimeOffsetConverterPage,
-				nameof(DateTimeOffsetConverter),
+			SectionModel.Create<DateTimeOffsetConverterPage>(nameof(DateTimeOffsetConverter),
 				"A converter that allows to convert from a DateTimeOffset type to a DateTime type"),
 
-			new SectionModel(
-				variableMultiValueConverterPage,
-				nameof(VariableMultiValueConverter),
+			SectionModel.Create<VariableMultiValueConverterPage>(nameof(VariableMultiValueConverter),
 				"A converter that allows you to combine multiple boolean bindings into a single binding."),
 
-			new SectionModel(
-				listIsNullOrEmptyConverterPage,
-				nameof(ListIsNullOrEmptyConverter),
+			SectionModel.Create<ListIsNullOrEmptyConverterPage>(nameof(ListIsNullOrEmptyConverter),
 				"A converter that allows you to check if collection is null or empty"),
 
-			new SectionModel(
-				listIsNotNullOrEmptyConverterPage,
-				nameof(ListIsNotNullOrEmptyConverter),
+			SectionModel.Create<ListIsNotNullOrEmptyConverterPage>(nameof(ListIsNotNullOrEmptyConverter),
 				"A converter that allows you to check if collection is not null or empty"),
 
-			new SectionModel(
-				listToStringConverterPage,
-				nameof(ListToStringConverter),
+			SectionModel.Create<ListToStringConverterPage>(nameof(ListToStringConverter),
 				"A converter that allows users to convert an incoming binding that implements IEnumerable to a single string value. The Separator property is used to join the items in the IEnumerable."),
 
-			new SectionModel(
-				enumToBoolConverterPage,
-				nameof(EnumToBoolConverter),
+			SectionModel.Create<EnumToBoolConverterPage>(nameof(EnumToBoolConverter),
 				"A converter that allows you to convert an Enum to boolean value"),
 
-			new SectionModel(
-				enumToIntConverterPage,
-				nameof(EnumToIntConverter),
+			SectionModel.Create<EnumToIntConverterPage>(nameof(EnumToIntConverter),
 				"A converter that allows you to convert an Enum to its underlying int value"),
 
-			new SectionModel(
-				imageResourceConverterPage,
-				nameof(ImageResourceConverter),
+			SectionModel.Create<ImageResourceConverterPage>(nameof(ImageResourceConverter),
 				"A converter that allows you to convert embeded ressource image id to an ImageSource"),
 
-			new SectionModel(
-				mathExpressionConverterPage,
-				nameof(MathExpressionConverter),
+			SectionModel.Create<MathExpressionConverterPage>(nameof(MathExpressionConverter),
 				"A converter that allows users to calculate an expression at runtime."),
-			new SectionModel(
-				stringToListConverterPage,
-				nameof(StringToListConverter),
+
+			SectionModel.Create<StringToListConverterPage>(nameof(StringToListConverter),
 				"A converter that splits a string by the separator and returns the enumerable sequence of strings as the result."),
 
-			new SectionModel(
-				imageResourceConverterPage,
-				nameof(ImageResourceConverter),
+			SectionModel.Create<ImageResourceConverterPage>(nameof(ImageResourceConverter),
 				"A converter that allows you to convert embeded ressource image id to an ImageSource"),
 
-			new SectionModel(
-				colorsConverterPage,
-				"ColorConverters",
+			SectionModel.Create<ColorsConverterPage>("ColorConverters",
 				"A group of converters that convert a Color to your strings values (RGB, HEX, HSL, etc)"),
 		})
 	{

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Extensions/ExtensionsGalleryViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Extensions/ExtensionsGalleryViewModel.cs
@@ -6,12 +6,10 @@ namespace CommunityToolkit.Maui.Sample.ViewModels.Converters;
 
 public class ExtensionsGalleryViewModel : BaseGalleryViewModel
 {
-	public ExtensionsGalleryViewModel(ColorAnimationExtensionsPage colorAnimationExtensionsPage)
+	public ExtensionsGalleryViewModel()
 		: base(new[]
 		{
-			new SectionModel(
-				colorAnimationExtensionsPage,
-				nameof(ColorAnimationExtensions),
+			SectionModel.Create<ColorAnimationExtensionsPage>(nameof(ColorAnimationExtensions),
 				"Extension methods that provide color animations"),
 		})
 	{

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/MainGalleryViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/MainGalleryViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using CommunityToolkit.Maui.Sample.Models;
+using CommunityToolkit.Maui.Sample.Pages;
 using CommunityToolkit.Maui.Sample.Pages.Alerts;
 using CommunityToolkit.Maui.Sample.Pages.Behaviors;
 using CommunityToolkit.Maui.Sample.Pages.Converters;
@@ -8,22 +9,19 @@ namespace CommunityToolkit.Maui.Sample.ViewModels;
 
 public class MainGalleryViewModel : BaseGalleryViewModel
 {
-	public MainGalleryViewModel(AlertsGalleryPage alertsGalleryPage,
-								BehaviorsGalleryPage behaviorsGalleryPage,
-								ConvertersGalleryPage convertersGalleryPage,
-								ExtensionsGalleryPage extensionsGalleryPage)
+	public MainGalleryViewModel()
 		: base(new[]
 		{
-			 new SectionModel(alertsGalleryPage, "Alerts", Color.FromArgb("#EF6950"),
+			 SectionModel.Create<AlertsGalleryPage>("Alerts", Color.FromArgb("#EF6950"),
 				 "Alerts allow you display alerts to your user"),
 
-			 new SectionModel(behaviorsGalleryPage, "Behaviors", Color.FromArgb("#8E8CD8"),
+			 SectionModel.Create<BehaviorsGalleryPage>("Behaviors", Color.FromArgb("#8E8CD8"),
 				 "Behaviors lets you add functionality to user interface controls without having to subclass them. Behaviors are written in code and added to controls in XAML or code"),
 
-			 new SectionModel(convertersGalleryPage, "Converters", Color.FromArgb("#EA005E"),
+			 SectionModel.Create<ConvertersGalleryPage>("Converters", Color.FromArgb("#EA005E"),
 				 "Converters let you convert bindings of a certain type to a different value, based on custom logic"),
 
-			 new SectionModel(extensionsGalleryPage, "Extensions", Color.FromArgb("#00EA56"),
+			 SectionModel.Create<ExtensionsGalleryPage>("Extensions", Color.FromArgb("#00EA56"),
 				 "Extenions lets you add methods to existing types without creating a new derived type, recompiling, or otherwise modifying the original type."),
 		})
 	{


### PR DESCRIPTION
 ### Description of Change ###

Leveraging Vlad's ideas in https://github.com/CommunityToolkit/Maui/pull/250, this PR provides an alternative example on how to remove the `ContentPage`s from being injected into  `BaseGalleryViewModel`.

 ### Additional information ###

 - Adds `public Type PageType` to `SectionModel` class
 - Leverages `ServiceProvider.GetRequiredService(Type type)` to retrieve a `ContentPage` from the `IServiceProvider`

```cs
async void HandleSelectionChanged(object? sender, SelectionChangedEventArgs e)
{
	ArgumentNullException.ThrowIfNull(sender);

	var collectionView = (CollectionView)sender;
	collectionView.SelectedItem = null;

	if (e.CurrentSelection.FirstOrDefault() is SectionModel sectionModel)
	{
		var page = ServiceProvider.GetRequiredService<BasePage>(sectionModel.PageType);
		if (string.IsNullOrWhiteSpace(page.Title))
		{
			page.Title = sectionModel.Title;
		}

		await Navigation.PushAsync(page);
	}
}
```
