### PR TITLE
Add `ColorTo*` Unit Tests

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Extensions/ColorConversionExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Extensions/ColorConversionExtensions.shared.cs
@@ -10,7 +10,7 @@ public static class ColorConversionExtensions
 	/// </summary>
 	/// <param name="c"></param>
 	/// <returns>RGB(255,255,255)</returns>
-	public static string ToRgbString(this Color c) => 
+	public static string ToRgbString(this Color c) =>
 		$"RGB({c.GetByteRed()},{c.GetByteGreen()},{c.GetByteBlue()})";
 
 	/// <summary>
@@ -19,7 +19,7 @@ public static class ColorConversionExtensions
 	/// <param name="c"></param>
 	/// <returns>RGBA(255,255,255,1)</returns>
 	public static string ToRgbaString(this Color c) =>
-        $"RGBA({c.GetByteRed()},{c.GetByteGreen()},{c.GetByteBlue()},{c.Alpha})";
+		$"RGBA({c.GetByteRed()},{c.GetByteGreen()},{c.GetByteBlue()},{c.Alpha})";
 
 	/// <summary>
 	/// Converts Color to Hex RGB
@@ -51,7 +51,7 @@ public static class ColorConversionExtensions
 	/// <param name="c"></param>
 	/// <returns>CMYK(100%,100%,100%,100%)</returns>
 	public static string ToCmykString(this Color c) =>
-        $"CMYK({c.GetPercentCyan():P0},{c.GetPercentMagenta():P0},{c.GetPercentYellow():P0},{c.GetPercentBlackKey():P0})";
+		$"CMYK({c.GetPercentCyan():P0},{c.GetPercentMagenta():P0},{c.GetPercentYellow():P0},{c.GetPercentBlackKey():P0})";
 
 	/// <summary>
 	/// Converts Color to CMYKA
@@ -59,7 +59,7 @@ public static class ColorConversionExtensions
 	/// <param name="c"></param>
 	/// <returns>CMYKA(100%,100%,100%,100%,1)</returns>
 	public static string ToCmykaString(this Color c) =>
-        $"CMYKA({c.GetPercentCyan():P0},{c.GetPercentMagenta():P0},{c.GetPercentYellow():P0},{c.GetPercentBlackKey():P0},{c.Alpha})";
+		$"CMYKA({c.GetPercentCyan():P0},{c.GetPercentMagenta():P0},{c.GetPercentYellow():P0},{c.GetPercentBlackKey():P0},{c.Alpha})";
 
 	/// <summary>
 	/// Converts Color to HSL
@@ -74,7 +74,7 @@ public static class ColorConversionExtensions
 	/// <param name="c"></param>
 	///  <returns>HSLA(360,100%,100%,1)</returns>
 	public static string ToHslaString(this Color c) =>
-        $"HSLA({c.GetDegreeHue():0},{c.GetSaturation():P0},{c.GetLuminosity():P0},{c.Alpha})";
+		$"HSLA({c.GetDegreeHue():0},{c.GetSaturation():P0},{c.GetLuminosity():P0},{c.Alpha})";
 
 	/// <summary>
 	/// Sets Red
@@ -83,10 +83,10 @@ public static class ColorConversionExtensions
 	/// <param name="newR"></param>
 	/// <returns>Color with updated Red</returns>
 	public static Color WithRed(this Color baseColor, double newR) =>
-		newR < 0 || newR > 1 
-			? throw new ArgumentOutOfRangeException(nameof(newR)) 
-			: Color.FromRgba(newR, baseColor.Green, baseColor.Blue, baseColor.Alpha); 
-		
+		newR < 0 || newR > 1
+			? throw new ArgumentOutOfRangeException(nameof(newR))
+			: Color.FromRgba(newR, baseColor.Green, baseColor.Blue, baseColor.Alpha);
+
 
 	/// <summary>
 	/// Sets Green
@@ -245,7 +245,7 @@ public static class ColorConversionExtensions
 	/// <param name="c"></param>
 	/// <returns>Percentage Cyan</returns>
 	public static float GetPercentCyan(this Color c) =>
-		(1- c.GetPercentBlackKey() == 0) ? 0 : 
+		(1 - c.GetPercentBlackKey() == 0) ? 0 :
 		(1 - c.Red - c.GetPercentBlackKey()) / (1 - c.GetPercentBlackKey());
 
 	/// <summary>
@@ -253,7 +253,7 @@ public static class ColorConversionExtensions
 	/// </summary>
 	/// <param name="c"></param>
 	/// <returns>Percentage Magenta</returns>
-    public static float GetPercentMagenta(this Color c) =>
+	public static float GetPercentMagenta(this Color c) =>
 		(1 - c.GetPercentBlackKey() == 0) ? 0 :
 		(1 - c.Green - c.GetPercentBlackKey()) / (1 - c.GetPercentBlackKey());
 
@@ -262,7 +262,7 @@ public static class ColorConversionExtensions
 	/// </summary>
 	/// <param name="c"></param>
 	/// <returns>Percentage Yellow</returns>
-    public static float GetPercentYellow(this Color c) =>
+	public static float GetPercentYellow(this Color c) =>
 		(1 - c.GetPercentBlackKey() == 0) ? 0 :
 		(1 - c.Blue - c.GetPercentBlackKey()) / (1 - c.GetPercentBlackKey());
 
@@ -315,18 +315,5 @@ public static class ColorConversionExtensions
 	/// <returns>Is Color Dark</returns>
 	public static bool IsDark(this Color c) => c.GetByteRed() + c.GetByteGreen() + c.GetByteBlue() <= 127 * 3;
 
-	static byte ToByte(double input)
-	{
-		if (input < 0)
-		{
-			return 0;
-		}
-
-		if (input > 255)
-		{
-			return 255;
-		}
-
-		return (byte)Math.Round(input);
-	}
+	static byte ToByte(double input) => (byte)Math.Round(Math.Clamp(input, 0, 255));
 }

--- a/src/CommunityToolkit.Maui.Core/Extensions/ColorConversionExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Extensions/ColorConversionExtensions.shared.cs
@@ -8,312 +8,441 @@ public static class ColorConversionExtensions
 	/// <summary>
 	/// Converts Color to RGB
 	/// </summary>
-	/// <param name="c"></param>
+	/// <param name="color"></param>
 	/// <returns>RGB(255,255,255)</returns>
-	public static string ToRgbString(this Color c) =>
-		$"RGB({c.GetByteRed()},{c.GetByteGreen()},{c.GetByteBlue()})";
+	public static string ToRgbString(this Color color)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+		return $"RGB({color.GetByteRed()},{color.GetByteGreen()},{color.GetByteBlue()})";
+	}
 
 	/// <summary>
 	/// Converts Color to RGBA
 	/// </summary>
-	/// <param name="c"></param>
+	/// <param name="color"></param>
 	/// <returns>RGBA(255,255,255,1)</returns>
-	public static string ToRgbaString(this Color c) =>
-		$"RGBA({c.GetByteRed()},{c.GetByteGreen()},{c.GetByteBlue()},{c.Alpha})";
+	public static string ToRgbaString(this Color color)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+		return $"RGBA({color.GetByteRed()},{color.GetByteGreen()},{color.GetByteBlue()},{color.Alpha})";
+	}
 
 	/// <summary>
 	/// Converts Color to Hex RGB
 	/// </summary>
-	/// <param name="c"></param>
+	/// <param name="color"></param>
 	/// <returns>#FFFFFF</returns>
-	public static string ToHexRgbString(this Color c) =>
-		$"#{c.GetByteRed():X2}{c.GetByteGreen():X2}{c.GetByteBlue():X2}";
+	public static string ToHexRgbString(this Color color)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+		return $"#{color.GetByteRed():X2}{color.GetByteGreen():X2}{color.GetByteBlue():X2}";
+	}
 
 	/// <summary>
 	/// Converts Color to Hex RGBA
 	/// </summary>
-	/// <param name="c"></param>
+	/// <param name="color"></param>
 	/// <returns>#FFFFFFFF</returns>
-	public static string ToHexRgbaString(this Color c) =>
-		$"#{c.GetByteRed():X2}{c.GetByteGreen():X2}{c.GetByteBlue():X2}{c.GetByteAlpha():X2}";
+	public static string ToHexRgbaString(this Color color)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+		return $"#{color.GetByteRed():X2}{color.GetByteGreen():X2}{color.GetByteBlue():X2}{color.GetByteAlpha():X2}";
+	}
 
 	/// <summary>
 	/// Converts Color to Hex ARGB
 	/// </summary>
-	/// <param name="c"></param>
+	/// <param name="color"></param>
 	/// <returns>#FFFFFFFF</returns>
-	public static string ToHexArgbString(this Color c) =>
-		$"#{c.GetByteAlpha():X2}{c.GetByteRed():X2}{c.GetByteGreen():X2}{c.GetByteBlue():X2}";
+	public static string ToHexArgbString(this Color color)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+		return $"#{color.GetByteAlpha():X2}{color.GetByteRed():X2}{color.GetByteGreen():X2}{color.GetByteBlue():X2}";
+	}
 
 	/// <summary>
 	/// Converts Color to CMYK
 	/// </summary>
-	/// <param name="c"></param>
+	/// <param name="color"></param>
 	/// <returns>CMYK(100%,100%,100%,100%)</returns>
-	public static string ToCmykString(this Color c) =>
-		$"CMYK({c.GetPercentCyan():P0},{c.GetPercentMagenta():P0},{c.GetPercentYellow():P0},{c.GetPercentBlackKey():P0})";
+	public static string ToCmykString(this Color color)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+		return $"CMYK({color.GetPercentCyan():P0},{color.GetPercentMagenta():P0},{color.GetPercentYellow():P0},{color.GetPercentBlackKey():P0})";
+	}
 
 	/// <summary>
 	/// Converts Color to CMYKA
 	/// </summary>
