### PR TITLE
Add `ProgressBarAnimationBehavior` Unit Tests

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/ProgressBarAnimationBehaviorPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/ProgressBarAnimationBehaviorPage.xaml
@@ -8,6 +8,7 @@
     x:Class="CommunityToolkit.Maui.Sample.Pages.Behaviors.ProgressBarAnimationBehaviorPage"
     x:TypeArguments="vm:ProgressBarAnimationBehaviorViewModel"
     x:DataType="vm:ProgressBarAnimationBehaviorViewModel">
+
     <VerticalStackLayout Padding="{StaticResource ContentPadding}" Spacing="50">
 
         <Label Text="The ProgressBarAnimationBehavior is a behavior that behavior that animates a ProgressBar"
@@ -15,7 +16,10 @@
 
         <ProgressBar>
             <ProgressBar.Behaviors>
-                <mct:ProgressBarAnimationBehavior AnimateProgress="{Binding Progress}" />
+                <mct:ProgressBarAnimationBehavior
+                    x:Name="ProgressBarAnimationBehavior"
+                    Progress="{Binding Progress}"
+                    Length="250"/>
             </ProgressBar.Behaviors>
         </ProgressBar>
 

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/ProgressBarAnimationBehaviorPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/ProgressBarAnimationBehaviorPage.xaml.cs
@@ -8,5 +8,9 @@ public partial class ProgressBarAnimationBehaviorPage : BasePage<ProgressBarAnim
 		: base(progressBarAnimationBehaviorViewModel)
 	{
 		InitializeComponent();
+
+		// Work-around for Error XFC0009 when assigning Easing in XAML
+		// No property, BindableProperty, or event found for "Easing", or mismatching type between value and property. (XFC0009)
+		ProgressBarAnimationBehavior.Easing = Easing.CubicOut;
 	}
 }

--- a/src/CommunityToolkit.Maui.UnitTests/Behaviors/MaskedBehavior_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Behaviors/MaskedBehavior_Tests.cs
@@ -78,17 +78,37 @@ public class MaskedBehavior_Tests : BaseTest
 	}
 
 	[Fact]
-	public void AttachedToValidElementTest()
+	public void AttachedToRemovedFromValidElementTest()
 	{
 		var entry = new Entry();
 		var editor = new Editor();
 		var inputView = new InputView();
 		var customInputView = new CustomInputView();
 
-		entry.Invoking(x => x.Behaviors.Add(new MaskedBehavior())).Should().NotThrow<InvalidOperationException>();
-		editor.Invoking(x => x.Behaviors.Add(new MaskedBehavior())).Should().NotThrow<InvalidOperationException>();
-		inputView.Invoking(x => x.Behaviors.Add(new MaskedBehavior())).Should().NotThrow<InvalidOperationException>();
-		customInputView.Invoking(x => x.Behaviors.Add(new MaskedBehavior())).Should().NotThrow<InvalidOperationException>();
+		var entryMaskedBehavior = new MaskedBehavior();
+		var editorMaskedBehavior = new MaskedBehavior();
+		var inputViewMaskedBehavior = new MaskedBehavior();
+		var customInputViewMaskedBehavior = new MaskedBehavior();
+
+		entry.Invoking(x => x.Behaviors.Add(entryMaskedBehavior)).Should().NotThrow<InvalidOperationException>();
+		editor.Invoking(x => x.Behaviors.Add(editorMaskedBehavior)).Should().NotThrow<InvalidOperationException>();
+		inputView.Invoking(x => x.Behaviors.Add(inputViewMaskedBehavior)).Should().NotThrow<InvalidOperationException>();
+		customInputView.Invoking(x => x.Behaviors.Add(customInputViewMaskedBehavior)).Should().NotThrow<InvalidOperationException>();
+
+		Assert.Single(entry.Behaviors.OfType<MaskedBehavior>());
+		Assert.Single(editor.Behaviors.OfType<MaskedBehavior>());
+		Assert.Single(inputView.Behaviors.OfType<MaskedBehavior>());
+		Assert.Single(customInputView.Behaviors.OfType<MaskedBehavior>());
+
+		entry.Invoking(x => x.Behaviors.Remove(entryMaskedBehavior)).Should().NotThrow<InvalidOperationException>();
+		editor.Invoking(x => x.Behaviors.Remove(editorMaskedBehavior)).Should().NotThrow<InvalidOperationException>();
+		inputView.Invoking(x => x.Behaviors.Remove(inputViewMaskedBehavior)).Should().NotThrow<InvalidOperationException>();
+		customInputView.Invoking(x => x.Behaviors.Remove(customInputViewMaskedBehavior)).Should().NotThrow<InvalidOperationException>();
+
+		Assert.Empty(entry.Behaviors);
+		Assert.Empty(editor.Behaviors);
+		Assert.Empty(inputView.Behaviors);
+		Assert.Empty(customInputView.Behaviors);
 	}
 
 	class CustomInputView : InputView

