### PR TITLE
Fix `GridLayout` `System.TypeLoadException` on Windows for `CommunityToolkit.Maui.Sample`

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/CommunityToolkit.Maui.Sample.csproj
+++ b/samples/CommunityToolkit.Maui.Sample/CommunityToolkit.Maui.Sample.csproj
@@ -38,7 +38,7 @@
     <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
 
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0-preview1" />
-    <PackageReference Include="CommunityToolkit.Maui.Markup" Version="1.0.0-pre5" />
+    <PackageReference Include="CommunityToolkit.Maui.Markup" Version="1.0.0-pre7" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
 ### Description of Change ###

This PR fixes the `System.TypeLoadException` for `GridLayout` causing the Gallery Pages to appear blank on the Windows Sample App:

> System.TypeLoadException: 'Could not load type 'Microsoft.Maui.Controls.GridLayout' from assembly 'Microsoft.Maui.Controls, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null


 ### Additional information ###

 The error was caused by an old version of `CommunityToolkit.Maui.Markup`. Updating to `CommunityToolkit.Maui.Markup-pre7` resolves the issue.
