### PR TITLE
Calculate and display code coverage report

### DIFF
--- a/.runsettings
+++ b/.runsettings
@@ -6,20 +6,11 @@
 
   <DataCollectionRunSettings>
     <DataCollectors>
-      <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector, Microsoft.VisualStudio.TraceCollector, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <DataCollector friendlyName="XPlat code coverage">
         <Configuration>
-          <CodeCoverage>
-            <Functions>              
-              <Include>                
-                <Function>.*CommunityToolkit.Maui\..*</Function>
-              </Include>
-              <Exclude>                
-                <Function>.*Tests.*</Function>
-                <Function>.*get_.*</Function>
-                <Function>.*set_.*</Function>
-              </Exclude>
-            </Functions>
-          </CodeCoverage>
+          <Format>cobertura</Format>
+          <SkipAutoProps>true</SkipAutoProps>          
+          <IncludeTestAssembly>false</IncludeTestAssembly>
         </Configuration>
       </DataCollector>
     </DataCollectors>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,13 +67,6 @@ jobs:
           Write-Host "##vso[build.updatebuildnumber]$fullVersionString"
         displayName: Set NuGet Version to PR Version
         condition: and(succeeded(), eq(variables['build.reason'], 'PullRequest'))
-      # build, test and pack the packages
-      - task: DotNetCoreCLI@2
-        displayName: 'Run Unit Tests'
-        inputs:
-          command: test
-          projects: '$(PathToCommunityToolkitUnitTestCsproj)'
-          arguments: '--configuration Release --settings ".runsettings" --collect "Code coverage"'
       - task: DotNetCoreCLI@2
         displayName: 'Check Dependencies'
         inputs:
@@ -81,12 +74,34 @@ jobs:
           custom: 'list'
           arguments: 'package --vulnerable --include-transitive'
           projects: $(PathToSolution)
+      # test
+      - task: DotNetCoreCLI@2
+        displayName: 'Run Unit Tests'
+        inputs:
+          command: 'test'
+          projects: '$(PathToCommunityToolkitUnitTestCsproj)'
+          arguments: '--configuration Release --settings ".runsettings" --collect "XPlat code coverage" --logger trx --results-directory $(Agent.TempDirectory)'
+          publishTestResults: false    
+      - task: PublishTestResults@2
+        displayName: 'Publish Test Results'
+        inputs:
+          testResultsFormat: VSTest
+          testResultsFiles: '**/*.trx'
+          searchFolder: $(Agent.TempDirectory)
+      - task: PublishCodeCoverageResults@1
+        displayName: 'Publish Code Coverage Results'
+        inputs:
+          codeCoverageTool: 'Cobertura'
+          summaryFileLocation: '$(Agent.TempDirectory)/**/coverage.cobertura.xml'
+          failIfCoverageEmpty: true
+      # build sample
       - task: VSBuild@1
         displayName: 'Build Community Toolkit Sample'
         inputs:
           solution: '$(PathToCommunityToolkitSampleCsproj)'
           configuration: 'Release'
           msbuildArgs: '/restore'
+      # pack
       - task: VSBuild@1
         displayName: 'Build and Pack CommunityToolkit.Maui.Core'
         inputs:
@@ -99,6 +114,7 @@ jobs:
           solution: '$(PathToCommunityToolkitCsproj)'
           configuration: 'Release'
           msbuildArgs: '/restore -t:pack -p:PackageVersion=$(NugetPackageVersion) -p:Version=$(NugetPackageVersion) -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg'
+      # publish
       - task: PowerShell@2
         displayName: 'Copy NuGet Packages to Staging Directory'
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,13 +67,6 @@ jobs:
           Write-Host "##vso[build.updatebuildnumber]$fullVersionString"
         displayName: Set NuGet Version to PR Version
         condition: and(succeeded(), eq(variables['build.reason'], 'PullRequest'))
-      - task: DotNetCoreCLI@2
-        displayName: 'Check Dependencies'
-        inputs:
-          command: 'custom'
-          custom: 'list'
-          arguments: 'package --vulnerable --include-transitive'
-          projects: $(PathToSolution)
       # test
       - task: DotNetCoreCLI@2
         displayName: 'Run Unit Tests'
@@ -114,6 +107,14 @@ jobs:
           solution: '$(PathToCommunityToolkitCsproj)'
           configuration: 'Release'
           msbuildArgs: '/restore -t:pack -p:PackageVersion=$(NugetPackageVersion) -p:Version=$(NugetPackageVersion) -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg'
+      # check vulnerabilities
+      - task: DotNetCoreCLI@2
+        displayName: 'Check Dependencies'
+        inputs:
+          command: 'custom'
+          custom: 'list'
+          arguments: 'package --vulnerable --include-transitive'
+          projects: $(PathToSolution)
       # publish
       - task: PowerShell@2
         displayName: 'Copy NuGet Packages to Staging Directory'

--- a/src/CommunityToolkit.Maui.UnitTests/CommunityToolkit.Maui.UnitTests.csproj
+++ b/src/CommunityToolkit.Maui.UnitTests/CommunityToolkit.Maui.UnitTests.csproj
@@ -11,8 +11,15 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.5.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Xunit" Version="2.4.1" />
-    <PackageReference Include="Xunit.Runner.VisualStudio" Version="2.4.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adds code coverage tab with the report:
https://dev.azure.com/dotnet/CommunityToolkit/_build/results?buildId=69366&view=codecoverage-tab
![image](https://user-images.githubusercontent.com/33021114/161241858-30b29cd7-42ce-4495-98cc-1b271535e493.png)