--- a/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
@@ -46,7 +46,7 @@ public class ProgressBarAnimationBehavior_Tests : BaseTest
 			var throwAwayProgressBar = new ProgressBar();
 			throwAwayProgressBar.EnableAnimations();
 
-			return throwAwayProgressBar.ProgressTo(progress, length, easing);
+			return throwAwayProgressBar.ProgressTo(progress, (uint)(length * 1.1), easing);
 		}
 	}
 

--- a/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
@@ -40,7 +40,7 @@ public class ProgressBarAnimationBehavior_Tests : BaseTest
 		Assert.Equal(length, progressBarAnimationBehavior.Length);
 		Assert.Equal(easing, progressBarAnimationBehavior.Easing);
 
-		static Task ensureProgressToAnimationCompleted(double progress, uint length, Easing easing)
+		static Task ensureProgressToAnimationCompleted(in double progress, in uint length, in Easing easing)
 		{
 			// Use a throw-away ProgressBar as a timer to wait for ProgressTo animation to complete
 			var throwAwayProgressBar = new ProgressBar();

--- a/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
@@ -43,10 +43,12 @@ public class ProgressBarAnimationBehavior_Tests : BaseTest
 		static Task ensureProgressToAnimationCompleted(in double progress, in uint length, in Easing easing)
 		{
 			// Use a throw-away ProgressBar as a timer to wait for ProgressTo animation to complete
+			// Because of the combination of Xunit's Synchronization Context with the MockAnimationHandler, Task.Delay(length) will always return before ProgressTo(progress, length, easing) is finished
 			var throwAwayProgressBar = new ProgressBar();
 			throwAwayProgressBar.EnableAnimations();
 
-			return throwAwayProgressBar.ProgressTo(progress, (uint)(length * 1.5), easing);
+			// Ensure the length is longer than the length of the test
+			return throwAwayProgressBar.ProgressTo(progress, (uint)Math.Round(length * 1.5, MidpointRounding.ToPositiveInfinity), easing);
 		}
 	}
 

--- a/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
@@ -34,7 +34,7 @@ public class ProgressBarAnimationBehavior_Tests : BaseTest
 		progressBarAnimationBehavior.Progress = progress;
 
 		// Wait for ProgressTo animation to complete
-		await Task.Delay(TimeSpan.FromMilliseconds(length * 1.25));
+		await Task.Delay(TimeSpan.FromMilliseconds(length * 2));
 
 		Assert.Equal(progress, progressBar.Progress);
 		Assert.Equal(progress, progressBarAnimationBehavior.Progress);

--- a/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
@@ -46,7 +46,7 @@ public class ProgressBarAnimationBehavior_Tests : BaseTest
 			var throwAwayProgressBar = new ProgressBar();
 			throwAwayProgressBar.EnableAnimations();
 
-			return throwAwayProgressBar.ProgressTo(progress, (uint)(length * 1.1), easing);
+			return throwAwayProgressBar.ProgressTo(progress, (uint)(length * 1.5), easing);
 		}
 	}
 