-	/// <param name="c"></param>
+	/// <param name="color"></param>
 	/// <returns>CMYKA(100%,100%,100%,100%,1)</returns>
-	public static string ToCmykaString(this Color c) =>
-		$"CMYKA({c.GetPercentCyan():P0},{c.GetPercentMagenta():P0},{c.GetPercentYellow():P0},{c.GetPercentBlackKey():P0},{c.Alpha})";
+	public static string ToCmykaString(this Color color)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+		return $"CMYKA({color.GetPercentCyan():P0},{color.GetPercentMagenta():P0},{color.GetPercentYellow():P0},{color.GetPercentBlackKey():P0},{color.Alpha})";
+	}
 
 	/// <summary>
 	/// Converts Color to HSL
 	/// </summary>
-	/// <param name="c"></param>
+	/// <param name="color"></param>
 	/// <returns>HSLA(360,100%,100%)</returns>
-	public static string ToHslString(this Color c) => $"HSL({c.GetDegreeHue():0},{c.GetSaturation():P0},{c.GetLuminosity():P0})";
+	public static string ToHslString(this Color color)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+		return $"HSL({color.GetDegreeHue():0},{color.GetSaturation():P0},{color.GetLuminosity():P0})";
+	}
 
 	/// <summary>
 	/// Converts Color to HSLA
 	/// </summary>
-	/// <param name="c"></param>
+	/// <param name="color"></param>
 	///  <returns>HSLA(360,100%,100%,1)</returns>
-	public static string ToHslaString(this Color c) =>
-		$"HSLA({c.GetDegreeHue():0},{c.GetSaturation():P0},{c.GetLuminosity():P0},{c.Alpha})";
+	public static string ToHslaString(this Color color)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+		return $"HSLA({color.GetDegreeHue():0},{color.GetSaturation():P0},{color.GetLuminosity():P0},{color.Alpha})";
+	}
 
 	/// <summary>
 	/// Sets Red
 	/// </summary>
-	/// <param name="baseColor"></param>
+	/// <param name="color"></param>
 	/// <param name="newR"></param>
 	/// <returns>Color with updated Red</returns>
-	public static Color WithRed(this Color baseColor, double newR) =>
-		newR < 0 || newR > 1
-			? throw new ArgumentOutOfRangeException(nameof(newR))
-			: Color.FromRgba(newR, baseColor.Green, baseColor.Blue, baseColor.Alpha);
+	public static Color WithRed(this Color color, double newR)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+
+		return newR < 0 || newR > 1
+				? throw new ArgumentOutOfRangeException(nameof(newR))
+				: Color.FromRgba(newR, color.Green, color.Blue, color.Alpha);
+	}
 
 
 	/// <summary>
 	/// Sets Green
 	/// </summary>
-	/// <param name="baseColor"></param>
+	/// <param name="color"></param>
 	/// <param name="newG"></param>
 	/// <returns>Color with updated Green</returns>
-	public static Color WithGreen(this Color baseColor, double newG) =>
-		newG < 0 || newG > 1
-			? throw new ArgumentOutOfRangeException(nameof(newG))
-			: Color.FromRgba(baseColor.Red, newG, baseColor.Blue, baseColor.Alpha);
+	public static Color WithGreen(this Color color, double newG)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+		return newG < 0 || newG > 1
+				? throw new ArgumentOutOfRangeException(nameof(newG))
+				: Color.FromRgba(color.Red, newG, color.Blue, color.Alpha);
+	}
 
 	/// <summary>
 	/// Sets Blue
 	/// </summary>
-	/// <param name="baseColor"></param>
+	/// <param name="color"></param>
 	/// <param name="newB"></param>
 	/// <returns>Color with updated Blue</returns>
-	public static Color WithBlue(this Color baseColor, double newB) =>
-		newB < 0 || newB > 1
-			? throw new ArgumentOutOfRangeException(nameof(newB))
-			: Color.FromRgba(baseColor.Red, baseColor.Green, newB, baseColor.Alpha);
+	public static Color WithBlue(this Color color, double newB)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+
+		return newB < 0 || newB > 1
+				? throw new ArgumentOutOfRangeException(nameof(newB))
+				: Color.FromRgba(color.Red, color.Green, newB, color.Alpha);
+	}
 
 	/// <summary>
 	/// Sets Red
 	/// </summary>
-	/// <param name="baseColor"></param>
+	/// <param name="color"></param>
 	/// <param name="newR"></param>
 	/// <returns>Color with updated red</returns>
-	public static Color WithRed(this Color baseColor, byte newR) =>
-		Color.FromRgba((double)newR / 255, baseColor.Green, baseColor.Blue, baseColor.Alpha);
+	public static Color WithRed(this Color color, byte newR)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+
+		return Color.FromRgba((double)newR / 255, color.Green, color.Blue, color.Alpha);
+	}
 
 	/// <summary>
 	/// Sets Green
 	/// </summary>
-	/// <param name="baseColor"></param>
+	/// <param name="color"></param>
 	/// <param name="newG"></param>
 	/// <returns>Color with updated Green</returns>
-	public static Color WithGreen(this Color baseColor, byte newG) =>
-		Color.FromRgba(baseColor.Red, (double)newG / 255, baseColor.Blue, baseColor.Alpha);
+	public static Color WithGreen(this Color color, byte newG)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+
+		return Color.FromRgba(color.Red, (double)newG / 255, color.Blue, color.Alpha);
+	}
 
 	/// <summary>
 	/// Sets Blue
 	/// </summary>
-	/// <param name="baseColor"></param>
+	/// <param name="color"></param>
 	/// <param name="newB"></param>
 	/// <returns>Color with updated Blue</returns>
-	public static Color WithBlue(this Color baseColor, byte newB) =>
-		Color.FromRgba(baseColor.Red, baseColor.Green, (double)newB / 255, baseColor.Alpha);
+	public static Color WithBlue(this Color color, byte newB)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+
+		return Color.FromRgba(color.Red, color.Green, (double)newB / 255, color.Alpha);
+	}
+
 
 	/// <summary>
 	/// Sets Alpha
 	/// </summary>
-	/// <param name="baseColor"></param>
+	/// <param name="color"></param>
 	/// <param name="newA"></param>
 	/// <returns>Color with updated alpha</returns>
-	public static Color WithAlpha(this Color baseColor, byte newA) =>
-		Color.FromRgba(baseColor.Red, baseColor.Green, baseColor.Blue, (double)newA / 255);
+	public static Color WithAlpha(this Color color, byte newA)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+
+		return Color.FromRgba(color.Red, color.Green, color.Blue, (double)newA / 255);
+	}
 
 	/// <summary>
 	/// Sets Cyan CMYK 
 	/// </summary>
-	/// <param name="baseColor"></param>
+	/// <param name="color"></param>
 	/// <param name="newC"></param>
 	/// <returns>Color with additional cyan</returns>
-	public static Color WithCyan(this Color baseColor, double newC) =>
-		Color.FromRgba((1 - newC) * (1 - baseColor.GetPercentBlackKey()),
-					   (1 - baseColor.GetPercentMagenta()) * (1 - baseColor.GetPercentBlackKey()),
-					   (1 - baseColor.GetPercentYellow()) * (1 - baseColor.GetPercentBlackKey()),
-					   baseColor.Alpha);
+	public static Color WithCyan(this Color color, double newC)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+
+		return Color.FromRgba((1 - newC) * (1 - color.GetPercentBlackKey()),
+								(1 - color.GetPercentMagenta()) * (1 - color.GetPercentBlackKey()),
+								(1 - color.GetPercentYellow()) * (1 - color.GetPercentBlackKey()),
+								color.Alpha);
+	}
 
 	/// <summary>
 	/// Sets Magenta CMYK Value
 	/// </summary>
-	/// <param name="baseColor"></param>
+	/// <param name="color"></param>
 	/// <param name="newM"></param>
 	/// <returns>Color with Magenta value</returns>
-	public static Color WithMagenta(this Color baseColor, double newM) =>
-		Color.FromRgba((1 - baseColor.GetPercentCyan()) * (1 - baseColor.GetPercentBlackKey()),
-					   (1 - newM) * (1 - baseColor.GetPercentBlackKey()),
-					   (1 - baseColor.GetPercentYellow()) * (1 - baseColor.GetPercentBlackKey()),
-					   baseColor.Alpha);
+	public static Color WithMagenta(this Color color, double newM)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+
+		return Color.FromRgba((1 - color.GetPercentCyan()) * (1 - color.GetPercentBlackKey()),
+								(1 - newM) * (1 - color.GetPercentBlackKey()),
+								(1 - color.GetPercentYellow()) * (1 - color.GetPercentBlackKey()),
+								color.Alpha);
+	}
 
 	/// <summary>
 	/// Sets Yellow CMYK value
 	/// </summary>
-	/// <param name="baseColor"></param>
+	/// <param name="color"></param>
 	/// <param name="newY"></param>
 	/// <returns>Color with Yellow value</returns>
-	public static Color WithYellow(this Color baseColor, double newY) =>
-		Color.FromRgba((1 - baseColor.GetPercentCyan()) * (1 - baseColor.GetPercentBlackKey()),
-					   (1 - baseColor.GetPercentMagenta()) * (1 - baseColor.GetPercentBlackKey()),
-					   (1 - newY) * (1 - baseColor.GetPercentBlackKey()),
-					   baseColor.Alpha);
+	public static Color WithYellow(this Color color, double newY)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+
+		return Color.FromRgba((1 - color.GetPercentCyan()) * (1 - color.GetPercentBlackKey()),
+								(1 - color.GetPercentMagenta()) * (1 - color.GetPercentBlackKey()),
+								(1 - newY) * (1 - color.GetPercentBlackKey()),
+								color.Alpha);
+	}
 
 	/// <summary>
 	/// Sets Black CMYK Key
 	/// </summary>
