### PR TITLE
Remove Null-Coalescing Assignment Operator Workaround from Sample App

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,13 +71,8 @@ jobs:
         displayName: Set NuGet Version to PR Version
         condition: and(succeeded(), eq(variables['build.reason'], 'PullRequest'))
       # build, test and pack the packages
-      # Build the Sample App first via the CLI to generate Source Generators which VSBuild@1 does not currently achieve
-      - task: CmdLine@2 
-        displayName: 'Build Community Toolkit Sample via CLI'
-        inputs:
-          script: 'dotnet build $(PathToCommunityToolkitSampleCsproj) -c Release'
       - task: VSBuild@1
-        displayName: 'Build Community Toolkit Sample via VSBuild Task'
+        displayName: 'Build Community Toolkit Sample'
         inputs:
           solution: '$(PathToCommunityToolkitSampleCsproj)'
           configuration: 'Release'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,8 +71,13 @@ jobs:
         displayName: Set NuGet Version to PR Version
         condition: and(succeeded(), eq(variables['build.reason'], 'PullRequest'))
       # build, test and pack the packages
+      # Build the Sample App first via the CLI to generate Source Generators which VSBuild@1 does not currently achieve
+      - task: CmdLine@2 
+        displayName: 'Build Community Toolkit Sample via CLI'
+        inputs:
+          script: 'dotnet build $(PathToCommunityToolkitSampleCsproj) -c Release'
       - task: VSBuild@1