--- a/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
@@ -1,0 +1,98 @@
+﻿using CommunityToolkit.Maui.Behaviors;
+using CommunityToolkit.Maui.UnitTests.Mocks;
+using FluentAssertions;
+using Xunit;
+
+namespace CommunityToolkit.Maui.UnitTests;
+
+public class ProgressBarAnimationBehavior_Tests
+{
+	public static readonly IReadOnlyList<object[]> ValidData = new[]
+	{
+		new object[] { 0.5, 1000, Easing.BounceIn },
+		new object[] { 1, 1500, Easing.Default },
+		new object[] { 0, 1250, Easing.CubicOut }
+	};
+
+	[Theory]
+	[MemberData(nameof(ValidData))]
+	public async Task ValidPropertiesTests(double progress, uint length, Easing easing)
+	{
+		var progressBar = new ProgressBar();
+		progressBar.EnableAnimations();
+
+		var progressBarAnimationBehavior = new ProgressBarAnimationBehavior();
+		progressBar.Behaviors.Add(progressBarAnimationBehavior);
+
+		Assert.Equal(0.0d, progressBar.Progress);
+		Assert.Equal(0.0d, ProgressBarAnimationBehavior.ProgressProperty.DefaultValue);
+		Assert.Equal((uint)500, ProgressBarAnimationBehavior.LengthProperty.DefaultValue);
+		Assert.Equal(Easing.Linear, ProgressBarAnimationBehavior.EasingProperty.DefaultValue);
+
+		progressBarAnimationBehavior.Length = length;
+		progressBarAnimationBehavior.Easing = easing;
+		progressBarAnimationBehavior.Progress = progress;
+
+		if (progressBar.Progress != progress)
+		{
+			Assert.True(progressBar.AnimationIsRunning(nameof(ProgressBar.ProgressTo)));
+			await Task.Delay(TimeSpan.FromMilliseconds(length));
+		}
+
+
+		Assert.False(progressBar.AnimationIsRunning(nameof(ProgressBar.ProgressTo)));
+
+		Assert.Equal(progress, progressBar.Progress);
+		Assert.Equal(progress, progressBarAnimationBehavior.Progress);
+		Assert.Equal(length, progressBarAnimationBehavior.Length);
+		Assert.Equal(easing, progressBarAnimationBehavior.Easing);
+	}
+
+	[Theory]
+	[InlineData(double.MinValue)]
+	[InlineData(-1)]
+	[InlineData(-0.0000000000001)]
+	[InlineData(1.0000000000001)]
+	[InlineData(double.MaxValue)]
+	public void InvalidProgressValuesTest(double progress)
+	{
+		var progressBarAnimationBehavior = new ProgressBarAnimationBehavior();
+
+		Assert.Throws<ArgumentOutOfRangeException>(() => progressBarAnimationBehavior.Progress = progress);
+	}
+
+	[Fact]
+	public void AttachedToInvalidElementTest()
+	{
+		IReadOnlyList<VisualElement> invalidVisualElements = new[]
+		{
+			new Button(),
+			new Frame(),
+			new Label(),
+			new VisualElement(),
+			new View(),
+			new Entry(),
+		};
+
+		foreach (var invalidVisualElement in invalidVisualElements)
+		{
+			Assert.Throws<InvalidOperationException>(() => invalidVisualElement.Behaviors.Add(new ProgressBarAnimationBehavior()));
+		}
+	}
+
+	[Fact]
+	public void AttachedToValidElementTest()
+	{
+		var progressBar = new ProgressBar();
+		var customProgressBar = new CustomProgressBar();
+
+		progressBar.Invoking(x => x.Behaviors.Add(new ProgressBarAnimationBehavior())).Should().NotThrow<InvalidOperationException>();
+		customProgressBar.Invoking(x => x.Behaviors.Add(new ProgressBarAnimationBehavior())).Should().NotThrow<InvalidOperationException>();
+	}
+
+	class CustomProgressBar : ProgressBar
+	{
+
+	}
+}
+

--- a/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
@@ -3,7 +3,7 @@ using CommunityToolkit.Maui.UnitTests.Mocks;
 using FluentAssertions;
 using Xunit;
 
-namespace CommunityToolkit.Maui.UnitTests;
+namespace CommunityToolkit.Maui.UnitTests.Behaviors;
 
 public class ProgressBarAnimationBehavior_Tests : BaseTest
 {
@@ -89,13 +89,25 @@ public class ProgressBarAnimationBehavior_Tests : BaseTest
 	}
 
 	[Fact]