-	/// <param name="baseColor"></param>
+	/// <param name="color"></param>
 	/// <param name="newK"></param>
 	/// <returns>Color with Black Key</returns>
-	public static Color WithBlackKey(this Color baseColor, double newK) =>
-		Color.FromRgba((1 - baseColor.GetPercentCyan()) * (1 - newK),
-					   (1 - baseColor.GetPercentMagenta()) * (1 - newK),
-					   (1 - baseColor.GetPercentYellow()) * (1 - newK),
-					   baseColor.Alpha);
+	public static Color WithBlackKey(this Color color, double newK)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+
+		return Color.FromRgba((1 - color.GetPercentCyan()) * (1 - newK),
+								(1 - color.GetPercentMagenta()) * (1 - newK),
+								(1 - color.GetPercentYellow()) * (1 - newK),
+								color.Alpha);
+	}
 
 	/// <summary>
 	/// Gets Red
 	/// </summary>
-	/// <param name="c"></param>
+	/// <param name="color"></param>
 	/// <returns>Red</returns>
-	public static byte GetByteRed(this Color c) => ToByte(c.Red * 255);
+	public static byte GetByteRed(this Color color)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+		return ToByte(color.Red * 255);
+	}
 
 	/// <summary>
 	/// Gets Green
 	/// </summary>
-	/// <param name="c"></param>
+	/// <param name="color"></param>
 	/// <returns>Green</returns>
-	public static byte GetByteGreen(this Color c) => ToByte(c.Green * 255);
+	public static byte GetByteGreen(this Color color)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+		return ToByte(color.Green * 255);
+	}
 
 	/// <summary>
 	/// Gets Blue
 	/// </summary>
-	/// <param name="c"></param>
+	/// <param name="color"></param>
 	/// <returns>BLue</returns>
-	public static byte GetByteBlue(this Color c) => ToByte(c.Blue * 255);
+	public static byte GetByteBlue(this Color color)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+		return ToByte(color.Blue * 255);
+	}
 
 	/// <summary>
 	/// Gets Alpha
 	/// </summary>
-	/// <param name="c"></param>
+	/// <param name="color"></param>
 	/// <returns>Alpha</returns>
-	public static byte GetByteAlpha(this Color c) => ToByte(c.Alpha * 255);
+	public static byte GetByteAlpha(this Color color)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+		return ToByte(color.Alpha * 255);
+	}
 
 	/// <summary>
 	/// Gets Degree Hue
 	/// </summary>
-	/// <param name="c"></param>
+	/// <param name="color"></param>
 	/// <returns>Degree Hue</returns>
 	// Hue is a degree on the color wheel from 0 to 360. 0 is red, 120 is green, 240 is blue.
-	public static double GetDegreeHue(this Color c) => c.GetHue() * 360;
+	public static double GetDegreeHue(this Color color)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+		return color.GetHue() * 360;
+	}
 
 
 	/// <summary>
 	/// Get percentage Black for Color
 	/// </summary>
-	/// <param name="c"></param>
+	/// <param name="color"></param>
 	/// <returns>Percentage Black</returns>
 	// Note : double Percent R, G and B are simply Color.R, Color.G and Color.B
-	public static float GetPercentBlackKey(this Color c) => 1 - Math.Max(Math.Max(c.Red, c.Green), c.Blue);
+	public static float GetPercentBlackKey(this Color color)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+		return 1 - Math.Max(Math.Max(color.Red, color.Green), color.Blue);
+	}
 
 	/// <summary>
 	/// Gets percentage Cyan for Color
 	/// </summary>
-	/// <param name="c"></param>
+	/// <param name="color"></param>
 	/// <returns>Percentage Cyan</returns>
-	public static float GetPercentCyan(this Color c) =>
-		(1 - c.GetPercentBlackKey() == 0) ? 0 :
-		(1 - c.Red - c.GetPercentBlackKey()) / (1 - c.GetPercentBlackKey());
+	public static float GetPercentCyan(this Color color)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+
+		return (1 - color.GetPercentBlackKey() is 0)
+				? 0
+				: (1 - color.Red - color.GetPercentBlackKey()) / (1 - color.GetPercentBlackKey());
+	}
 
 	/// <summary>
 	/// Gets percentage Magenta for Color
 	/// </summary>
-	/// <param name="c"></param>
+	/// <param name="color"></param>
 	/// <returns>Percentage Magenta</returns>
-	public static float GetPercentMagenta(this Color c) =>
-		(1 - c.GetPercentBlackKey() == 0) ? 0 :
-		(1 - c.Green - c.GetPercentBlackKey()) / (1 - c.GetPercentBlackKey());
+	public static float GetPercentMagenta(this Color color)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+
+		return (1 - color.GetPercentBlackKey() is 0)
+				? 0
+				: (1 - color.Green - color.GetPercentBlackKey()) / (1 - color.GetPercentBlackKey());
+	}
 
 	/// <summary>
 	/// G
 	/// </summary>
-	/// <param name="c"></param>
+	/// <param name="color"></param>
 	/// <returns>Percentage Yellow</returns>
-	public static float GetPercentYellow(this Color c) =>
-		(1 - c.GetPercentBlackKey() == 0) ? 0 :
-		(1 - c.Blue - c.GetPercentBlackKey()) / (1 - c.GetPercentBlackKey());
+	public static float GetPercentYellow(this Color color)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+		return (1 - color.GetPercentBlackKey() is 0)
+				? 0
+				: (1 - color.Blue - color.GetPercentBlackKey()) / (1 - color.GetPercentBlackKey());
+	}
 
 	/// <summary>
 	/// Inverts the Color
 	/// </summary>
-	/// <param name="baseColor"></param>
+	/// <param name="color"></param>
 	/// <returns>Inverse Color</returns>
-	public static Color ToInverseColor(this Color baseColor) =>
-		Color.FromRgb(1 - baseColor.Red, 1 - baseColor.Green, 1 - baseColor.Blue);
+	public static Color ToInverseColor(this Color color)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+		return Color.FromRgb(1 - color.Red, 1 - color.Green, 1 - color.Blue);
+	}
 
 	/// <summary>
 	/// Converts dark colors to Colors.Black; coonverts light colors to Colors.White
 	/// </summary>
-	/// <param name="baseColor"></param>
+	/// <param name="color"></param>
 	/// <returns>Black or White Color</returns>
-	public static Color ToBlackOrWhite(this Color baseColor) => baseColor.IsDark() ? Colors.Black : Colors.White;
+	public static Color ToBlackOrWhite(this Color color)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+		return color.IsDark() ? Colors.Black : Colors.White;
+	}
 
 	/// <summary>
 	/// Converts Color to Colors.Black or Colors.White for text
 	/// </summary>
-	/// <param name="baseColor"></param>
+	/// <param name="color"></param>
 	/// <returns>Black or White Text Color</returns>
-	public static Color ToBlackOrWhiteForText(this Color baseColor) =>
-		baseColor.IsDarkForTheEye() ? Colors.White : Colors.Black;
+	public static Color ToBlackOrWhiteForText(this Color color)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+		return color.IsDarkForTheEye() ? Colors.White : Colors.Black;
+	}
 
 	/// <summary>
 	/// Converts a Color to Grayscale
 	/// </summary>
-	/// <param name="baseColor"></param>
+	/// <param name="color"></param>
 	/// <returns>Gray Scale Color</returns>
-	public static Color ToGrayScale(this Color baseColor)
+	public static Color ToGrayScale(this Color color)
 	{
-		var avg = (baseColor.Red + baseColor.Blue + baseColor.Green) / 3;
+		ArgumentNullException.ThrowIfNull(color);
+
+		var avg = (color.Red + color.Blue + color.Green) / 3;
 		return Color.FromRgb(avg, avg, avg);
 	}
 
 	/// <summary>
 	/// Determines if a Color is dark for the eye
 	/// </summary>
-	/// <param name="c"></param>
+	/// <param name="color"></param>
 	/// <returns>Whether the Color is dark</returns>
-	public static bool IsDarkForTheEye(this Color c) =>
-		(c.GetByteRed() * 0.299) + (c.GetByteGreen() * 0.587) + (c.GetByteBlue() * 0.114) <= 186;
+	public static bool IsDarkForTheEye(this Color color)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+		return (color.GetByteRed() * 0.299) + (color.GetByteGreen() * 0.587) + (color.GetByteBlue() * 0.114) <= 186;
+	}
 
 	/// <summary>
 	/// Determines whether a Color is dark
 	/// </summary>
-	/// <param name="c"></param>
+	/// <param name="color"></param>
 	/// <returns>Is Color Dark</returns>
-	public static bool IsDark(this Color c) => c.GetByteRed() + c.GetByteGreen() + c.GetByteBlue() <= 127 * 3;
+	public static bool IsDark(this Color color)
+	{
+		ArgumentNullException.ThrowIfNull(color);
+		return	color.GetByteRed() + color.GetByteGreen() + color.GetByteBlue() <= 127 * 3;
+	}
 
 	static byte ToByte(float input)
 	{

--- a/src/CommunityToolkit.Maui.Core/Extensions/ColorConversionExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Extensions/ColorConversionExtensions.shared.cs
@@ -317,15 +317,7 @@ public static class ColorConversionExtensions
 
 	static byte ToByte(float input)
 	{
-		if (input < 0)
-		{
-			return 0;
-		}
-		if (input > 255)
-		{
-			return 255;
-		}
-
-		return (byte)Math.Round(input);
+		var clampedInput = Math.Clamp(input, 0, 255);
+		return (byte)Math.Round(clampedInput);
 	}
 }

