### PR TITLE
Add Null Support for BaseOneWayConverter<TFrom, TTo> 

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,10 +4,11 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <!--CS1574: XML comment has cref attribute that could not be resolved-->
+    <!--CS1572: XML comment has a param tag for '[parameter]', but there is no parameter by that name -->
     <!--CS1573: Parameter has no matching param tag in the XML comment -->
+    <!--CS1574: XML comment has cref attribute that could not be resolved-->
     <!--CS1734: XML comment has a paramref tag, but there is no parameter by that name-->
-    <WarningsAsErrors>nullable,CS1574,CS1573,CS1734</WarningsAsErrors>
+    <WarningsAsErrors>nullable,CS1572,CS1573,CS1574,CS1734</WarningsAsErrors>
     <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
     <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
     

--- a/src/CommunityToolkit.Maui.UnitTests/BaseTest.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/BaseTest.cs
@@ -6,7 +6,7 @@ namespace CommunityToolkit.Maui.UnitTests;
 
 public abstract class BaseTest : IDisposable
 {
-	readonly CultureInfo? defaultCulture, defaultUICulture;
+	readonly CultureInfo defaultCulture, defaultUICulture;
 
 	bool isDisposed;
 
@@ -38,8 +38,8 @@ public abstract class BaseTest : IDisposable
 
 		Device.PlatformServices = null;
 
-		Thread.CurrentThread.CurrentCulture = defaultCulture ?? throw new NullReferenceException();
-		Thread.CurrentThread.CurrentUICulture = defaultUICulture ?? throw new NullReferenceException();
+		Thread.CurrentThread.CurrentCulture = defaultCulture;
+		Thread.CurrentThread.CurrentUICulture = defaultUICulture;
 
 		DispatcherProvider.SetCurrent(null);
 		DeviceDisplay.SetCurrent(null);

--- a/src/CommunityToolkit.Maui.UnitTests/CommunityToolkit.Maui.UnitTests.csproj
+++ b/src/CommunityToolkit.Maui.UnitTests/CommunityToolkit.Maui.UnitTests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.5.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Xunit" Version="2.4.1" />
     <PackageReference Include="Xunit.Runner.VisualStudio" Version="2.4.3" />
   </ItemGroup>

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/ImageResourceConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/ImageResourceConverter_Tests.cs
@@ -35,11 +35,14 @@ public class ImageResourceConverter_Tests : BaseTest
 		var expectedMemoryStream = await GetStreamFromImageSource(expectedResource, CancellationToken.None);
 
 		var imageResourceConverter = new ImageResourceConverter();
-		var result = (ImageSource)imageResourceConverter.Convert(resourceToLoad, typeof(ImageResourceConverter), null, CultureInfo.CurrentCulture);
+		var convertResult = (ImageSource)(imageResourceConverter.Convert(resourceToLoad, typeof(ImageSource), null, CultureInfo.CurrentCulture) ?? throw new NullReferenceException());
+		var streamResult = await GetStreamFromImageSource(convertResult, CancellationToken.None);
 
-		var streamResult = await GetStreamFromImageSource(result, CancellationToken.None);
+		var convertFromResult = imageResourceConverter.ConvertFrom(resourceToLoad);
+		var streamFromResult = await GetStreamFromImageSource(convertFromResult, CancellationToken.None);
 
-		Assert.True(StreamEquals(streamResult, expectedMemoryStream));
+		Assert.True(StreamEquals(expectedMemoryStream, streamResult));
+		Assert.True(StreamEquals(expectedMemoryStream, streamFromResult));
 	}
 
 	[Fact]