-	public void AttachedToValidElementTest()
+	public void AttachedToRemovedFromValidElementTest()
 	{
 		var progressBar = new ProgressBar();
 		var customProgressBar = new CustomProgressBar();
 
-		progressBar.Invoking(x => x.Behaviors.Add(new ProgressBarAnimationBehavior())).Should().NotThrow<InvalidOperationException>();
-		customProgressBar.Invoking(x => x.Behaviors.Add(new ProgressBarAnimationBehavior())).Should().NotThrow<InvalidOperationException>();
+		var progressBarAnimationBehavior_ProgressBar = new ProgressBarAnimationBehavior();
+		var progressBarAnimationBehavior_CustomProgressBar = new ProgressBarAnimationBehavior();
+
+		progressBar.Invoking(x => x.Behaviors.Add(progressBarAnimationBehavior_ProgressBar)).Should().NotThrow<InvalidOperationException>();
+		customProgressBar.Invoking(x => x.Behaviors.Add(progressBarAnimationBehavior_CustomProgressBar)).Should().NotThrow<InvalidOperationException>();
+
+		Assert.Single(progressBar.Behaviors.OfType<ProgressBarAnimationBehavior>());
+		Assert.Single(customProgressBar.Behaviors.OfType<ProgressBarAnimationBehavior>());
+
+		progressBar.Invoking(x => x.Behaviors.Remove(progressBarAnimationBehavior_ProgressBar)).Should().NotThrow<InvalidOperationException>();
+		customProgressBar.Invoking(x => x.Behaviors.Remove(progressBarAnimationBehavior_CustomProgressBar)).Should().NotThrow<InvalidOperationException>();
+
+		Assert.Empty(progressBar.Behaviors);
+		Assert.Empty(customProgressBar.Behaviors);
 	}
 
 	class CustomProgressBar : ProgressBar

--- a/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
@@ -33,13 +33,21 @@ public class ProgressBarAnimationBehavior_Tests : BaseTest
 		progressBarAnimationBehavior.Easing = easing;
 		progressBarAnimationBehavior.Progress = progress;
 
-		// Wait for ProgressTo animation to complete
-		await Task.Delay(TimeSpan.FromMilliseconds(length * 2));
+		await ensureProgressToAnimationCompleted(progress, length, easing);
 
 		Assert.Equal(progress, progressBar.Progress);
 		Assert.Equal(progress, progressBarAnimationBehavior.Progress);
 		Assert.Equal(length, progressBarAnimationBehavior.Length);
 		Assert.Equal(easing, progressBarAnimationBehavior.Easing);
+
+		static Task ensureProgressToAnimationCompleted(double progress, uint length, Easing easing)
+		{
+			// Use a throw-away ProgressBar as a timer to wait for ProgressTo animation to complete
+			var throwAwayProgressBar = new ProgressBar();
+			throwAwayProgressBar.EnableAnimations();
+
+			return throwAwayProgressBar.ProgressTo(progress, length, easing);
+		}
 	}
 
 	[Theory]

--- a/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
@@ -9,7 +9,7 @@ public class ProgressBarAnimationBehavior_Tests : BaseTest
 {
 	public static readonly IReadOnlyList<object[]> ValidData = new[]
 	{
-		new object[] { 0.5, 50, Easing.BounceIn },
+		new object[] { 0.5, 175, Easing.BounceIn },
 		new object[] { 1, 1500, Easing.Default },
 		new object[] { 0, 750, Easing.CubicOut }
 	};
@@ -54,16 +54,19 @@ public class ProgressBarAnimationBehavior_Tests : BaseTest
 	}
 
 	[Theory]
-	[InlineData(double.MinValue)]
-	[InlineData(-1)]
-	[InlineData(-0.0000000000001)]
-	[InlineData(1.0000000000001)]
-	[InlineData(double.MaxValue)]
-	public void InvalidProgressValuesTest(double progress)
+	[InlineData(double.MinValue, 0)]
+	[InlineData(-1, 0)]
+	[InlineData(-0.0000000000001, 0)]
+	[InlineData(1.0000000000001, 1)]
+	[InlineData(double.MaxValue, 1)]
+	public void InvalidProgressValuesTest(double inputProgressValue, double expectedProgressValue)
 	{
-		var progressBarAnimationBehavior = new ProgressBarAnimationBehavior();
+		var progressBarAnimationBehavior = new ProgressBarAnimationBehavior
+		{
+			Progress = inputProgressValue
+		};
 
-		Assert.Throws<ArgumentOutOfRangeException>(() => progressBarAnimationBehavior.Progress = progress);
+		Assert.Equal(expectedProgressValue, progressBarAnimationBehavior.Progress);
 	}
 
 	[Fact]

--- a/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
@@ -11,7 +11,7 @@ public class ProgressBarAnimationBehavior_Tests : BaseTest
 	{
 		new object[] { 0.5, 50, Easing.BounceIn },
 		new object[] { 1, 1500, Easing.Default },
-		new object[] { 0, 250, Easing.CubicOut }
+		new object[] { 0, 750, Easing.CubicOut }
 	};
 
 	[Theory]
