### PR TITLE
Use TrySetResult to prevent InvalidOperationException

### DIFF
--- a/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.android.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.android.cs
@@ -152,7 +152,7 @@ public partial class Snackbar
 		{
 			base.OnDismissed(transientBottomBar, e);
 
-			dismissedTCS.SetResult(true);
+			dismissedTCS.TrySetResult(true);
 			snackbar.OnDismissed();
 		}
 	}


### PR DESCRIPTION
 ### Description of Change ###

Use TrySetResult to prevent InvalidOperationException when the underlying Task is already in one of the three final states: RanToCompletion, Faulted, or Canceled.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #266 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [ ] Rebased on top of `main` at time of PR
 - [ ] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