@@ -47,7 +50,8 @@ public class ImageResourceConverter_Tests : BaseTest
 	{
 		var imageResourceConverter = new ImageResourceConverter();
 
-		Assert.Null(imageResourceConverter.Convert(null, typeof(ImageResourceConverter), null, CultureInfo.CurrentCulture));
+		Assert.Null(imageResourceConverter.Convert(null, typeof(ImageSource), null, CultureInfo.CurrentCulture));
+		Assert.Null(imageResourceConverter.ConvertFrom(null));
 	}
 
 	[Theory]

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/ImageResourceConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/ImageResourceConverter_Tests.cs
@@ -60,6 +60,6 @@ public class ImageResourceConverter_Tests : BaseTest
 	{
 		var imageResourceConverter = new ImageResourceConverter();
 
-		Assert.Throws<ArgumentException>(() => imageResourceConverter.Convert(value, typeof(ImageResourceConverter), null, CultureInfo.CurrentCulture));
+		Assert.Throws<ArgumentException>(() => imageResourceConverter.Convert(value, typeof(ImageSource), null, CultureInfo.CurrentCulture));
 	}
 }

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/IsListNotNullOrEmptyConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/IsListNotNullOrEmptyConverter_Tests.cs
@@ -29,8 +29,10 @@ public class IsListNotNullOrEmptyConverter_Tests : BaseTest
 	}
 
 	[Theory]
-	[InlineData(0)]
-	public void InvalidConverterValuesThrowArgumentException(object value)
+	[InlineData(7)]
+	[InlineData('c')]
+	[InlineData(true)]
+	public void InvalidConverterValuesThrowArgumentException(object? value)
 	{
 		var listIsNotNullOrEmptyConverter = new IsListNotNullOrEmptyConverter();
 

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/IsListNotNullOrEmptyConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/IsListNotNullOrEmptyConverter_Tests.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System.Collections;
+using System.Globalization;
 using CommunityToolkit.Maui.Converters;
 using Xunit;
 
@@ -16,13 +17,15 @@ public class IsListNotNullOrEmptyConverter_Tests : BaseTest
 
 	[Theory]
 	[MemberData(nameof(Data))]
-	public void IsListNotNullOrEmptyConverter(object value, bool expectedResult)
+	public void IsListNotNullOrEmptyConverter(IEnumerable? value, bool expectedResult)
 	{
 		var listIsNotNullOrEmptyConverter = new IsListNotNullOrEmptyConverter();
 
-		var result = (bool)listIsNotNullOrEmptyConverter.Convert(value, typeof(IsListNotNullOrEmptyConverter), null, CultureInfo.CurrentCulture);
+		var convertResult = (bool)(listIsNotNullOrEmptyConverter.Convert(value, typeof(IEnumerable), null, CultureInfo.CurrentCulture) ?? throw new NullReferenceException());
+		var convertFromResult = listIsNotNullOrEmptyConverter.ConvertFrom(value);
 
-		Assert.Equal(expectedResult, result);
+		Assert.Equal(expectedResult, convertResult);
+		Assert.Equal(expectedResult, convertFromResult);
 	}
 
 	[Theory]
@@ -31,6 +34,6 @@ public class IsListNotNullOrEmptyConverter_Tests : BaseTest
 	{
 		var listIsNotNullOrEmptyConverter = new IsListNotNullOrEmptyConverter();
 
-		Assert.Throws<ArgumentException>(() => listIsNotNullOrEmptyConverter.Convert(value, typeof(IsListNotNullOrEmptyConverter), null, CultureInfo.CurrentCulture));
+		Assert.Throws<ArgumentException>(() => listIsNotNullOrEmptyConverter.Convert(value, typeof(IEnumerable), null, CultureInfo.CurrentCulture));
 	}
 }

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/IsListNotNullOrEmptyConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/IsListNotNullOrEmptyConverter_Tests.cs
@@ -21,7 +21,7 @@ public class IsListNotNullOrEmptyConverter_Tests : BaseTest
 	{
 		var listIsNotNullOrEmptyConverter = new IsListNotNullOrEmptyConverter();
 
-		var convertResult = (bool)(listIsNotNullOrEmptyConverter.Convert(value, typeof(IEnumerable), null, CultureInfo.CurrentCulture) ?? throw new NullReferenceException());
+		var convertResult = (bool?)listIsNotNullOrEmptyConverter.Convert(value, typeof(IEnumerable), null, CultureInfo.CurrentCulture);
 		var convertFromResult = listIsNotNullOrEmptyConverter.ConvertFrom(value);
 
 		Assert.Equal(expectedResult, convertResult);

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/IsListNullOrEmptyConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/IsListNullOrEmptyConverter_Tests.cs
@@ -17,13 +17,15 @@ public class IsListNullOrEmptyConverter_Tests : BaseTest
 
 	[Theory]
 	[MemberData(nameof(Data))]
-	public void IsListNullOrEmptyConverter(object value, bool expectedResult)
+	public void IsListNullOrEmptyConverter(IEnumerable? value, bool expectedResult)
 	{
 		var listIstNullOrEmptyConverter = new IsListNullOrEmptyConverter();
 
-		var result = (bool)(listIstNullOrEmptyConverter.Convert(value, typeof(IEnumerable), null, CultureInfo.CurrentCulture) ?? throw new NullReferenceException());
+		var convertResult = (bool?)listIstNullOrEmptyConverter.Convert(value, typeof(IEnumerable), null, CultureInfo.CurrentCulture);
+		var convertFromResult = listIstNullOrEmptyConverter.ConvertFrom(value);
 
-		Assert.Equal(expectedResult, result);
+		Assert.Equal(expectedResult, convertResult);
+		Assert.Equal(expectedResult, convertFromResult);
 	}
 
 	[Theory]

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/IsListNullOrEmptyConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/IsListNullOrEmptyConverter_Tests.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System.Collections;
+using System.Globalization;
 using CommunityToolkit.Maui.Converters;
 using Xunit;
 
@@ -20,7 +21,7 @@ public class IsListNullOrEmptyConverter_Tests : BaseTest
 	{
 		var listIstNullOrEmptyConverter = new IsListNullOrEmptyConverter();
 
-		var result = (bool)listIstNullOrEmptyConverter.Convert(value, typeof(IsListNullOrEmptyConverter), null, CultureInfo.CurrentCulture);
+		var result = (bool)(listIstNullOrEmptyConverter.Convert(value, typeof(IEnumerable), null, CultureInfo.CurrentCulture) ?? throw new NullReferenceException());
 
 		Assert.Equal(expectedResult, result);
 	}
@@ -31,6 +32,6 @@ public class IsListNullOrEmptyConverter_Tests : BaseTest
 	{
 		var listIstNullOrEmptyConverter = new IsListNullOrEmptyConverter();
 
-		Assert.Throws<ArgumentException>(() => listIstNullOrEmptyConverter.Convert(value, typeof(IsListNullOrEmptyConverter), null, CultureInfo.CurrentCulture));
+		Assert.Throws<ArgumentException>(() => listIstNullOrEmptyConverter.Convert(value, typeof(IEnumerable), null, CultureInfo.CurrentCulture));
 	}
 }

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/IsStringNotNullOrEmptyConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/IsStringNotNullOrEmptyConverter_Tests.cs
@@ -11,12 +11,17 @@ public class IsStringNotNullOrEmptyConverter_Tests : BaseTest
 	[InlineData(null, false)]
 	[InlineData("", false)]
 	[InlineData(" ", true)]