@@ -21,7 +21,6 @@ public class ProgressBarAnimationBehavior_Tests : BaseTest
 		var progressBar = new ProgressBar();
 		progressBar.EnableAnimations();
 
-		var didAnimationComplete = false;
 		var progressBarAnimationCompletedTCS = new TaskCompletionSource();
 
 		var progressBarAnimationBehavior = new ProgressBarAnimationBehavior();
@@ -37,9 +36,11 @@ public class ProgressBarAnimationBehavior_Tests : BaseTest
 		progressBarAnimationBehavior.Easing = easing;
 		progressBarAnimationBehavior.Progress = progress;
 
-		await progressBarAnimationCompletedTCS.Task.ConfigureAwait(false);
+		if (progressBar.Progress != progress)
+		{
+			await progressBarAnimationCompletedTCS.Task;
+		}
 
-		Assert.True(didAnimationComplete);
 		Assert.Equal(progress, progressBar.Progress);
 		Assert.Equal(progress, progressBarAnimationBehavior.Progress);
 		Assert.Equal(length, progressBarAnimationBehavior.Length);
@@ -48,7 +49,6 @@ public class ProgressBarAnimationBehavior_Tests : BaseTest
 		void HandleAnimationComplted(object? sender, EventArgs e)
 		{
 			ArgumentNullException.ThrowIfNull(sender);
-			didAnimationComplete = true;
 			progressBarAnimationCompletedTCS.SetResult();
 		}
 	}

--- a/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
@@ -34,7 +34,7 @@ public class ProgressBarAnimationBehavior_Tests : BaseTest
 		progressBarAnimationBehavior.Progress = progress;
 
 		// Wait for ProgressTo animation to complete
-		await Task.Delay(TimeSpan.FromMilliseconds(length * 1.1));
+		await Task.Delay(TimeSpan.FromMilliseconds(length * 1.25));
 
 		Assert.Equal(progress, progressBar.Progress);
 		Assert.Equal(progress, progressBarAnimationBehavior.Progress);

--- a/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
@@ -5,13 +5,13 @@ using Xunit;
 
 namespace CommunityToolkit.Maui.UnitTests;
 