--- a/src/CommunityToolkit.Maui.Core/Extensions/ColorConversionExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Extensions/ColorConversionExtensions.shared.cs
@@ -315,5 +315,17 @@ public static class ColorConversionExtensions
 	/// <returns>Is Color Dark</returns>
 	public static bool IsDark(this Color c) => c.GetByteRed() + c.GetByteGreen() + c.GetByteBlue() <= 127 * 3;
 
-	static byte ToByte(double input) => (byte)Math.Round(Math.Clamp(input, 0, 255));
+	static byte ToByte(float input)
+	{
+		if (input < 0)
+		{
+			return 0;
+		}
+		if (input > 255)
+		{
+			return 255;
+		}
+
+		return (byte)Math.Round(input);
+	}
 }

--- a/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
@@ -10,7 +10,7 @@ public class ProgressBarAnimationBehavior_Tests : BaseTest
 	public static readonly IReadOnlyList<object[]> ValidData = new[]
 	{
 		new object[] { 0.5, 175, Easing.BounceIn },
-		new object[] { 1, 1500, Easing.Default },
+		new object[] { 1, 500, Easing.Default },
 		new object[] { 0, 750, Easing.CubicOut }
 	};
 

--- a/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Behaviors/ProgressBarAnimationBehavior_Tests.cs
@@ -14,7 +14,7 @@ public class ProgressBarAnimationBehavior_Tests : BaseTest
 		new object[] { 0, 750, Easing.CubicOut }
 	};
 