-	public void IsNotNullOrEmptyConverter_ValidStringValue(string? value, bool expectedResult)
+	public void IsStringNotNullOrEmptyConverter_ValidStringValue(string? value, bool expectedResult)
 	{
 		var isNotNullOrEmptyConverter = new IsStringNotNullOrEmptyConverter();
 
-		var result = (bool)isNotNullOrEmptyConverter.Convert(value, null, null, null);
+#pragma warning disable CS8605 // Unboxing a possibly null value.
+		var baseResult = (bool)isNotNullOrEmptyConverter.Convert(value, typeof(bool), null, null);
+#pragma warning restore CS8605 // Unboxing a possibly null value.
 
+		var result = isNotNullOrEmptyConverter.ConvertFrom(value);
+
+		Assert.Equal(expectedResult, baseResult);
 		Assert.Equal(expectedResult, result);
 	}
 
@@ -24,10 +29,10 @@ public class IsStringNotNullOrEmptyConverter_Tests : BaseTest
 	[InlineData(17)]
 	[InlineData(true)]
 	[InlineData('c')]
-	public void IsNotNullOrEmptyConverter_InvalidValue(object value)
+	public void IsStringNotNullOrEmptyConverter_InvalidValue(object value)
 	{
 		var isNotNullOrEmptyConverter = new IsStringNotNullOrEmptyConverter();
 
-		Assert.Throws<InvalidCastException>(() => isNotNullOrEmptyConverter.Convert(value, null, null, null));
+		Assert.Throws<ArgumentException>(() => isNotNullOrEmptyConverter.Convert(value, typeof(bool), null, null));
 	}
 }