-public class ProgressBarAnimationBehavior_Tests
+public class ProgressBarAnimationBehavior_Tests : BaseTest
 {
 	public static readonly IReadOnlyList<object[]> ValidData = new[]
 	{
-		new object[] { 0.5, 1000, Easing.BounceIn },
+		new object[] { 0.5, 50, Easing.BounceIn },
 		new object[] { 1, 1500, Easing.Default },
-		new object[] { 0, 1250, Easing.CubicOut }
+		new object[] { 0, 250, Easing.CubicOut }
 	};
 
 	[Theory]
@@ -33,14 +33,8 @@ public class ProgressBarAnimationBehavior_Tests
 		progressBarAnimationBehavior.Easing = easing;
 		progressBarAnimationBehavior.Progress = progress;
 
-		if (progressBar.Progress != progress)
-		{
-			Assert.True(progressBar.AnimationIsRunning(nameof(ProgressBar.ProgressTo)));
-			await Task.Delay(TimeSpan.FromMilliseconds(length));
-		}
-
-
-		Assert.False(progressBar.AnimationIsRunning(nameof(ProgressBar.ProgressTo)));
+		// Wait for ProgressTo animation to complete
+		await Task.Delay(TimeSpan.FromMilliseconds(length * 1.1));
 
 		Assert.Equal(progress, progressBar.Progress);
 		Assert.Equal(progress, progressBarAnimationBehavior.Progress);

--- a/src/CommunityToolkit.Maui/Behaviors/BaseBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/BaseBehavior.shared.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
@@ -12,7 +11,7 @@ namespace CommunityToolkit.Maui.Behaviors;
 public abstract class BaseBehavior<TView> : Behavior<TView> where TView : VisualElement
 {
 	static readonly MethodInfo? getContextMethod
-		= typeof(BindableObject).GetRuntimeMethods()?.FirstOrDefault(m => m.Name == "GetContext");
+		= typeof(BindableObject).GetRuntimeMethods()?.FirstOrDefault(m => m.Name is "GetContext");
 
 	static readonly FieldInfo? bindingField
 		= getContextMethod?.ReturnType.GetRuntimeField("Binding");

--- a/src/CommunityToolkit.Maui/Behaviors/ProgressBarAnimationBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/ProgressBarAnimationBehavior.shared.cs
@@ -37,7 +37,7 @@ public class ProgressBarAnimationBehavior : BaseBehavior<ProgressBar>
 	}
 
 	/// <summary>
-	/// Progress, 0-1.0
+	/// Value of <see cref="ProgressBar.Progress"/>, can have a minimum value of 0 and a maximum value of 1
 	/// </summary>
 	public double Progress
 	{

--- a/src/CommunityToolkit.Maui/Behaviors/ProgressBarAnimationBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/ProgressBarAnimationBehavior.shared.cs
@@ -7,6 +7,8 @@ namespace CommunityToolkit.Maui.Behaviors;
 /// /// </summary>
 public class ProgressBarAnimationBehavior : BaseBehavior<ProgressBar>
 {
+	readonly WeakEventManager animationCompletedEventManager = new();
+
 	/// <summary>
 	/// Backing BindableProperty for the <see cref="Progress"/> property.
 	/// </summary>
@@ -24,6 +26,15 @@ public class ProgressBarAnimationBehavior : BaseBehavior<ProgressBar>
 	/// </summary>
 	public static readonly BindableProperty EasingProperty =
 		BindableProperty.CreateAttached(nameof(Easing), typeof(Easing), typeof(ProgressBarAnimationBehavior), Easing.Linear);
+
+	/// <summary>
+	/// Event that is triggered when the ProgressBar.ProgressTo() animation completes
+	/// </summary>
+	public event EventHandler AnimationCompleted
+	{
+		add => animationCompletedEventManager.AddEventHandler(value);
+		remove => animationCompletedEventManager.RemoveEventHandler(value);
+	}
 
 	/// <summary>
 	/// Progress, 0-1.0
@@ -70,6 +81,8 @@ public class ProgressBarAnimationBehavior : BaseBehavior<ProgressBar>
 									progressBarAnimationBehavior.Progress,
 									progressBarAnimationBehavior.Length,
 									progressBarAnimationBehavior.Easing);
+
+			progressBarAnimationBehavior.OnAnimationCompleted();
 		}
 	}
 
@@ -78,4 +91,6 @@ public class ProgressBarAnimationBehavior : BaseBehavior<ProgressBar>
 		token.ThrowIfCancellationRequested();
 		return progressBar.ProgressTo(progress, animationLength, animationEasing);
 	}
+
+	void OnAnimationCompleted() => animationCompletedEventManager.HandleEvent(this, EventArgs.Empty, nameof(AnimationCompleted));
 }

--- a/src/CommunityToolkit.Maui/Behaviors/ProgressBarAnimationBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/ProgressBarAnimationBehavior.shared.cs
@@ -37,20 +37,12 @@ public class ProgressBarAnimationBehavior : BaseBehavior<ProgressBar>
 	}
 
 	/// <summary>
-	/// Value of <see cref="ProgressBar.Progress"/>, can have a minimum value of 0 and a maximum value of 1
+	/// Value of <see cref="ProgressBar.Progress"/>, clamped to a minimum value of 0 and a maximum value of 1
 	/// </summary>
 	public double Progress
 	{
 		get => (double)GetValue(ProgressProperty);
-		set
-		{
-			if (value < 0 || value > 1)
-			{
-				throw new ArgumentOutOfRangeException(nameof(Progress), $"{nameof(Progress)} can have a minimum value of 0 and a maximum value of 1");
-			}
-
-			SetValue(ProgressProperty, value);
-		}
+		set => SetValue(ProgressProperty, Math.Clamp(value, 0, 1));
 	}
 
 	/// <summary>

