### PR TITLE
♻ Removed Maui.Controls namespace from Core project

### DIFF
--- a/src/CommunityToolkit.Maui.Core/CommunityToolkit.Maui.Core.csproj
+++ b/src/CommunityToolkit.Maui.Core/CommunityToolkit.Maui.Core.csproj
@@ -80,6 +80,7 @@
   <ItemGroup>
     <None Include="..\..\build\nuget.png" PackagePath="icon.png" Pack="true" />
     <None Include="ReadMe.txt" pack="true" PackagePath="." />
+    <Using Remove="Microsoft.Maui.Controls"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This is a simple fix, to remove the `Microsoft.Maui.Controls` from the `ImplicitUsing` on `CommunityToolkit.Maui.Core`.
This will help us guarantee that we will not have that reference on core, helping development process and code-review.