--- a/src/CommunityToolkit.Maui/Behaviors/EventToCommandBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/EventToCommandBehavior.shared.cs
@@ -33,7 +33,7 @@ public class EventToCommandBehavior : BaseBehavior<VisualElement>
 	public static readonly BindableProperty EventArgsConverterProperty =
 		BindableProperty.Create(nameof(EventArgsConverter), typeof(ICommunityToolkitValueConverter), typeof(EventToCommandBehavior));
 
-	readonly MethodInfo eventHandlerMethodInfo = typeof(EventToCommandBehavior).GetTypeInfo()?.GetDeclaredMethod(nameof(OnTriggerHandled)) ?? throw new NullReferenceException($"Cannot find method {nameof(OnTriggerHandled)}");
+	readonly MethodInfo eventHandlerMethodInfo = typeof(EventToCommandBehavior).GetTypeInfo()?.GetDeclaredMethod(nameof(OnTriggerHandled)) ?? throw new InvalidOperationException($"Cannot find method {nameof(OnTriggerHandled)}");
 
 	Delegate? eventHandler;
 

--- a/src/CommunityToolkit.Maui/Converters/BaseConverterOneWay.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/BaseConverterOneWay.shared.cs
@@ -27,7 +27,7 @@ public abstract class BaseConverterOneWay<TFrom, TTo> : BaseConverterOneWay
 #pragma warning restore CS8604 // Possible null reference argument.
 		}
 
-		if (value is not TFrom)
+		if (value is not TFrom convertedValue)
 		{
 			throw new ArgumentException($"value needs to be of type {typeof(TFrom)}");
 		}
@@ -37,7 +37,7 @@ public abstract class BaseConverterOneWay<TFrom, TTo> : BaseConverterOneWay
 			throw new ArgumentException($"targetType needs to be typeof {typeof(TTo)}");
 		}
 
-		return ConvertFrom((TFrom)value);
+		return ConvertFrom(convertedValue);
 	}
 
 	/// <summary>

--- a/src/CommunityToolkit.Maui/Converters/BaseConverterOneWay.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/BaseConverterOneWay.shared.cs
@@ -56,7 +56,7 @@ public abstract class BaseConverterOneWay<TFrom, TTo> : BaseConverterOneWay
 			return true; // ref-type
 		}
 
-		if (Nullable.GetUnderlyingType(type) != null)
+		if (Nullable.GetUnderlyingType(type) is not null)
 		{
 			return true; // Nullable<T>
 		}

--- a/src/CommunityToolkit.Maui/Converters/BaseConverterOneWay.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/BaseConverterOneWay.shared.cs
@@ -27,7 +27,7 @@ public abstract class BaseConverterOneWay<TFrom, TTo> : BaseConverterOneWay
 #pragma warning restore CS8604 // Possible null reference argument.
 		}
 
-		if (value?.GetType() != typeof(TFrom))
+		if (value is not TFrom)
 		{
 			throw new ArgumentException($"value needs to be of type {typeof(TFrom)}");
 		}

--- a/src/CommunityToolkit.Maui/Converters/BaseConverterOneWay.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/BaseConverterOneWay.shared.cs
@@ -51,17 +51,17 @@ public abstract class BaseConverterOneWay<TFrom, TTo> : BaseConverterOneWay
 	{
 		var type = typeof(T);
 
-		if (!type.IsValueType)
+		if (type.IsValueType)
 		{
-			return true; // ref-type
+			return true; // value type
 		}
 
-		if (Nullable.GetUnderlyingType(type) != null)
+		if (Nullable.GetUnderlyingType(type) is not null)
 		{
 			return true; // Nullable<T>
 		}
 
-		return false; // value-type
+		return true; // ref type
 	}
 }
 