--- a/src/CommunityToolkit.Maui/Behaviors/ProgressBarAnimationBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/ProgressBarAnimationBehavior.shared.cs
@@ -8,28 +8,74 @@ namespace CommunityToolkit.Maui.Behaviors;
 public class ProgressBarAnimationBehavior : BaseBehavior<ProgressBar>
 {
 	/// <summary>
-	/// Backing BindableProperty for the <see cref="AnimateProgress"/> property.
+	/// Backing BindableProperty for the <see cref="Progress"/> property.
 	/// </summary>
-	public static readonly BindableProperty AnimateProgressProperty =
-		BindableProperty.CreateAttached(nameof(AnimateProgress), typeof(double), typeof(ProgressBar), 0.0d, propertyChanged: OnAnimateProgressPropertyChanged);
+	public static readonly BindableProperty ProgressProperty =
+		BindableProperty.CreateAttached(nameof(Progress), typeof(double), typeof(ProgressBarAnimationBehavior), 0.0d, propertyChanged: OnAnimateProgressPropertyChanged);
 
 	/// <summary>
-	/// Animation Progress, 0-1.0
+	/// BindableProperty for the <see cref="Length"/> property
 	/// </summary>
-	public double AnimateProgress
+	public static readonly BindableProperty LengthProperty =
+		BindableProperty.CreateAttached(nameof(Length), typeof(uint), typeof(ProgressBarAnimationBehavior), (uint)500);
+
+	/// <summary>
+	/// BindableProperty for the <see cref="Easing"/> property
+	/// </summary>
+	public static readonly BindableProperty EasingProperty =
+		BindableProperty.CreateAttached(nameof(Easing), typeof(Easing), typeof(ProgressBarAnimationBehavior), Easing.Linear);
+
+	/// <summary>
+	/// Progress, 0-1.0
+	/// </summary>
+	public double Progress
 	{
-		get => (double)GetValue(AnimateProgressProperty);
-		set => SetValue(AnimateProgressProperty, value);
+		get => (double)GetValue(ProgressProperty);
+		set
+		{
+			if (value < 0 || value > 1)
+			{
+				throw new ArgumentOutOfRangeException(nameof(Progress), $"{nameof(Progress)} can have a minimum value of 0 and a maximum value of 1");
+			}
+
+			SetValue(ProgressProperty, value);
+		}
+	}
+
+	/// <summary>
+	/// Length in milliseconds of the progress bar animation
+	/// </summary>
+	public uint Length
+	{
+		get => (uint)GetValue(LengthProperty);
+		set => SetValue(LengthProperty, value);
+	}
+
+	/// <summary>
+	/// Easing of the progress bar animation
+	/// </summary>
+	public Easing Easing
+	{
+		get => (Easing)GetValue(EasingProperty);
+		set => SetValue(EasingProperty, value);
 	}
 
 	static async void OnAnimateProgressPropertyChanged(BindableObject bindable, object oldValue, object newValue)
-		=> await ((ProgressBarAnimationBehavior)bindable).Animate();
-
-	async Task Animate()
 	{
-		if (View != null)
+		var progressBarAnimationBehavior = (ProgressBarAnimationBehavior)bindable;
+
+		if (progressBarAnimationBehavior.View is not null)
 		{
-			await View.ProgressTo(AnimateProgress, 500, Easing.Linear);
+			await AnimateProgress(progressBarAnimationBehavior.View,
+									progressBarAnimationBehavior.Progress,
+									progressBarAnimationBehavior.Length,
+									progressBarAnimationBehavior.Easing);
 		}
+	}
+
+	static Task AnimateProgress(in ProgressBar progressBar, in double progress, in uint animationLength, in Easing animationEasing, in CancellationToken token = default)
+	{
+		token.ThrowIfCancellationRequested();
+		return progressBar.ProgressTo(progress, animationLength, animationEasing);
 	}
 }


### PR DESCRIPTION
 ### Description of Change ###

This PR adds Unit Tests for `ProgressBarAnimationBehavior`

 ### Linked Issues ###

 - Fixes #48 

 ### PR Checklist ###
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)

 ### Additional information ###

I've also included a few changes to `ProgressAnimationBehavior`:
- Rename `ProgressBarAnimationBehavior.AnimateProgress` to `ProgressBarAnimationBehavior.Progress` 
  - This property mirrors and directly changes `ProgressBar.Progress`
  - This naming change should improve discoverability for devs familiar with `ProgressBar.Progress` who are seeking to bind to `ProgressBarAnimationBehavior.ProgressProperty`
- Added the bindable property `ProgressBarAnimationBehavior.Easing` 
  - This new property allows users to change the `Easing easing` of the `ProgressTo` animation
- Added the bindable property `ProgressBarAnimationBehavior.Length` 
  -  This new property allow users to change the `uint length` of the `ProgressTo` animation
- Added the event `ProgressBarAnimationBehavior.AnimationCompleted`
  - This new event is triggered when the `ProgressTo` animation is completed
  - This event is required by the Unit Tests in order to ensure the `ProgressTo` animation has completed before `Assert`'ing the results