-	[Theory]
+	[Theory(Timeout = 5000)]
 	[MemberData(nameof(ValidData))]
 	public async Task ValidPropertiesTests(double progress, uint length, Easing easing)
 	{

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToBlackKeyConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToBlackKeyConverter_Tests.cs
@@ -1,0 +1,66 @@
+﻿using CommunityToolkit.Maui.Converters;
+using Xunit;
+
+namespace CommunityToolkit.Maui.UnitTests.Converters;
+
+public class ColorToBlackKeyConverter_Tests : BaseTest
+{
+	public readonly static IReadOnlyList<object[]> ValidInputData = new[]
+	{
+		new object[] { 0, 0, 0, 0, 1 },
+		new object[] { 0, 0, 0, 1, 1 },
+		new object[] { 0, 0, 1, 0, 0 },
+		new object[] { 0, 0, 1, 1, 0 },
+		new object[] { 0, 1, 0, 0, 0 },
+		new object[] { 0, 1, 0, 1, 0 },
+		new object[] { 0, 1, 1, 0, 0 },
+		new object[] { 0, 1, 1, 1, 0 },
+		new object[] { 1, 0, 0, 0, 0 },
+		new object[] { 1, 0, 0, 1, 0 },
+		new object[] { 1, 0, 1, 0, 0 },
+		new object[] { 1, 0, 1, 1, 0 },
+		new object[] { 1, 1, 0, 0, 0 },
+		new object[] { 1, 1, 0, 1, 0 },
+		new object[] { 1, 1, 1, 0, 0 },
+		new object[] { 1, 1, 1, 1, 0 },
+		new object[] { 0.5, 0, 0, 1, 0.5 },
+		new object[] { 0.5, 0, 0, 0, 0.5 },
+		new object[] { 0, 0.5, 0, 1, 0.5 },
+		new object[] { 0, 0.5, 0, 0, 0.5 },
+		new object[] { 0.5, 0.5, 0.5, 1, 0.5 },
+		new object[] { 0.5, 0.5, 0.5, 0, 0.5 },
+		new object[] { 0.25, 0.25, 0.25, 1, 0.75 },
+		new object[] { 0.25, 0.25, 0.25, 0, 0.75 },
+		new object[] { 0.25, 0.25, 1, 1, 0 },
+		new object[] { 0.25, 0.25, 1, 0, 0 },
+		new object[] { 0.25, 1, 0.25, 1, 0 },
+		new object[] { 0.25, 1, 0.25, 0, 0 },
+		new object[] { 0.75, 1, 0.25, 1, 0 },
+		new object[] { 0.75, 1, 0.25, 0, 0 },
+		new object[] { 0.75, 0, 1, 1, 0 },
+		new object[] { 0.75, 0, 1, 0, 0 },
+	};
+
+	[Theory]
+	[MemberData(nameof(ValidInputData))]
+	public void ColorToBlackKeyConverterValidInputTest(float red, float green, float blue, float alpha, double expectedResult)
+	{
+		var converter = new ColorToBlackKeyConverter();
+		var color = new Color(red, green, blue, alpha);
+
+		var resultConvertFrom = converter.ConvertFrom(color);
+		var resultConvert = converter.Convert(color, typeof(double), null, null);
+
+		Assert.Equal(expectedResult, resultConvertFrom);
+		Assert.Equal(expectedResult, resultConvert);
+	}
+
+	[Fact]
+	public void ColorToBlackKeyConverterNullInputTest()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => new ColorToBlackKeyConverter().ConvertFrom(null));
+		Assert.Throws<ArgumentNullException>(() => new ColorToBlackKeyConverter().Convert(null, typeof(double), null, null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+}

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToByteAlphaConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToByteAlphaConverter_Tests.cs
@@ -1,0 +1,41 @@
+﻿using CommunityToolkit.Maui.Converters;
+using Xunit;
+
+namespace CommunityToolkit.Maui.UnitTests.Converters;
+
+public class ColorToByteAlphaConverter_Tests : BaseTest
+{
+	public static IReadOnlyList<object[]> ValidInputData = new[]
+	{
+		new object[] { float.MinValue, (byte)0 },
+		new object[] { -0.01f, (byte)0 },
+		new object[] { -0f, (byte)0 },
+		new object[] { 0f, (byte)0 },
+		new object[] { 100f, (byte)100 },
+		new object[] { 255f, (byte)255 },
+		new object[] { 255.01f, (byte)255 },
+		new object[] { float.MaxValue, (byte)255 },
+	};
+
+	[Theory]
+	[MemberData(nameof(ValidInputData))]
+	public void ColorToByteAlphaConverterValidInputTest(float alpha, byte expectedResult)
+	{
+		var converter = new ColorToByteAlphaConverter();
+
+		var resultConvertFrom = converter.ConvertFrom(new Color(0, 0, 0, alpha));
+		var resultConvert = converter.Convert(new Color(0, 0, 0, alpha), typeof(byte), null, null);
+
+		Assert.Equal(expectedResult, resultConvertFrom);
+		Assert.Equal(expectedResult, resultConvert);
+	}
+
+	[Fact]
+	public void ColorToComponentConvertersNullInputTest()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => new ColorToByteAlphaConverter().ConvertFrom(null));
+		Assert.Throws<ArgumentNullException>(() => new ColorToByteAlphaConverter().Convert(null, typeof(byte), null, null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+}

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToByteAlphaConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToByteAlphaConverter_Tests.cs
@@ -21,10 +21,11 @@ public class ColorToByteAlphaConverter_Tests : BaseTest
 	[MemberData(nameof(ValidInputData))]
 	public void ColorToByteAlphaConverterValidInputTest(float alpha, byte expectedResult)
 	{
+		var color = new Color(0, 0, 0, alpha);
 		var converter = new ColorToByteAlphaConverter();
 
-		var resultConvertFrom = converter.ConvertFrom(new Color(0, 0, 0, alpha));
-		var resultConvert = converter.Convert(new Color(0, 0, 0, alpha), typeof(byte), null, null);
+		var resultConvertFrom = converter.ConvertFrom(color);
+		var resultConvert = converter.Convert(color, typeof(byte), null, null);
 
 		Assert.Equal(expectedResult, resultConvertFrom);
 		Assert.Equal(expectedResult, resultConvert);

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToByteAlphaConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToByteAlphaConverter_Tests.cs
@@ -5,15 +5,17 @@ namespace CommunityToolkit.Maui.UnitTests.Converters;
 
 public class ColorToByteAlphaConverter_Tests : BaseTest
 {
-	public static IReadOnlyList<object[]> ValidInputData = new[]
+	public readonly static IReadOnlyList<object[]> ValidInputData = new[]
 	{
 		new object[] { float.MinValue, (byte)0 },
 		new object[] { -0.01f, (byte)0 },
 		new object[] { -0f, (byte)0 },
 		new object[] { 0f, (byte)0 },
-		new object[] { 100f, (byte)100 },
-		new object[] { 255f, (byte)255 },
-		new object[] { 255.01f, (byte)255 },
+		new object[] { 0.25f, (byte)64 },
+		new object[] { 0.5f, (byte)128 },
+		new object[] { 0.75f, (byte)191 },
+		new object[] { 1f, (byte)255 },
+		new object[] { 1.001f, (byte)255 },
 		new object[] { float.MaxValue, (byte)255 },
 	};
 

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToByteBlueConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToByteBlueConverter_Tests.cs
@@ -1,0 +1,44 @@
+﻿using CommunityToolkit.Maui.Converters;
+using Xunit;
+
+namespace CommunityToolkit.Maui.UnitTests.Converters;
+
+public class ColorToByteBlueConverter_Tests : BaseTest
+{
+	public readonly static IReadOnlyList<object[]> ValidInputData = new[]
+	{
+		new object[] { float.MinValue, (byte)0 },
+		new object[] { -0.01f, (byte)0 },
+		new object[] { -0f, (byte)0 },
+		new object[] { 0f, (byte)0 },
+		new object[] { 0.25f, (byte)64 },
+		new object[] { 0.5f, (byte)128 },
+		new object[] { 0.75f, (byte)191 },
+		new object[] { 1f, (byte)255 },
+		new object[] { 1.001f, (byte)255 },
+		new object[] { float.MaxValue, (byte)255 },
+	};
+
+	[Theory]
+	[MemberData(nameof(ValidInputData))]
+	public void ColorToByteBlueConverterValidInputTest(float blue, byte expectedResult)
+	{
+		var color = new Color(0, 0, blue, 0);
+		var converter = new ColorToByteBlueConverter();
+
+		var resultConvertFrom = converter.ConvertFrom(color);
+		var resultConvert = converter.Convert(color, typeof(byte), null, null);
+
+		Assert.Equal(expectedResult, resultConvertFrom);
+		Assert.Equal(expectedResult, resultConvert);
+	}
+
+	[Fact]
+	public void ColorToByteBlueConverterNullInputTest()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => new ColorToByteBlueConverter().ConvertFrom(null));
+		Assert.Throws<ArgumentNullException>(() => new ColorToByteBlueConverter().Convert(null, typeof(byte), null, null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+}

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToByteGreenConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToByteGreenConverter_Tests.cs
@@ -1,0 +1,44 @@
+﻿using CommunityToolkit.Maui.Converters;
+using Xunit;
+
+namespace CommunityToolkit.Maui.UnitTests.Converters;
+
+public class ColorToByteGreenConverter_Tests : BaseTest
+{
+	public readonly static IReadOnlyList<object[]> ValidInputData = new[]
+	{
+		new object[] { float.MinValue, (byte)0 },
+		new object[] { -0.01f, (byte)0 },
+		new object[] { -0f, (byte)0 },
+		new object[] { 0f, (byte)0 },
+		new object[] { 0.25f, (byte)64 },
+		new object[] { 0.5f, (byte)128 },
+		new object[] { 0.75f, (byte)191 },
+		new object[] { 1f, (byte)255 },
+		new object[] { 1.001f, (byte)255 },
+		new object[] { float.MaxValue, (byte)255 },
+	};
+
+	[Theory]
+	[MemberData(nameof(ValidInputData))]
+	public void ColorToByteGreenConverterValidInputTest(float green, byte expectedResult)
+	{
+		var color = new Color(0, green, 0, 0);
+		var converter = new ColorToByteGreenConverter();
+
+		var resultConvertFrom = converter.ConvertFrom(color);
+		var resultConvert = converter.Convert(color, typeof(byte), null, null);
+
+		Assert.Equal(expectedResult, resultConvertFrom);
+		Assert.Equal(expectedResult, resultConvert);
+	}
+
+	[Fact]
+	public void ColorToByteGreenConverterNullInputTest()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => new ColorToByteGreenConverter().ConvertFrom(null));
+		Assert.Throws<ArgumentNullException>(() => new ColorToByteGreenConverter().Convert(null, typeof(byte), null, null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+}

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToByteRedConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToByteRedConverter_Tests.cs
@@ -22,9 +22,10 @@ public class ColorToByteRedConverter_Tests : BaseTest
 	public void ColorToByteRedConverterValidInputTest(float red, byte expectedResult)
 	{
 		var converter = new ColorToByteRedConverter();
+		var color = new Color(red, 0, 0, 0);
 
-		var resultConvertFrom = converter.ConvertFrom(new Color(red, 0, 0, 1));
-		var resultConvert = converter.Convert(new Color(red, 0, 0, 1), typeof(byte), null, null);
+		var resultConvertFrom = converter.ConvertFrom(color);
+		var resultConvert = converter.Convert(color, typeof(byte), null, null);
 
 		Assert.Equal(expectedResult, resultConvertFrom);
 		Assert.Equal(expectedResult, resultConvert);

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToByteRedConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToByteRedConverter_Tests.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace CommunityToolkit.Maui.UnitTests.Converters;
 
-public class ColorToByteAlphaConverter_Tests : BaseTest
+public class ColorToByteRedConverter_Tests : BaseTest
 {
 	public static IReadOnlyList<object[]> ValidInputData = new[]
 	{
@@ -19,23 +19,23 @@ public class ColorToByteAlphaConverter_Tests : BaseTest
 
 	[Theory]
 	[MemberData(nameof(ValidInputData))]
-	public void ColorToByteAlphaConverterValidInputTest(float alpha, byte expectedResult)
+	public void ColorToByteRedConverterValidInputTest(float red, byte expectedResult)
 	{
-		var converter = new ColorToByteAlphaConverter();
+		var converter = new ColorToByteRedConverter();
 
-		var resultConvertFrom = converter.ConvertFrom(new Color(0, 0, 0, alpha));
-		var resultConvert = converter.Convert(new Color(0, 0, 0, alpha), typeof(byte), null, null);
+		var resultConvertFrom = converter.ConvertFrom(new Color(red, 0, 0, 1));
+		var resultConvert = converter.Convert(new Color(red, 0, 0, 1), typeof(byte), null, null);
 
 		Assert.Equal(expectedResult, resultConvertFrom);
 		Assert.Equal(expectedResult, resultConvert);
 	}
 
 	[Fact]
-	public void ColorToByteAlphaConverterNullInputTest()
+	public void ColorToByteRedConverterNullInputTest()
 	{
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-		Assert.Throws<ArgumentNullException>(() => new ColorToByteAlphaConverter().ConvertFrom(null));
-		Assert.Throws<ArgumentNullException>(() => new ColorToByteAlphaConverter().Convert(null, typeof(byte), null, null));
+		Assert.Throws<ArgumentNullException>(() => new ColorToByteRedConverter().ConvertFrom(null));
+		Assert.Throws<ArgumentNullException>(() => new ColorToByteRedConverter().Convert(null, typeof(byte), null, null));
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 }

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToByteRedConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToByteRedConverter_Tests.cs
@@ -5,15 +5,17 @@ namespace CommunityToolkit.Maui.UnitTests.Converters;
 
 public class ColorToByteRedConverter_Tests : BaseTest
 {
-	public static IReadOnlyList<object[]> ValidInputData = new[]
+	public readonly static IReadOnlyList<object[]> ValidInputData = new[]
 	{
 		new object[] { float.MinValue, (byte)0 },
 		new object[] { -0.01f, (byte)0 },
 		new object[] { -0f, (byte)0 },
 		new object[] { 0f, (byte)0 },
-		new object[] { 100f, (byte)100 },
-		new object[] { 255f, (byte)255 },
-		new object[] { 255.01f, (byte)255 },
+		new object[] { 0.25f, (byte)64 },
+		new object[] { 0.5f, (byte)128 },
+		new object[] { 0.75f, (byte)191 },
+		new object[] { 1f, (byte)255 },
+		new object[] { 1.001f, (byte)255 },
 		new object[] { float.MaxValue, (byte)255 },
 	};
 

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToDegreeHueConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToDegreeHueConverter_Tests.cs
@@ -1,0 +1,66 @@
+﻿using CommunityToolkit.Maui.Converters;
+using Xunit;
+
+namespace CommunityToolkit.Maui.UnitTests.Converters;
+
+public class ColorToDegreeHueConverter_Tests : BaseTest
+{
+	public readonly static IReadOnlyList<object[]> ValidInputData = new[]
+	{
+		new object[] { 0, 0, 0, 0, 0 },
+		new object[] { 0, 0, 0, 1, 0 },
+		new object[] { 0, 0, 1, 0, 240 },
+		new object[] { 0, 0, 1, 1, 240 },
+		new object[] { 0, 1, 0, 0, 120 },
+		new object[] { 0, 1, 0, 1, 120 },
+		new object[] { 0, 1, 1, 0, 180 },
+		new object[] { 0, 1, 1, 1, 180 },
+		new object[] { 1, 0, 0, 0, 360 },
+		new object[] { 1, 0, 0, 1, 360 },
+		new object[] { 1, 0, 1, 0, 300 },
+		new object[] { 1, 0, 1, 1, 300 },
+		new object[] { 1, 1, 0, 0, 60 },
+		new object[] { 1, 1, 0, 1, 60 },
+		new object[] { 1, 1, 1, 0, 0 },
+		new object[] { 1, 1, 1, 1, 0 },
+		new object[] { 0.5, 0, 0, 1, 360 },
+		new object[] { 0.5, 0, 0, 0, 360 },
+		new object[] { 0, 0.5, 0, 1, 120 },
+		new object[] { 0, 0.5, 0, 0, 120 },
+		new object[] { 0.5, 0.5, 0.5, 1, 0 },
+		new object[] { 0.5, 0.5, 0.5, 0, 0 },
+		new object[] { 0.25, 0.25, 0.25, 1, 0 },
+		new object[] { 0.25, 0.25, 0.25, 0, 0 },
+		new object[] { 0.25, 0.25, 1, 1, 240 },
+		new object[] { 0.25, 0.25, 1, 0, 240 },
+		new object[] { 0.25, 1, 0.25, 1, 120 },
+		new object[] { 0.25, 1, 0.25, 0, 120 },
+		new object[] { 0.75, 1, 0.25, 1, 80 },
+		new object[] { 0.75, 1, 0.25, 0, 80 },
+		new object[] { 0.75, 0, 1, 1, 285 },
+		new object[] { 0.75, 0, 1, 0, 285 },
+	};
+
+	[Theory]
+	[MemberData(nameof(ValidInputData))]
+	public void ColorToDegreeHueConverterValidInputTest(float red, float green, float blue, float alpha, double expectedResult)
+	{
+		var converter = new ColorToDegreeHueConverter();
+		var color = new Color(red, green, blue, alpha);
+
+		var resultConvertFrom = converter.ConvertFrom(color);
+		var resultConvert = converter.Convert(color, typeof(double), null, null);
+
+		Assert.Equal(expectedResult, resultConvertFrom);
+		Assert.Equal(expectedResult, resultConvert);
+	}
+
+	[Fact]
+	public void ColorToDegreeHueConverterNullInputTest()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => new ColorToDegreeHueConverter().ConvertFrom(null));
+		Assert.Throws<ArgumentNullException>(() => new ColorToDegreeHueConverter().Convert(null, typeof(double), null, null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+}

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToPercentCyanConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToPercentCyanConverter_Tests.cs
@@ -31,6 +31,14 @@ public class ColorToPercentCyanConverter_Tests : BaseTest
 		new object[] { 0.5, 0.5, 0.5, 0, 0 },
 		new object[] { 0.25, 0.25, 0.25, 1, 0 },
 		new object[] { 0.25, 0.25, 0.25, 0, 0 },
+		new object[] { 0.25, 0.25, 1, 1, 0.75 },
+		new object[] { 0.25, 0.25, 1, 0, 0.75 },
+		new object[] { 0.25, 1, 0.25, 1, 0.75 },
+		new object[] { 0.25, 1, 0.25, 0, 0.75 },
+		new object[] { 0.75, 1, 0.25, 1, 0.25 },
+		new object[] { 0.75, 1, 0.25, 0, 0.25 },
+		new object[] { 0.75, 0, 1, 1, 0.25 },
+		new object[] { 0.75, 0, 1, 0, 0.25 },
 	};
 
 	[Theory]

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToPercentCyanConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToPercentCyanConverter_Tests.cs
@@ -1,0 +1,58 @@
+﻿using CommunityToolkit.Maui.Converters;
+using Xunit;
+
+namespace CommunityToolkit.Maui.UnitTests.Converters;
+
+public class ColorToPercentCyanConverter_Tests : BaseTest
+{
+	public readonly static IReadOnlyList<object[]> ValidInputData = new[]
+	{
+		new object[] { 0, 0, 0, 0, 0 },
+		new object[] { 0, 0, 0, 1, 0 },
+		new object[] { 0, 0, 1, 0, 1 },
+		new object[] { 0, 0, 1, 1, 1 },
+		new object[] { 0, 1, 0, 0, 1 },
+		new object[] { 0, 1, 0, 1, 1 },
+		new object[] { 0, 1, 1, 0, 1 },
+		new object[] { 0, 1, 1, 1, 1 },
+		new object[] { 1, 0, 0, 0, 0 },
+		new object[] { 1, 0, 0, 1, 0 },
+		new object[] { 1, 0, 1, 0, 0 },
+		new object[] { 1, 0, 1, 1, 0 },
+		new object[] { 1, 1, 0, 0, 0 },
+		new object[] { 1, 1, 0, 1, 0 },
+		new object[] { 1, 1, 1, 0, 0 },
+		new object[] { 1, 1, 1, 1, 0 },
+		new object[] { 0.5, 0, 0, 1, 0 },
+		new object[] { 0.5, 0, 0, 0, 0 },
+		new object[] { 0, 0.5, 0, 1, 1 },
+		new object[] { 0, 0.5, 0, 0, 1 },
+		new object[] { 0.5, 0.5, 0.5, 1, 0 },
+		new object[] { 0.5, 0.5, 0.5, 0, 0 },
+		new object[] { 0.25, 0.25, 0.25, 1, 0 },
+		new object[] { 0.25, 0.25, 0.25, 0, 0 },
+	};
+
+	[Theory]
+	[MemberData(nameof(ValidInputData))]
+	public void ColorToPercentCyanConverterValidInputTest(float red, float green, float blue, float alpha, double expectedResult)
+	{
+		var converter = new ColorToPercentCyanConverter();
+		var color = new Color(red, green, blue, alpha);
+
+		var resultConvertFrom = converter.ConvertFrom(color);
+		var resultConvert = converter.Convert(color, typeof(double), null, null);
+
+		Assert.Equal(expectedResult, resultConvertFrom);
+		Assert.Equal(expectedResult, resultConvert);
+	}
+
+	[Fact]
+	public void ColorToPercentCyanConverterNullInputTest()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => new ColorToPercentCyanConverter().ConvertFrom(null));
+		Assert.Throws<ArgumentNullException>(() => new ColorToPercentCyanConverter().Convert(null, typeof(double), null, null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+}

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToPercentMagentaConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToPercentMagentaConverter_Tests.cs
@@ -1,0 +1,66 @@
+﻿using CommunityToolkit.Maui.Converters;
+using Xunit;
+
+namespace CommunityToolkit.Maui.UnitTests.Converters;
+
+public class ColorToPercentMagentaConverter_Tests : BaseTest
+{
+	public readonly static IReadOnlyList<object[]> ValidInputData = new[]
+	{
+		new object[] { 0, 0, 0, 0, 0 },
+		new object[] { 0, 0, 0, 1, 0 },
+		new object[] { 0, 0, 1, 0, 1 },
+		new object[] { 0, 0, 1, 1, 1 },
+		new object[] { 0, 1, 0, 0, 0 },
+		new object[] { 0, 1, 0, 1, 0 },
+		new object[] { 0, 1, 1, 0, 0 },
+		new object[] { 0, 1, 1, 1, 0 },
+		new object[] { 1, 0, 0, 0, 1 },
+		new object[] { 1, 0, 0, 1, 1 },
+		new object[] { 1, 0, 1, 0, 1 },
+		new object[] { 1, 0, 1, 1, 1 },
+		new object[] { 1, 1, 0, 0, 0 },
+		new object[] { 1, 1, 0, 1, 0 },
+		new object[] { 1, 1, 1, 0, 0 },
+		new object[] { 1, 1, 1, 1, 0 },
+		new object[] { 0.5, 0, 0, 1, 1 },
+		new object[] { 0.5, 0, 0, 0, 1 },
+		new object[] { 0, 0.5, 0, 1, 0 },
+		new object[] { 0, 0.5, 0, 0, 0 },
+		new object[] { 0.5, 0.5, 0.5, 1, 0 },
+		new object[] { 0.5, 0.5, 0.5, 0, 0 },
+		new object[] { 0.25, 0.25, 0.25, 1, 0 },
+		new object[] { 0.25, 0.25, 0.25, 0, 0 },
+		new object[] { 0.25, 0.25, 1, 1, 0.75 },
+		new object[] { 0.25, 0.25, 1, 0, 0.75 },
+		new object[] { 0.25, 1, 0.25, 1, 0 },
+		new object[] { 0.25, 1, 0.25, 0, 0 },
+		new object[] { 0.75, 1, 0.25, 1, 0 },
+		new object[] { 0.75, 1, 0.25, 0, 0 },
+		new object[] { 0.75, 0, 1, 1, 1 },
+		new object[] { 0.75, 0, 1, 0, 1 },
+	};
+
+	[Theory]
+	[MemberData(nameof(ValidInputData))]
+	public void ColorToPercentMagentaConverterValidInputTest(float red, float green, float blue, float alpha, double expectedResult)
+	{
+		var converter = new ColorToPercentMagentaConverter();
+		var color = new Color(red, green, blue, alpha);
+
+		var resultConvertFrom = converter.ConvertFrom(color);
+		var resultConvert = converter.Convert(color, typeof(double), null, null);
+
+		Assert.Equal(expectedResult, resultConvertFrom);
+		Assert.Equal(expectedResult, resultConvert);
+	}
+
+	[Fact]
+	public void ColorToPercentMagentaCyanConverterNullInputTest()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => new ColorToPercentMagentaConverter().ConvertFrom(null));
+		Assert.Throws<ArgumentNullException>(() => new ColorToPercentMagentaConverter().Convert(null, typeof(double), null, null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+}

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToPercentMagentaConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToPercentMagentaConverter_Tests.cs
@@ -56,7 +56,7 @@ public class ColorToPercentMagentaConverter_Tests : BaseTest
 	}
 
 	[Fact]
-	public void ColorToPercentMagentaCyanConverterNullInputTest()
+	public void ColorToPercentMagentaConverterNullInputTest()
 	{
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
 		Assert.Throws<ArgumentNullException>(() => new ColorToPercentMagentaConverter().ConvertFrom(null));

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToPercentYellowConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/ColorToPercentYellowConverter_Tests.cs
@@ -1,0 +1,68 @@
+﻿using CommunityToolkit.Maui.Converters;
+using Xunit;
+
+namespace CommunityToolkit.Maui.UnitTests.Converters;
+
+public class ColorToPercentYellowConverter_Tests : BaseTest
+{
+	public readonly static IReadOnlyList<object[]> ValidInputData = new[]
+	{
+		new object[] { 0, 0, 0, 0, 0 },
+		new object[] { 0, 0, 0, 1, 0 },
+		new object[] { 0, 0, 1, 0, 0 },
+		new object[] { 0, 0, 1, 1, 0 },
+		new object[] { 0, 1, 0, 0, 1 },
+		new object[] { 0, 1, 0, 1, 1 },
+		new object[] { 0, 1, 1, 0, 0 },
+		new object[] { 0, 1, 1, 1, 0 },
+		new object[] { 1, 0, 0, 0, 1 },
+		new object[] { 1, 0, 0, 1, 1 },
+		new object[] { 1, 0, 1, 0, 0 },
+		new object[] { 1, 0, 1, 1, 0 },
+		new object[] { 1, 1, 0, 0, 1 },
+		new object[] { 1, 1, 0, 1, 1 },
+		new object[] { 1, 1, 1, 0, 0 },
+		new object[] { 1, 1, 1, 1, 0 },
+		new object[] { 0.5, 0, 0, 1, 1 },
+		new object[] { 0.5, 0, 0, 0, 1 },
+		new object[] { 0, 0.5, 0, 1, 1 },
+		new object[] { 0, 0.5, 0, 0, 1 },
+		new object[] { 0, 0, 0.5, 1, 0 },
+		new object[] { 0, 0, 0.5, 0, 0 },
+		new object[] { 0.5, 0.5, 0.5, 1, 0 },
+		new object[] { 0.5, 0.5, 0.5, 0, 0 },
+		new object[] { 0.25, 0.25, 0.25, 1, 0 },
+		new object[] { 0.25, 0.25, 0.25, 0, 0 },
+		new object[] { 0.25, 0.25, 1, 1, 0 },
+		new object[] { 0.25, 0.25, 1, 0, 0 },
+		new object[] { 0.25, 1, 0.25, 1, 0.75 },
+		new object[] { 0.25, 1, 0.25, 0, 0.75 },
+		new object[] { 0.75, 1, 0.25, 1, 0.75 },
+		new object[] { 0.75, 1, 0.25, 0, 0.75 },
+		new object[] { 0.75, 0, 1, 1, 0 },
+		new object[] { 0.75, 0, 1, 0, 0 },
+	};
+
+	[Theory]
+	[MemberData(nameof(ValidInputData))]
+	public void ColorToPercentYellowConverterValidInputTest(float red, float green, float blue, float alpha, double expectedResult)
+	{
+		var converter = new ColorToPercentYellowConverter();
+		var color = new Color(red, green, blue, alpha);
+
+		var resultConvertFrom = converter.ConvertFrom(color);
+		var resultConvert = converter.Convert(color, typeof(double), null, null);
+
+		Assert.Equal(expectedResult, resultConvertFrom);
+		Assert.Equal(expectedResult, resultConvert);
+	}
+
+	[Fact]
+	public void ColorToPercentYellowCyanConverterNullInputTest()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => new ColorToPercentYellowConverter().ConvertFrom(null));
+		Assert.Throws<ArgumentNullException>(() => new ColorToPercentYellowConverter().Convert(null, typeof(double), null, null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+}

--- a/src/CommunityToolkit.Maui.UnitTests/Extensions/ColorConversionExtensions_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Extensions/ColorConversionExtensions_Tests.cs
@@ -296,6 +296,14 @@ public class ColorConversionExtensions_Tests
 		Assert.Equal(testDef.ExpectedRGB, result);
 	}
 
+	[Fact]
+	public void ToRgbStringNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.ToRgbString(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
 	[Theory]
 	[MemberData(nameof(ColorTestData))]
 	public void ToRgbaString(ColorTestDefinition testDef)
@@ -303,6 +311,14 @@ public class ColorConversionExtensions_Tests
 		var result = testDef.Color.ToRgbaString();
 
 		Assert.Equal(testDef.ExpectedRGBA, result);
+	}
+
+	[Fact]
+	public void ToRgbaStringNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.ToRgbaString(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 
 	[Theory]
@@ -314,6 +330,14 @@ public class ColorConversionExtensions_Tests
 		Assert.Equal(testDef.ExpectedHEXRGB, result);
 	}
 
+	[Fact]
+	public void ToHexRgbStringNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.ToHexRgbString(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
 	[Theory]
 	[MemberData(nameof(ColorTestData))]
 	public void ToHexRgbaString(ColorTestDefinition testDef)
@@ -321,6 +345,14 @@ public class ColorConversionExtensions_Tests
 		var result = testDef.Color.ToHexRgbaString();
 
 		Assert.Equal(testDef.ExpectedHEXRGBA, result);
+	}
+
+	[Fact]
+	public void ToHexRgbaStringNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.ToHexRgbaString(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 
 	[Theory]
@@ -332,6 +364,14 @@ public class ColorConversionExtensions_Tests
 		Assert.Equal(testDef.ExpectedHEXARGB, result);
 	}
 
+	[Fact]
+	public void ToHexArgbStringNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.ToHexArgbString(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
 	[Theory]
 	[MemberData(nameof(ColorTestData))]
 	public void ToCmykString(ColorTestDefinition testDef)
@@ -339,6 +379,14 @@ public class ColorConversionExtensions_Tests
 		var result = testDef.Color.ToCmykString();
 
 		Assert.Equal(testDef.ExpectedCMYK, result);
+	}
+
+	[Fact]
+	public void ToCmykStringNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.ToCmykString(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 
 	[Theory]
@@ -350,6 +398,14 @@ public class ColorConversionExtensions_Tests
 		Assert.Equal(testDef.ExpectedCMYKA, result);
 	}
 
+	[Fact]
+	public void ToCmykaStringNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.ToCmykaString(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
 	[Theory]
 	[MemberData(nameof(ColorTestData))]
 	public void ToHslString(ColorTestDefinition testDef)
@@ -357,6 +413,14 @@ public class ColorConversionExtensions_Tests
 		var result = testDef.Color.ToHslString();
 
 		Assert.Equal(testDef.ExpectedHslString, result);
+	}
+
+	[Fact]
+	public void ToHslStringNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.ToHslString(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 
 	[Theory]
@@ -368,6 +432,14 @@ public class ColorConversionExtensions_Tests
 		Assert.Equal(testDef.ExpectedHslaString, result);
 	}
 
+	[Fact]
+	public void ToHslaStringNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.ToHslaString(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
 	[Theory]
 	[MemberData(nameof(ColorTestData))]
 	public void GetByteRed(ColorTestDefinition testDef)
@@ -375,6 +447,14 @@ public class ColorConversionExtensions_Tests
 		var result = testDef.Color.GetByteRed();
 
 		Assert.Equal(testDef.ExpectedByteR, result);
+	}
+
+	[Fact]
+	public void GetByteRedNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.GetByteRed(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 
 	[Theory]
@@ -386,6 +466,14 @@ public class ColorConversionExtensions_Tests
 		Assert.Equal(testDef.ExpectedByteG, result);
 	}
 
+	[Fact]
+	public void GetByteGreenNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.GetByteGreen(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
 	[Theory]
 	[MemberData(nameof(ColorTestData))]
 	public void GetByteBlue(ColorTestDefinition testDef)
@@ -393,6 +481,14 @@ public class ColorConversionExtensions_Tests
 		var result = testDef.Color.GetByteBlue();
 
 		Assert.Equal(testDef.ExpectedByteB, result);
+	}
+
+	[Fact]
+	public void GetByteBlueNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.GetByteBlue(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 
 	[Theory]
@@ -404,6 +500,14 @@ public class ColorConversionExtensions_Tests
 		Assert.Equal(testDef.ExpectedByteA, result);
 	}
 
+	[Fact]
+	public void GetByteAlphaNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.GetByteAlpha(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
 	[Theory]
 	[MemberData(nameof(ColorTestData))]
 	public void GetPctBlackKey(ColorTestDefinition def)
@@ -411,6 +515,14 @@ public class ColorConversionExtensions_Tests
 		var result = def.Color.GetPercentBlackKey();
 
 		Assert.Equal(def.ExpectedPctBlack, result);
+	}
+
+	[Fact]
+	public void GetPercentBlackKeyNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.GetPercentBlackKey(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 
 	[Theory]
@@ -422,6 +534,14 @@ public class ColorConversionExtensions_Tests
 		Assert.Equal(def.ExpectedDegreeHue, result);
 	}
 
+	[Fact]
+	public void GetDegreeHueNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.GetDegreeHue(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
 	[Theory]
 	[MemberData(nameof(ColorTestData))]
 	public void GetPctCyan(ColorTestDefinition testDef)
@@ -429,6 +549,14 @@ public class ColorConversionExtensions_Tests
 		var result = testDef.Color.GetPercentCyan();
 
 		Assert.Equal(testDef.ExpectedPctCyan, result);
+	}
+
+	[Fact]
+	public void GetPercentCyanNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.GetPercentCyan(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 
 	[Theory]
@@ -440,6 +568,14 @@ public class ColorConversionExtensions_Tests
 		Assert.Equal(testDef.ExpectedPctMagenta, result);
 	}
 
+	[Fact]
+	public void GetPercentMagentaNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.GetPercentMagenta(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
 	[Theory]
 	[MemberData(nameof(ColorTestData))]
 	public void GetPctYellow(ColorTestDefinition testDef)
@@ -447,6 +583,14 @@ public class ColorConversionExtensions_Tests
 		var result = testDef.Color.GetPercentYellow();
 
 		Assert.Equal(testDef.ExpectedPctYellow, result);
+	}
+
+	[Fact]
+	public void GetPercentYellowNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.GetPercentYellow(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 
 	[Theory]
@@ -458,6 +602,14 @@ public class ColorConversionExtensions_Tests
 		Assert.Equal(testDef.ExpectedInverse, result);
 	}
 
+	[Fact]
+	public void ToInverseColorNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.ToInverseColor(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
 	[Theory]
 	[MemberData(nameof(ColorTestData))]
 	public void ToGrayScale(ColorTestDefinition testDef)
@@ -465,6 +617,14 @@ public class ColorConversionExtensions_Tests
 		var result = testDef.Color.ToGrayScale();
 
 		Assert.Equal(testDef.ExpectedGreyScale, result);
+	}
+
+	[Fact]
+	public void ToGrayScaleNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.ToGrayScale(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 
 	[Theory]
@@ -476,6 +636,14 @@ public class ColorConversionExtensions_Tests
 		Assert.Equal(testDef.ExpectedIsDark, result);
 	}
 
+	[Fact]
+	public void IsDarkNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.IsDark(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
 	[Theory]
 	[MemberData(nameof(ColorTestData))]
 	public void IsDarkForTheEye(ColorTestDefinition testDef)
@@ -483,6 +651,14 @@ public class ColorConversionExtensions_Tests
 		var result = testDef.Color.IsDarkForTheEye();
 
 		Assert.Equal(testDef.ExpectedIsDarkForEye, result);
+	}
+
+	[Fact]
+	public void IsDarkForTheEyeNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.IsDarkForTheEye(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 
 	[Fact]
@@ -518,6 +694,14 @@ public class ColorConversionExtensions_Tests
 		Assert.Equal(testDef.ExpectedToBlackOrWhite, result);
 	}
 
+	[Fact]
+	public void ToBlackOrWhiteNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.ToBlackOrWhite(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
 	[Theory]
 	[MemberData(nameof(ColorTestData))]
 	public void ToBlackOrWhiteForText(ColorTestDefinition testDef)
@@ -525,6 +709,14 @@ public class ColorConversionExtensions_Tests
 		var result = testDef.Color.ToBlackOrWhiteForText();
 
 		Assert.Equal(testDef.ExpectedToBlackOrWhiteForText, result);
+	}
+
+	[Fact]
+	public void ToBlackOrWhiteForTextNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.ToBlackOrWhiteForText(null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 
 	[Theory]
@@ -555,6 +747,14 @@ public class ColorConversionExtensions_Tests
 		Assert.Throws<ArgumentOutOfRangeException>(() => c.WithRed(red));
 	}
 
+	[Fact]
+	public void WithRedNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.WithRed(null, 0));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
 	[Theory]
 	[MemberData(nameof(ColorTestData))]
 	public void WithGreen_Double(ColorTestDefinition testDef)
@@ -581,6 +781,14 @@ public class ColorConversionExtensions_Tests
 		var green = -new Random().NextDouble();
 
 		Assert.Throws<ArgumentOutOfRangeException>(() => c.WithGreen(green));
+	}
+
+	[Fact]
+	public void WithGreenNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.WithGreen(null, 0));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 
 	[Theory]
@@ -611,6 +819,14 @@ public class ColorConversionExtensions_Tests
 		var blue = -new Random().NextDouble();
 
 		Assert.Throws<ArgumentOutOfRangeException>(() => c.WithBlue(blue));
+	}
+
+	[Fact]
+	public void WithBlueNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.WithBlue(null, 0));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 
 	[Theory]
@@ -658,6 +874,14 @@ public class ColorConversionExtensions_Tests
 		Assert.Equal(Math.Round(testDef.A, 2), Math.Round(newColor.Alpha, 2));
 	}
 
+	[Fact]
+	public void WithCyanNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.WithCyan(null, 0));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
 	[Theory]
 	[MemberData(nameof(ColorTestData))]
 	public void WithAlpha(ColorTestDefinition testDef)
@@ -665,6 +889,14 @@ public class ColorConversionExtensions_Tests
 		var newColor = testDef.Color.WithAlpha(testDef.A);
 
 		Assert.Equal(testDef.ExpectedByteA, newColor.GetByteAlpha());
+	}
+
+	[Fact]
+	public void WithAlphaNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.WithAlpha(null, 0));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 
 	[Theory]
@@ -682,6 +914,14 @@ public class ColorConversionExtensions_Tests
 		Assert.Equal(Math.Round(testDef.A, 2), Math.Round(newColor.Alpha, 2));
 	}
 
+	[Fact]
+	public void WithMagentaNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.WithMagenta(null, 0));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
 	[Theory]
 	[MemberData(nameof(ColorTestData))]
 	public void WithYellow(ColorTestDefinition testDef)
@@ -695,6 +935,14 @@ public class ColorConversionExtensions_Tests
 		Assert.Equal(Math.Round(testDef.R, 2), Math.Round(newColor.Red, 2));
 		Assert.Equal(Math.Round(testDef.G, 2), Math.Round(newColor.Green, 2));
 		Assert.Equal(Math.Round(testDef.A, 2), Math.Round(newColor.Alpha, 2));
+	}
+
+	[Fact]
+	public void WithYellowNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.WithYellow(null, 0));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 
 	[Theory]