--- a/src/CommunityToolkit.Maui/Converters/BaseConverterOneWay.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/BaseConverterOneWay.shared.cs
@@ -51,17 +51,17 @@ public abstract class BaseConverterOneWay<TFrom, TTo> : BaseConverterOneWay
 	{
 		var type = typeof(T);
 
-		if (type.IsValueType)
+		if (!type.IsValueType)
 		{
-			return true; // value type
+			return true; // ref-type
 		}
 
-		if (Nullable.GetUnderlyingType(type) is not null)
+		if (Nullable.GetUnderlyingType(type) != null)
 		{
 			return true; // Nullable<T>
 		}
 
-		return true; // ref type
+		return false; // value-type
 	}
 }
 

--- a/src/CommunityToolkit.Maui/Converters/BaseConverterOneWay.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/BaseConverterOneWay.shared.cs
@@ -28,7 +28,7 @@ public abstract class BaseConverterOneWay<TFrom, TTo> : BaseConverterOneWay
 		}
 		else if (value is null && !IsNullable<TFrom>())
 		{
-			throw new ArgumentException($"value cannot be null because {nameof(TFrom)} is not Nullable");
+			throw new ArgumentNullException(nameof(value), $"value cannot be null because {nameof(TFrom)} is not Nullable");
 		}
 
 		if (value is not TFrom convertedValue)

--- a/src/CommunityToolkit.Maui/Converters/BaseConverterOneWay.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/BaseConverterOneWay.shared.cs
@@ -26,6 +26,10 @@ public abstract class BaseConverterOneWay<TFrom, TTo> : BaseConverterOneWay
 			return ConvertFrom(default);
 #pragma warning restore CS8604 // Possible null reference argument.
 		}
+		else if (value is null && !IsNullable<TFrom>())
+		{
+			throw new ArgumentException($"value cannot be null because {nameof(TFrom)} is not Nullable");
+		}
 
 		if (value is not TFrom convertedValue)
 		{

--- a/src/CommunityToolkit.Maui/Converters/EqualConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/EqualConverter.shared.cs
@@ -17,8 +17,8 @@ public class EqualConverter : BaseConverterOneWay
 	/// <param name="culture">The culture to use in the converter. This is not implemented.</param>
 	/// <returns>True if <paramref name="value"/> and <paramref name="parameter"/> are equal, False if they are not equal.</returns>
 	[return: NotNull]
-	public override object? Convert(object? value, Type? targetType, object? parameter, CultureInfo? culture) => ConvertInternal(value, parameter);
+	public override object? Convert(object? value, Type? targetType, object? parameter, CultureInfo? culture) => IsEqual(value, parameter);
 
-	internal static bool ConvertInternal(object? value, object? parameter) =>
+	internal static bool IsEqual(object? value, object? parameter) =>
 		(value != null && value.Equals(parameter)) || (value == null && parameter == null);
 }

--- a/src/CommunityToolkit.Maui/Converters/ImageResourceConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ImageResourceConverter.shared.cs
@@ -7,18 +7,15 @@ namespace CommunityToolkit.Maui.Converters;
 /// <summary>
 /// Converts embedded image resource ID to it ImageSource.
 /// </summary>
