### PR TITLE
Add `ColorToColor` Converter Unit Tests

### DIFF
--- a/src/CommunityToolkit.Maui.UnitTests/CommunityToolkit.Maui.UnitTests.csproj
+++ b/src/CommunityToolkit.Maui.UnitTests/CommunityToolkit.Maui.UnitTests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.5.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Xunit" Version="2.4.1" />
     <PackageReference Include="Xunit.Runner.VisualStudio" Version="2.4.3" />
   </ItemGroup>

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToColorConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToColorConverter_Tests.cs
@@ -44,7 +44,7 @@ public class ColorToColorConverter_Tests : BaseTest
 	};
 
 	public static IReadOnlyList<object?[]> ColorToGrayScaleColorData { get; } = new[]
-{
+	{
 		new object[] { Colors.White, Colors.White},
 		new object[] { Colors.Yellow, new Color(2f/3f, 2f/3f, 2f/3f, 1) },
 		new object[] { Colors.Pink, new Color(0.8496732f, 0.8496732f, 0.8496732f, 1) },

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToColorConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToColorConverter_Tests.cs
@@ -1,0 +1,77 @@
+﻿using CommunityToolkit.Maui.Converters;
+using Xunit;
+
+namespace CommunityToolkit.Maui.UnitTests;
+
+public class ColorToColorConverter_Tests : BaseTest
+{
+	public static IReadOnlyList<object?[]> Data { get; } = new[]
+	{
+		new object[] { Colors.DarkBlue, Colors.Black },
+		//new object[] { Colors.DarkCyan, Colors.Black },
+		//new object[] { Colors.DarkGrey, Colors.Black },
+		//new object[] { Colors.Black, Colors.Black },
+		new object[] { Colors.Brown, Colors.White },
+		//new object[] { Colors.Yellow, Colors.White},
+		//new object[] { Colors.Pink, Colors.White},
+		//new object[] { Colors.LightBlue, Colors.White},
+		//new object[] { Colors.Wheat, Colors.White},
+		//new object[] { Colors.White, Colors.White},
+		//new object[] { Colors.Transparent, Colors.White},
+		//new object?[] { default(Color), Colors.White},
+	};
+
+	[Theory]
+	[MemberData(nameof(Data))]
+	public void ColorToBlackOrWhiteConverterValidArgumentsTest(Color initialColor, Color expectedColor)
+	{
+		var converter = new ColorToBlackOrWhiteConverter();
+
+		var convertedColor = converter.ConvertFrom(initialColor);
+
+		Assert.Equal(expectedColor, convertedColor);
+	}
+
+	[Fact]
+	public void ColorToBlackOrWhiteConverterInvalidArgumentsTest()
+	{
+
+	}
+}
+/*
+/// <summary>
+/// Converts the incoming value from <see cref="Color"/> and returns the object of a type <see cref="Color"/>.
+/// </summary>
+public class ColorToBlackOrWhiteConverter : BaseConverterOneWay<Color, Color>
+{
+	/// <inheritdoc/>
+	public override Color ConvertFrom(Color value) => value.ToBlackOrWhite();
+}
+
+/// <summary>
+/// Converts the incoming value from <see cref="Color"/> and returns the object of a type <see cref="Color"/>.
+/// </summary>
+public class ColorToColorForTextConverter : BaseConverterOneWay<Color, Color>
+{
+	/// <inheritdoc/>
+	public override Color ConvertFrom(Color value) => value.ToBlackOrWhiteForText();
+}
+
+/// <summary>
+/// Converts the incoming value from <see cref="Color"/> and returns the object of a type <see cref="Color"/>.
+/// </summary>
+public class ColorToGrayScaleColorConverter : BaseConverterOneWay<Color, Color>
+{
+	/// <inheritdoc/>
+	public override Color ConvertFrom(Color value) => value.ToGrayScale();
+}
+
+/// <summary>
+/// Converts the incoming value from <see cref="Color"/> and returns the object of a type <see cref="Color"/>.
+/// </summary>
+public class ColorToInverseColorConverter : BaseConverterOneWay<Color, Color>
+{
+	/// <inheritdoc/>
+	public override Color ConvertFrom(Color value) => value.ToInverseColor();
+}
+*/

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToColorConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToColorConverter_Tests.cs
@@ -1,77 +1,222 @@
 ﻿using CommunityToolkit.Maui.Converters;
 using Xunit;
 
-namespace CommunityToolkit.Maui.UnitTests;
+namespace CommunityToolkit.Maui.UnitTests.Converters;
 
 public class ColorToColorConverter_Tests : BaseTest
 {
-	public static IReadOnlyList<object?[]> Data { get; } = new[]
+	public static IReadOnlyList<object?[]> ColorToBlackOrWhiteData { get; } = new[]
 	{
+		new object[] { Colors.Black, Colors.Black },
 		new object[] { Colors.DarkBlue, Colors.Black },
-		//new object[] { Colors.DarkCyan, Colors.Black },
-		//new object[] { Colors.DarkGrey, Colors.Black },
-		//new object[] { Colors.Black, Colors.Black },
+		new object[] { Colors.DarkCyan, Colors.Black },
+		new object[] { Colors.Brown, Colors.Black },
+		new object[] { Colors.DarkGreen, Colors.Black },
+		new object[] { Colors.DarkSlateGray, Colors.Black },
+		new object[] { Colors.Transparent, Colors.Black},
+		new object[] { Colors.White, Colors.White},
+		new object[] { Colors.DarkSalmon, Colors.White },
+		new object[] { Colors.DarkOrchid, Colors.White },
+		new object[] { Colors.DarkGrey, Colors.White },
+		new object[] { Colors.Yellow, Colors.White },
+		new object[] { Colors.Pink, Colors.White },
+		new object[] { Colors.LightBlue, Colors.White },
+		new object[] { Colors.Wheat, Colors.White }
+	};
+
+	public static IReadOnlyList<object?[]> ColorToColorForTextData { get; } = new[]
+	{
+		new object[] { Colors.White, Colors.Black},
+		new object[] { Colors.Yellow, Colors.Black },
+		new object[] { Colors.Pink, Colors.Black },
+		new object[] { Colors.LightBlue, Colors.Black },
+		new object[] { Colors.Wheat, Colors.Black },
+		new object[] { Colors.Black, Colors.White },
+		new object[] { Colors.DarkBlue, Colors.White },
+		new object[] { Colors.DarkCyan, Colors.White },
 		new object[] { Colors.Brown, Colors.White },
-		//new object[] { Colors.Yellow, Colors.White},
-		//new object[] { Colors.Pink, Colors.White},
-		//new object[] { Colors.LightBlue, Colors.White},
-		//new object[] { Colors.Wheat, Colors.White},
-		//new object[] { Colors.White, Colors.White},
-		//new object[] { Colors.Transparent, Colors.White},
-		//new object?[] { default(Color), Colors.White},
+		new object[] { Colors.DarkGreen, Colors.White },
+		new object[] { Colors.DarkSlateGray, Colors.White },
+		new object[] { Colors.Transparent, Colors.White},
+		new object[] { Colors.DarkSalmon, Colors.White },
+		new object[] { Colors.DarkOrchid, Colors.White },
+		new object[] { Colors.DarkGrey, Colors.White }
+	};
+
+	public static IReadOnlyList<object?[]> ColorToGrayScaleColorData { get; } = new[]
+{
+		new object[] { Colors.White, Colors.White},
+		new object[] { Colors.Yellow, new Color(2f/3f, 2f/3f, 2f/3f, 1) },
+		new object[] { Colors.Pink, new Color(0.8496732f, 0.8496732f, 0.8496732f, 1) },
+		new object[] { Colors.LightBlue, new Color(0.8091503f, 0.8091503f, 0.8091503f, 1) },
+		new object[] { Colors.Wheat, new Color(0.84444445f, 0.84444445f, 0.84444445f, 1) },
+		new object[] { Colors.Black, Colors.Black },
+		new object[] { Colors.DarkBlue, new Color(0.18169935f, 0.18169935f, 0.18169935f, 1) },
+		new object[] { Colors.DarkCyan, new Color(0.3633987f, 0.3633987f, 0.3633987f, 1) },
+		new object[] { Colors.Brown, new Color(0.3254902f, 0.3254902f, 0.3254902f, 1) },
+		new object[] { Colors.DarkGreen, new Color(0.13071896f, 0.13071896f, 0.13071896f, 1) },
+		new object[] { Colors.DarkSlateGray, new Color(0.26797387f, 0.26797387f, 0.26797387f, 1) },
+		new object[] { Colors.Transparent, Colors.Black},
+		new object[] { Colors.DarkSalmon, new Color(0.66013074f, 0.66013074f, 0.66013074f, 1) },
+		new object[] { Colors.DarkOrchid, new Color(0.5320262f, 0.5320262f, 0.5320262f, 1) },
+		new object[] { Colors.DarkGrey, new Color(0.6627451f, 0.6627451f, 0.6627451f, 1) }
+	};
+
+	public static IReadOnlyList<object?[]> ColorToInverseColorConverterData { get; } = new[]
+	{
+		new object[] { Colors.White, Colors.Black},
+		new object[] { new Color(0,0,0), new Color(1,1,1) },
+		new object[] { new Color(0,0,1), new Color(1,1,0) },
+		new object[] { new Color(0,1,0), new Color(1,0,1) },
+		new object[] { new Color(0,1,1), new Color(1,0,0) },
+		new object[] { new Color(1,0,0), new Color(0,1,1) },
+		new object[] { new Color(1,0,1), new Color(0,1,0) },
+		new object[] { new Color(1,1,0), new Color(0,0,1) },
+		new object[] { new Color(1,1,1), new Color(0,0,0) },
+		new object[] { Colors.Black, Colors.White },
 	};
 
 	[Theory]
-	[MemberData(nameof(Data))]
+	[MemberData(nameof(ColorToBlackOrWhiteData))]
 	public void ColorToBlackOrWhiteConverterValidArgumentsTest(Color initialColor, Color expectedColor)
 	{
 		var converter = new ColorToBlackOrWhiteConverter();
 
-		var convertedColor = converter.ConvertFrom(initialColor);
+		var convertedColor = converter.Convert(initialColor, typeof(Color), null, null);
+		var convertedColorFrom = converter.ConvertFrom(initialColor);
 
 		Assert.Equal(expectedColor, convertedColor);
+		Assert.Equal(expectedColor, convertedColorFrom);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData(2)]
+	[InlineData('c')]
+	[InlineData(true)]
+	public void ColorToBlackOrWhiteConverterConvertInvalidArgumentsTest(object? value)
+	{
+		var converter = new ColorToBlackOrWhiteConverter();
+
+		Assert.Throws<ArgumentException>(() => converter.Convert(value, typeof(Color), null, null));
 	}
 
 	[Fact]
-	public void ColorToBlackOrWhiteConverterInvalidArgumentsTest()
+	public void ColorToBlackOrWhiteConverterConvertFromInvalidArgumentsTest()
 	{
+		var converter = new ColorToBlackOrWhiteConverter();
 
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => converter.ConvertFrom(null));
+		Assert.Throws<ArgumentNullException>(() => converter.ConvertFrom(default));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
+	[Theory]
+	[MemberData(nameof(ColorToColorForTextData))]
+	public void ColorToColorForTextConverterValidArgumentsTest(Color initialColor, Color expectedColor)
+	{
+		var converter = new ColorToColorForTextConverter();
+
+		var convertedColor = converter.Convert(initialColor, typeof(Color), null, null);
+		var convertedColorFrom = converter.ConvertFrom(initialColor);
+
+		Assert.Equal(expectedColor, convertedColor);
+		Assert.Equal(expectedColor, convertedColorFrom);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData(2)]
+	[InlineData('c')]
+	[InlineData(true)]
+	public void ColorToColorForTextConverterConvertInvalidArgumentsTest(object? value)
+	{
+		var converter = new ColorToColorForTextConverter();
+
+		Assert.Throws<ArgumentException>(() => converter.Convert(value, typeof(Color), null, null));
+	}
+
+	[Fact]
+	public void ColorToColorForTextConverterConvertFromInvalidArgumentsTest()
+	{
+		var converter = new ColorToColorForTextConverter();
+
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => converter.ConvertFrom(null));
+		Assert.Throws<ArgumentNullException>(() => converter.ConvertFrom(default));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
+	[Theory]
+	[MemberData(nameof(ColorToGrayScaleColorData))]
+	public void ColorToGrayScaleColorConverterValidArgumentsTest(Color initialColor, Color expectedColor)
+	{
+		var converter = new ColorToGrayScaleColorConverter();
+
+		var convertedColor = converter.Convert(initialColor, typeof(Color), null, null);
+		var convertedColorFrom = converter.ConvertFrom(initialColor);
+
+		Assert.Equal(expectedColor, convertedColor);
+		Assert.Equal(expectedColor, convertedColorFrom);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData(2)]
+	[InlineData('c')]
+	[InlineData(true)]
+	public void ColorToGrayScaleColorConverterConvertInvalidArgumentsTest(object? value)
+	{
+		var converter = new ColorToGrayScaleColorConverter();
+
+		Assert.Throws<ArgumentException>(() => converter.Convert(value, typeof(Color), null, null));
+	}
+
+	[Fact]
+	public void ColorToGrayScaleColorConverterConvertFromInvalidArgumentsTest()
+	{
+		var converter = new ColorToGrayScaleColorConverter();
+
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => converter.ConvertFrom(null));
+		Assert.Throws<ArgumentNullException>(() => converter.ConvertFrom(default));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
+	[Theory]
+	[MemberData(nameof(ColorToInverseColorConverterData))]
+	public void ColorToInverseColorConverterConverterValidArgumentsTest(Color initialColor, Color expectedColor)
+	{
+		var converter = new ColorToInverseColorConverter();
+
+		var convertedColor = converter.Convert(initialColor, typeof(Color), null, null);
+		var convertedColorFrom = converter.ConvertFrom(initialColor);
+
+		Assert.Equal(expectedColor, convertedColor);
+		Assert.Equal(expectedColor, convertedColorFrom);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData(2)]
+	[InlineData('c')]
+	[InlineData(true)]
+	public void ColorToInverseColorConverterConvertInvalidArgumentsTest(object? value)
+	{
+		var converter = new ColorToInverseColorConverter();
+
+		Assert.Throws<ArgumentException>(() => converter.Convert(value, typeof(Color), null, null));
+	}
+
+	[Fact]
+	public void ColorToInverseColorConverterConvertFromInvalidArgumentsTest()
+	{
+		var converter = new ColorToInverseColorConverter();
+
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => converter.ConvertFrom(null));
+		Assert.Throws<ArgumentNullException>(() => converter.ConvertFrom(default));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 }
-/*
-/// <summary>
-/// Converts the incoming value from <see cref="Color"/> and returns the object of a type <see cref="Color"/>.
-/// </summary>
-public class ColorToBlackOrWhiteConverter : BaseConverterOneWay<Color, Color>
-{
-	/// <inheritdoc/>
-	public override Color ConvertFrom(Color value) => value.ToBlackOrWhite();
-}
-
-/// <summary>
-/// Converts the incoming value from <see cref="Color"/> and returns the object of a type <see cref="Color"/>.
-/// </summary>
-public class ColorToColorForTextConverter : BaseConverterOneWay<Color, Color>
-{
-	/// <inheritdoc/>
-	public override Color ConvertFrom(Color value) => value.ToBlackOrWhiteForText();
-}
-
-/// <summary>
-/// Converts the incoming value from <see cref="Color"/> and returns the object of a type <see cref="Color"/>.
-/// </summary>
-public class ColorToGrayScaleColorConverter : BaseConverterOneWay<Color, Color>
-{
-	/// <inheritdoc/>
-	public override Color ConvertFrom(Color value) => value.ToGrayScale();
-}
-
-/// <summary>
-/// Converts the incoming value from <see cref="Color"/> and returns the object of a type <see cref="Color"/>.
-/// </summary>
-public class ColorToInverseColorConverter : BaseConverterOneWay<Color, Color>
-{
-	/// <inheritdoc/>
-	public override Color ConvertFrom(Color value) => value.ToInverseColor();
-}
-*/

--- a/src/CommunityToolkit.Maui/Converters/ColorToColorConverters.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ColorToColorConverters.shared.cs
@@ -8,7 +8,11 @@ namespace CommunityToolkit.Maui.Converters;
 public class ColorToBlackOrWhiteConverter : BaseConverterOneWay<Color, Color>
 {
 	/// <inheritdoc/>
-	public override Color ConvertFrom(Color value) => value.ToBlackOrWhite();
+	public override Color ConvertFrom(Color value)
+	{
+		ArgumentNullException.ThrowIfNull(value);
+		return value.ToBlackOrWhite();
+	}
 }
 
 /// <summary>
@@ -17,7 +21,11 @@ public class ColorToBlackOrWhiteConverter : BaseConverterOneWay<Color, Color>
 public class ColorToColorForTextConverter : BaseConverterOneWay<Color, Color>
 {
 	/// <inheritdoc/>
-	public override Color ConvertFrom(Color value) => value.ToBlackOrWhiteForText();
+	public override Color ConvertFrom(Color value)
+	{
+		ArgumentNullException.ThrowIfNull(value);
+		return value.ToBlackOrWhiteForText();
+	}
 }
 
 /// <summary>
@@ -26,7 +34,11 @@ public class ColorToColorForTextConverter : BaseConverterOneWay<Color, Color>
 public class ColorToGrayScaleColorConverter : BaseConverterOneWay<Color, Color>
 {
 	/// <inheritdoc/>
-	public override Color ConvertFrom(Color value) => value.ToGrayScale();
+	public override Color ConvertFrom(Color value)
+	{
+		ArgumentNullException.ThrowIfNull(value);
+		return value.ToGrayScale();
+	}
 }
 
 /// <summary>
@@ -35,5 +47,9 @@ public class ColorToGrayScaleColorConverter : BaseConverterOneWay<Color, Color>
 public class ColorToInverseColorConverter : BaseConverterOneWay<Color, Color>
 {
 	/// <inheritdoc/>
-	public override Color ConvertFrom(Color value) => value.ToInverseColor();
+	public override Color ConvertFrom(Color value)
+	{
+		ArgumentNullException.ThrowIfNull(value);
+		return value.ToInverseColor();
+	}
 }


### PR DESCRIPTION
 ### Description of Change ###

This PR implements unit tests for the ColorToColor Converters found in `ColorToColorConverters.shared.cs`

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #52 

 ### PR Checklist ###
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)


 ### Additional information ###

I've also added `ArgumentNullException.ThrowIfNull(value);` to each Converter. Even though we have `<nullable>Enable</nullable>`, devs who do not have nullable enabled may still try to pass in `null` via the public API.