@@ -714,6 +962,14 @@ public class ColorConversionExtensions_Tests
 		Assert.Equal(testDef.A, newColor.Alpha);
 	}
 
+	[Fact]
+	public void WithBlackKeyNullInput()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => ColorConversionExtensions.WithBlackKey(null, 0));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
 
 	[Theory]
 	[InlineData(-1, 0)]
@@ -725,7 +981,6 @@ public class ColorConversionExtensions_Tests
 		Assert.Equal(realColor, newColor.GetByteBlue());
 		Assert.Equal(realColor, newColor.GetByteGreen());
 	}
-
 
 	public class ColorTestDefinition
 	{

--- a/src/CommunityToolkit.Maui/Converters/ColorToComponentConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ColorToComponentConverter.shared.cs
@@ -8,7 +8,12 @@ namespace CommunityToolkit.Maui.Converters;
 public class ColorToByteAlphaConverter : BaseConverterOneWay<Color, byte>
 {
 	/// <inheritdoc/>
-	public override byte ConvertFrom(Color value) => value.GetByteAlpha();
+	public override byte ConvertFrom(Color value)
+	{
+		ArgumentNullException.ThrowIfNull(value);
+
+		return value.GetByteAlpha();
+	}
 }
 
 /// <summary>
@@ -17,7 +22,12 @@ public class ColorToByteAlphaConverter : BaseConverterOneWay<Color, byte>
 public class ColorToByteRedConverter : BaseConverterOneWay<Color, byte>
 {
 	/// <inheritdoc/>
-	public override byte ConvertFrom(Color value) => value.GetByteRed();
+	public override byte ConvertFrom(Color value)
+	{
+		ArgumentNullException.ThrowIfNull(value);
+
+		return value.GetByteRed();
+	}
 }
 
 /// <summary>
@@ -26,7 +36,12 @@ public class ColorToByteRedConverter : BaseConverterOneWay<Color, byte>
 public class ColorToByteGreenConverter : BaseConverterOneWay<Color, byte>
 {
 	/// <inheritdoc/>
-	public override byte ConvertFrom(Color value) => value.GetByteGreen();
+	public override byte ConvertFrom(Color value)
+	{
+		ArgumentNullException.ThrowIfNull(value);
+
+		return value.GetByteGreen();
+	}
 }
 
 /// <summary>
@@ -35,7 +50,12 @@ public class ColorToByteGreenConverter : BaseConverterOneWay<Color, byte>
 public class ColorToByteBlueConverter : BaseConverterOneWay<Color, byte>
 {
 	/// <inheritdoc/>
-	public override byte ConvertFrom(Color value) => value.GetByteBlue();
+	public override byte ConvertFrom(Color value)
+	{
+		ArgumentNullException.ThrowIfNull(value);
+
+		return value.GetByteBlue();
+	}
 }
 
 /// <summary>
@@ -44,7 +64,12 @@ public class ColorToByteBlueConverter : BaseConverterOneWay<Color, byte>
 public class ColorToPercentCyanConverter : BaseConverterOneWay<Color, double>
 {
 	/// <inheritdoc/>
-	public override double ConvertFrom(Color value) => value.GetPercentCyan();
+	public override double ConvertFrom(Color value)
+	{
+		ArgumentNullException.ThrowIfNull(value);
+
+		return value.GetPercentCyan();
+	}
 }
 
 /// <summary>
@@ -53,7 +78,12 @@ public class ColorToPercentCyanConverter : BaseConverterOneWay<Color, double>
 public class ColorToPercentMagentaConverter : BaseConverterOneWay<Color, double>
 {
 	/// <inheritdoc/>
-	public override double ConvertFrom(Color value) => value.GetPercentMagenta();
+	public override double ConvertFrom(Color value)
+	{
+		ArgumentNullException.ThrowIfNull(value);
+
+		return value.GetPercentMagenta();
+	}
 }
 
 /// <summary>
@@ -62,7 +92,12 @@ public class ColorToPercentMagentaConverter : BaseConverterOneWay<Color, double>
 public class ColorToPercentYellowConverter : BaseConverterOneWay<Color, double>
 {
 	/// <inheritdoc/>
-	public override double ConvertFrom(Color value) => value.GetPercentYellow();
+	public override double ConvertFrom(Color value)
+	{
+		ArgumentNullException.ThrowIfNull(value);
+
+		return value.GetPercentYellow();
+	}
 }
 
 /// <summary>
@@ -71,7 +106,12 @@ public class ColorToPercentYellowConverter : BaseConverterOneWay<Color, double>
 public class ColorToBlackKeyConverter : BaseConverterOneWay<Color, double>
 {
 	/// <inheritdoc/>
-	public override double ConvertFrom(Color value) => value.GetPercentBlackKey();
+	public override double ConvertFrom(Color value)
+	{
+		ArgumentNullException.ThrowIfNull(value);
+
+		return value.GetPercentBlackKey();
+	}
 }
 
 /// <summary>
@@ -81,5 +121,10 @@ public class ColorToBlackKeyConverter : BaseConverterOneWay<Color, double>
 public class ColorToDegreeHueConverter : BaseConverterOneWay<Color, double>
 {
 	/// <inheritdoc/>
-	public override double ConvertFrom(Color value) => value.GetDegreeHue();
+	public override double ConvertFrom(Color value)
+	{
+		ArgumentNullException.ThrowIfNull(value);
+
+		return value.GetDegreeHue();
+	}
 }


### PR DESCRIPTION
 ### Description of Change ###

This PR adds Unit Tests for the `ColorTo*` Converters.

 ### Linked Issues ###

 - Fixes #53 

 ### PR Checklist ###
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)

 ### Additional information ###

- Added `ArgumentNullException.ThrowIfNull` to `ColorConversionExtensions` APIs
- Update `ProgressBarAnimationBehavior_Tests.cs`
  - This test was randomly timing out due to a race condition (including in our CI pipeline)
  - Added `Timeout = 5000` to `ProgressBarAnimationBehavior_Tests.cs`
  - Lowered the longest test's time duration from `1500` `500`
 