-        displayName: 'Build Community Toolkit Sample'
+        displayName: 'Build Community Toolkit Sample via VSBuild Task'
         inputs:
           solution: '$(PathToCommunityToolkitSampleCsproj)'
           configuration: 'Release'

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Alerts/SnackbarPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Alerts/SnackbarPage.xaml.cs
@@ -20,8 +20,6 @@ public partial class SnackbarPage : BasePage
 	{
 		InitializeComponent();
 
-		SnackbarShownStatus ??= new();
-		DisplayCustomSnackbarButton ??= new();
 		DisplayCustomSnackbarButton.Text = displayCustomSnackbarText;
 
 		Snackbar.Shown += Snackbar_Shown;

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/CharactersValidationBehaviorPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/CharactersValidationBehaviorPage.xaml.cs
@@ -8,11 +8,6 @@ public partial class CharactersValidationBehaviorPage : BasePage
 	public CharactersValidationBehaviorPage()
 	{
 		InitializeComponent();
-
-		Page ??= this;
-		CharacterTypePicker ??= new Picker();
-		MinimumCharacterCountEntry ??= new Entry();
-		MaximumCharacterCountEntry ??= new Entry();
 	}
 
 	public IReadOnlyList<CharacterType> CharacterTypes { get; } =

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/EmailValidationBehaviorPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/EmailValidationBehaviorPage.xaml.cs
@@ -7,6 +7,5 @@ public partial class EmailValidationBehaviorPage : BasePage
 	public EmailValidationBehaviorPage()
 	{
 		InitializeComponent();
-		EmailValidator ??= new();
 	}
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/MaxLengthReachedBehaviorPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/MaxLengthReachedBehaviorPage.xaml.cs
@@ -9,10 +9,6 @@ partial class MaxLengthReachedBehaviorPage : BasePage<MaxLengthReachedBehaviorVi
 		: base(maxLengthReachedBehaviorViewModel)
 	{
 		InitializeComponent();
-
-		NextEntry ??= new();
-		MaxLengthSetting ??= new();
-		AutoDismissKeyboardSetting ??= new();
 	}
 
 	void MaxLengthReachedBehavior_MaxLengthReached(object? sender, MaxLengthReachedEventArgs e)

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/MultiValidationBehaviorPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/MultiValidationBehaviorPage.xaml.cs
@@ -5,11 +5,5 @@ public partial class MultiValidationBehaviorPage : BasePage
 	public MultiValidationBehaviorPage()
 	{
 		InitializeComponent();
-
-		AnyValidation ??= new();
-		MultiValidation ??= new();
-		DigitValidation ??= new();
-		UpperValidation ??= new();
-		SymbolValidation ??= new();
 	}
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/UserStoppedTypingBehaviorPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/UserStoppedTypingBehaviorPage.xaml.cs
@@ -8,9 +8,5 @@ public partial class UserStoppedTypingBehaviorPage : BasePage<UserStoppedTypingB
 		: base(userStoppedTypingBehaviorViewModel)
 	{
 		InitializeComponent();
-
-		TimeThresholdSetting ??= new();
-		AutoDismissKeyboardSetting ??= new();
-		MinimumLengthThresholdSetting ??= new();
 	}
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Converters/BoolToObjectConverterPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Converters/BoolToObjectConverterPage.xaml.cs
@@ -7,9 +7,6 @@ public partial class BoolToObjectConverterPage : BasePage
 	public BoolToObjectConverterPage()
 	{
 		InitializeComponent();
-
-		CheckBox ??= new();
-		Ellipse ??= new();
 	}
 
 	void OnButtonClicked(object? sender, EventArgs args)

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Converters/ColorsConverterPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Converters/ColorsConverterPage.xaml.cs
@@ -12,9 +12,6 @@ public partial class ColorsConverterPage : BasePage
 	public ColorsConverterPage()
 	{
 		InitializeComponent();
-
-		Picker ??= new();
-		BoxView ??= new();
 	}
 
 	protected override void OnAppearing()

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Converters/IndexToArrayItemConverterPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Converters/IndexToArrayItemConverterPage.xaml.cs
@@ -8,6 +8,5 @@ public partial class IndexToArrayItemConverterPage : BasePage<IndexToArrayItemCo
 		: base(indexToArrayItemConverterViewModel)
 	{
 		InitializeComponent();
-		Stepper ??= new();
 	}
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Converters/InvertedBoolConverterPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Converters/InvertedBoolConverterPage.xaml.cs
@@ -5,7 +5,5 @@ public partial class InvertedBoolConverterPage : BasePage
 	public InvertedBoolConverterPage()
 	{
 		InitializeComponent();
-
-		ColorToggle ??= new();
 	}
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Converters/NotEqualConverterPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Converters/NotEqualConverterPage.xaml.cs
@@ -5,7 +5,5 @@ public partial class NotEqualConverterPage : BasePage
 	public NotEqualConverterPage()
 	{
 		InitializeComponent();
-
-		ExampleText ??= new();
 	}
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Converters/StringToListConverterPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Converters/StringToListConverterPage.xaml.cs
@@ -5,7 +5,5 @@ public partial class StringToListConverterPage : BasePage
 	public StringToListConverterPage()
 	{
 		InitializeComponent();
-
-		ExampleText ??= new();
 	}
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Converters/TextCaseConverterPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Converters/TextCaseConverterPage.xaml.cs
@@ -5,7 +5,5 @@ public partial class TextCaseConverterPage : BasePage
 	public TextCaseConverterPage()
 	{
 		InitializeComponent();
-
-		ExampleText ??= new();
 	}
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ColorAnimationExtensionsPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ColorAnimationExtensionsPage.xaml.cs
@@ -16,13 +16,6 @@ public partial class ColorAnimationExtensionsPage : BasePage
 	public ColorAnimationExtensionsPage()
 	{
 		InitializeComponent();
-
-		RateInput ??= new();
-		ColorFrame ??= new();
-		ColorPicker ??= new();
-		EasingPicker ??= new();
-		DurationInput ??= new();
-		TextColorToDescriptionLabel ??= new();
 	}
 
 	protected override void OnAppearing()

--- a/src/CommunityToolkit.Maui.SourceGenerators/CommunityToolkit.Maui.SourceGenerators.csproj
+++ b/src/CommunityToolkit.Maui.SourceGenerators/CommunityToolkit.Maui.SourceGenerators.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0-1.final" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/CommunityToolkit.Maui.SourceGenerators/CommunityToolkit.Maui.SourceGenerators.csproj
+++ b/src/CommunityToolkit.Maui.SourceGenerators/CommunityToolkit.Maui.SourceGenerators.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.1.0-1.final" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0-1.final" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/CommunityToolkit.Maui.SourceGenerators/CommunityToolkit.Maui.SourceGenerators.csproj
+++ b/src/CommunityToolkit.Maui.SourceGenerators/CommunityToolkit.Maui.SourceGenerators.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0-1.final" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/CommunityToolkit.Maui.SourceGenerators/CommunityToolkit.Maui.SourceGenerators.csproj
+++ b/src/CommunityToolkit.Maui.SourceGenerators/CommunityToolkit.Maui.SourceGenerators.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
   </ItemGroup>

--- a/src/CommunityToolkit.Maui.SourceGenerators/CommunityToolkit.Maui.SourceGenerators.csproj
+++ b/src/CommunityToolkit.Maui.SourceGenerators/CommunityToolkit.Maui.SourceGenerators.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

This PR Removes the Null-Coalescing Assignment Operator (`??=`) Workaround that was required for instantiating XAML fields when Nullable is enabled.
 
This workaround is now handled natively via Source Generators in .NET MAUI https://github.com/dotnet/maui/issues/1796#event-5661151291