-public class ImageResourceConverter : BaseConverterOneWay
+public class ImageResourceConverter : BaseConverterOneWay<string?, ImageSource?>
 {
 	/// <summary>
 	/// Converts embedded image resource ID to it ImageSource.
 	/// </summary>
 	/// <param name="value">The value to convert.</param>
-	/// <param name="targetType">The type of the binding target property. This is not implemented.</param>
-	/// <param name="parameter">Additional parameter for the converter to handle. This is not implemented.</param>
-	/// <param name="culture">The culture to use in the converter. This is not implemented.</param>
 	/// <returns>The ImageSource related to the provided resource ID of the embedded image. If it's null it will returns null.</returns>
 	[return: NotNullIfNotNull("value")]
-	public override object? Convert(object? value, Type? targetType, object? parameter, CultureInfo? culture)
+	public override ImageSource? ConvertFrom(string? value)
 	{
 		if (value == null)
 		{

--- a/src/CommunityToolkit.Maui/Converters/IsListNotNullOrEmptyConverter.cs
+++ b/src/CommunityToolkit.Maui/Converters/IsListNotNullOrEmptyConverter.cs
@@ -1,22 +1,16 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
+﻿using System.Collections;
 
 namespace CommunityToolkit.Maui.Converters;
 
 /// <summary>
 /// Converts the incoming value to a <see cref="bool"/> indicating whether or not the value is not null and not empty.
 /// </summary>
-public class IsListNotNullOrEmptyConverter : BaseConverterOneWay
+public class IsListNotNullOrEmptyConverter : BaseConverterOneWay<IEnumerable?, bool>
 {
 	/// <summary>
 	/// Converts the incoming value to a <see cref="bool"/> indicating whether or not the value is not null and not empty.
 	/// </summary>
 	/// <param name="value">The value to convert.</param>
-	/// <param name="targetType">The type of the binding target property. This is not implemented.</param>
-	/// <param name="parameter">Additional parameter for the converter to handle. This is not implemented.</param>
-	/// <param name="culture">The culture to use in the converter. This is not implemented.</param>
-	/// <returns>A <see cref="bool"/> indicating if the incoming value is not null and not empty.</returns>
-	[return: NotNull]
-	public override object? Convert(object? value, Type? targetType, object? parameter, CultureInfo? culture) =>
+	public override bool ConvertFrom(IEnumerable? value) =>
 		!IsListNullOrEmptyConverter.IsListNullOrEmpty(value);
 }

--- a/src/CommunityToolkit.Maui/Converters/IsListNullOrEmptyConverter.cs
+++ b/src/CommunityToolkit.Maui/Converters/IsListNullOrEmptyConverter.cs
@@ -1,38 +1,26 @@
 ﻿using System.Collections;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using CommunityToolkit.Maui.Extensions;
 
 namespace CommunityToolkit.Maui.Converters;
 
 /// <summary>
 /// Converts the incoming value to a <see cref="bool"/> indicating whether or not the value is null or empty.
 /// </summary>
-public class IsListNullOrEmptyConverter : BaseConverterOneWay
+public class IsListNullOrEmptyConverter : BaseConverterOneWay<IEnumerable?, bool>
 {
 	/// <summary>
 	/// Converts the incoming value to a <see cref="bool"/> indicating whether or not the value is null or empty.
 	/// </summary>
 	/// <param name="value">The value to convert.</param>
-	/// <param name="targetType">The type of the binding target property. This is not implemented.</param>
-	/// <param name="parameter">Additional parameter for the converter to handle. This is not implemented.</param>
-	/// <param name="culture">The culture to use in the converter. This is not implemented.</param>
 	/// <returns>A <see cref="bool"/> indicating if the incoming value is null or empty.</returns>
-	[return: NotNull]
-	public override object? Convert(object? value, Type? targetType, object? parameter, CultureInfo? culture) => IsListNullOrEmpty(value);
+	public override bool ConvertFrom(IEnumerable? value) => IsListNullOrEmpty(value);
 
-	internal static bool IsListNullOrEmpty([NotNullWhen(false)] object? value)
+	internal static bool IsListNullOrEmpty(IEnumerable? value)
 	{
 		if (value is null)
 		{
 			return true;
 		}
-
-		if (value is IEnumerable list)
-		{
-			return !list.GetEnumerator().MoveNext();
-		}
-
-		throw new ArgumentException("Value is not a valid IEnumerable or null", nameof(value));
+		
+		return !value.GetEnumerator().MoveNext();
 	}
 }

--- a/src/CommunityToolkit.Maui/Converters/IsStringNotNullOrEmptyConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/IsStringNotNullOrEmptyConverter.shared.cs
@@ -1,7 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-
-namespace CommunityToolkit.Maui.Converters;
+﻿namespace CommunityToolkit.Maui.Converters;
 
 /// <summary>
 /// Converts the incoming value to a <see cref="bool"/> indicating whether or not the value is not null and not empty.
@@ -12,10 +9,5 @@ public class IsStringNotNullOrEmptyConverter : BaseConverterOneWay<string?, bool
 	/// Converts the incoming string to a <see cref="bool"/> indicating whether or not the value is not null and not empty using string.IsNullOrEmpty.
 	/// </summary>
 	/// <param name="value">The value to convert.</param>
-	public override bool ConvertFrom(string? value)
-	{
-		var stringValue = value;
-
-		return !string.IsNullOrEmpty(stringValue);
-	}
+	public override bool ConvertFrom(string? value) => !string.IsNullOrEmpty(value);
 }

--- a/src/CommunityToolkit.Maui/Converters/IsStringNotNullOrEmptyConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/IsStringNotNullOrEmptyConverter.shared.cs
@@ -6,20 +6,15 @@ namespace CommunityToolkit.Maui.Converters;
 /// <summary>
 /// Converts the incoming value to a <see cref="bool"/> indicating whether or not the value is not null and not empty.
 /// </summary>
-public class IsStringNotNullOrEmptyConverter : BaseConverterOneWay
+public class IsStringNotNullOrEmptyConverter : BaseConverterOneWay<string?, bool>
 {
 	/// <summary>
 	/// Converts the incoming string to a <see cref="bool"/> indicating whether or not the value is not null and not empty using string.IsNullOrEmpty.
 	/// </summary>
 	/// <param name="value">The value to convert.</param>
-	/// <param name="targetType">The type of the binding target property. This is not implemented.</param>
-	/// <param name="parameter">Additional parameter for the converter to handle. This is not implemented.</param>
-	/// <param name="culture">The culture to use in the converter. This is not implemented.</param>
-	/// <returns>A <see cref="bool"/> indicating if the incoming value is not null and not empty.</returns>
-	[return: NotNull]
-	public override object? Convert(object? value, Type? targetType, object? parameter, CultureInfo? culture)
+	public override bool ConvertFrom(string? value)
 	{
-		var stringValue = (string?)value;
+		var stringValue = value;
 
 		return !string.IsNullOrEmpty(stringValue);
 	}

--- a/src/CommunityToolkit.Maui/Converters/ItemSelectedEventArgsConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ItemSelectedEventArgsConverter.shared.cs
@@ -6,26 +6,17 @@ namespace CommunityToolkit.Maui.Converters;
 /// <summary>
 /// Converts/Extracts the incoming value from <see cref="SelectedItemChangedEventArgs"/> object and returns the value of <see cref="SelectedItemChangedEventArgs.SelectedItem"/> property from it.
 /// </summary>
-public class ItemSelectedEventArgsConverter : BaseConverterOneWay
+public class ItemSelectedEventArgsConverter : BaseConverterOneWay<SelectedItemChangedEventArgs?, object?>
 {
 	/// <summary>
 	/// Converts/Extracts the incoming value from <see cref="SelectedItemChangedEventArgs"/> object and returns the value of <see cref="SelectedItemChangedEventArgs.SelectedItem"/> property from it.
 	/// </summary>
 	/// <param name="value">The value to convert.</param>
-	/// <param name="targetType">The type of the binding target property. This is not implemented.</param>
-	/// <param name="parameter">Additional parameter for the converter to handle. This is not implemented.</param>
-	/// <param name="culture">The culture to use in the converter. This is not implemented.</param>
 	/// <returns>A <see cref="SelectedItemChangedEventArgs.SelectedItem"/> object from object of type <see cref="SelectedItemChangedEventArgs"/>.</returns>
 	[return: NotNullIfNotNull("value")]
-	public override object? Convert(object? value, Type? targetType, object? parameter, CultureInfo? culture)
+	public override object? ConvertFrom(SelectedItemChangedEventArgs? value) => value switch
 	{
-		if (value == null)
-		{
-			return null;
-		}
-
-		return value is SelectedItemChangedEventArgs selectedItemChangedEventArgs
-		   ? selectedItemChangedEventArgs.SelectedItem
-		   : throw new ArgumentException("Expected value to be of type SelectedItemChangedEventArgs", nameof(value));
-	}
+		null => null,
+		_ => value.SelectedItem
+	};
 }

--- a/src/CommunityToolkit.Maui/Converters/ItemTappedEventArgsConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ItemTappedEventArgsConverter.shared.cs
@@ -6,7 +6,7 @@ namespace CommunityToolkit.Maui.Converters;
 /// <summary>
 /// Converts/Extracts the incoming value from <see cref="ItemTappedEventArgs"/> object and returns the value of <see cref="ItemTappedEventArgs.Item"/> property from it.
 /// </summary>
-public class ItemTappedEventArgsConverter : BaseConverterOneWay
+public class ItemTappedEventArgsConverter : BaseConverterOneWay<ItemTappedEventArgs?, object?>
 {
 	/// <summary>
 	/// Converts/Extracts the incoming value from <see cref="ItemTappedEventArgs"/> object and returns the value of <see cref="ItemTappedEventArgs.Item"/> property from it.
@@ -17,15 +17,9 @@ public class ItemTappedEventArgsConverter : BaseConverterOneWay
 	/// <param name="culture">The culture to use in the converter. This is not implemented.</param>
 	/// <returns>A <see cref="ItemTappedEventArgs.Item"/> object from object of type <see cref="ItemTappedEventArgs"/>.</returns>
 	[return: NotNullIfNotNull("value")]
-	public override object? Convert(object? value, Type? targetType, object? parameter, CultureInfo? culture)
+	public override object? ConvertFrom(ItemTappedEventArgs? value) => value switch
 	{
-		if (value == null)
-		{
-			return null;
-		}
-
-		return value is ItemTappedEventArgs itemTappedEventArgs
-			? itemTappedEventArgs.Item
-			: throw new ArgumentException("Expected value to be of type ItemTappedEventArgs", nameof(value));
-	}
+		null => null,
+		_ => value.Item
+	};
 }

--- a/src/CommunityToolkit.Maui/Converters/ItemTappedEventArgsConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ItemTappedEventArgsConverter.shared.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 namespace CommunityToolkit.Maui.Converters;
@@ -12,9 +13,6 @@ public class ItemTappedEventArgsConverter : BaseConverterOneWay<ItemTappedEventA
 	/// Converts/Extracts the incoming value from <see cref="ItemTappedEventArgs"/> object and returns the value of <see cref="ItemTappedEventArgs.Item"/> property from it.
 	/// </summary>
 	/// <param name="value">The value to convert.</param>
-	/// <param name="targetType">The type of the binding target property. This is not implemented.</param>
-	/// <param name="parameter">Additional parameter for the converter to handle. This is not implemented.</param>
-	/// <param name="culture">The culture to use in the converter. This is not implemented.</param>
 	/// <returns>A <see cref="ItemTappedEventArgs.Item"/> object from object of type <see cref="ItemTappedEventArgs"/>.</returns>
 	[return: NotNullIfNotNull("value")]
 	public override object? ConvertFrom(ItemTappedEventArgs? value) => value switch

--- a/src/CommunityToolkit.Maui/Converters/NotEqualConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/NotEqualConverter.shared.cs
@@ -18,5 +18,5 @@ public class NotEqualConverter : BaseConverterOneWay
 	/// <returns>True if <paramref name="value"/> and <paramref name="parameter"/> are not equal, False if they are equal.</returns>
 	[return: NotNull]
 	public override object? Convert(object? value, Type? targetType, object? parameter, CultureInfo? culture) =>
-		!EqualConverter.ConvertInternal(value, parameter);
+		!EqualConverter.IsEqual(value, parameter);
 }


### PR DESCRIPTION
> Note: This PR targets the `feature/not-supported-exception` branch, aka #296. It does not target the `main` branch

 ### Description of Change ###

This PR adds `null` support for `BaseOneWayConverter<TFrom, TTo>`.

Adding support for `null` enables us to use nullable generics, eg `<TFrom?, TTo?>` which then introduces the possibility to update the following converters from `BaseOneWayConverter` to `BaseOneWayConverter<TFrom, TTo>`:
- `public class ImageResourceConverter : BaseOneWayConverter<TFrom, TTo>`
- `public class IsStringNotNullEmptyConverter : BaseOneWayConverter<TFrom, TTo>`
- `public class IsListNotNullOrEmptyConverter : BaseOneWayConverter<TFrom, TTo>`
- `public class IsListNullOrEmptyConverter : BaseOneWayConverter<TFrom, TTo>`
- `public class ItemSelectedEventArgsConverter : BaseOneWayConverter<TFrom, TTo>`
- `public class ItemTappedEventArgsConverter : BaseOneWayConverter<TFrom, TTo>`