### PR TITLE
Update Sample App for MacCatalyst

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Base/BaseGalleryPage.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Base/BaseGalleryPage.cs
@@ -16,7 +16,7 @@ public abstract class BaseGalleryPage<TViewModel> : BasePage<TViewModel> where T
 		{
 			// Work-around to ensure content doesn't get clipped by iOS Status Bar + Naviagtion Bar
 			(Device.iOS, TargetIdiom.Phone) => new Thickness(0, 96, 0, 0),
-			(Device.iOS, _) => new Thickness(0, 84, 0, 0),
+			(Device.iOS or Device.MacCatalyst, _) => new Thickness(0, 84, 0, 0),
 			_ => 0
 		};
 

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Base/BasePage.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Base/BasePage.cs
@@ -21,7 +21,7 @@ public abstract class BasePage : ContentPage
 		Padding = Device.RuntimePlatform switch
 		{
 			// Work-around to ensure content doesn't get clipped by iOS Status Bar + Naviagtion Bar
-			Device.iOS => new Thickness(12, 108, 12, 12),
+			Device.iOS or Device.MacCatalyst => new Thickness(12, 108, 12, 12),
 			_ => 12
 		};
 	}


### PR DESCRIPTION
 ### Description of Change ###

.NET MAUI Preview 13 introduced `Device.MacCatalyst`. Previously, `Device.RuntimePlatform ==  Device.iOS` was true on `net6.0-maccatalyst`

This PR updates the Sample App to differentiate between `Device.iOS` and `Device.MacCatalyst`.