### PR TITLE
`ListToStringConverter`: Remove Unused Null Coalescing Operator + Update XML Documentation

### DIFF
--- a/src/CommunityToolkit.Maui.UnitTests/Converters/ListToStringConverter_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/ListToStringConverter_Tests.cs
@@ -28,6 +28,17 @@ public class ListToStringConverter_Tests : BaseTest
 		Assert.Equal(expectedResult, convertFromResult);
 	}
 
+	[Fact]
+	public void NullSeparatorValueThrowArgumentNullException()
+	{
+		var listToStringConverter = new ListToStringConverter();
+
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => listToStringConverter.Separator = null);
+		Assert.Throws<ArgumentNullException>(() => new ListToStringConverter { Separator = null });
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
 	[Theory]
 	[InlineData(0)]
 	[InlineData(5.5)]

--- a/src/CommunityToolkit.Maui/Converters/ListToStringConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ListToStringConverter.shared.cs
@@ -9,7 +9,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class ListToStringConverter : BaseConverterOneWay<IEnumerable, string>
 {
 	/// <summary>
-	/// The separator value that separates each item in the collection
+	/// The value that separates each item in the collection
 	/// This value is superceded by the ConverterParameter, if provided
 	/// If ConverterParameter is null, this Separator property will be used for the <see cref="ListToStringConverter"/>
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/ListToStringConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ListToStringConverter.shared.cs
@@ -9,7 +9,9 @@ namespace CommunityToolkit.Maui.Converters;
 public class ListToStringConverter : BaseConverterOneWay<IEnumerable, string>
 {
 	/// <summary>
-	/// The separator that should be between each item in the collection
+	/// The separator value that separates each item in the collection
+	/// This value is superceded by the ConverterParameter, if provided
+	/// If ConverterParameter is null, this Separator property will be used for the <see cref="ListToStringConverter"/>
 	/// </summary>
 	public string Separator { get; set; } = string.Empty;
 
@@ -25,7 +27,7 @@ public class ListToStringConverter : BaseConverterOneWay<IEnumerable, string>
 	{
 		ArgumentNullException.ThrowIfNull(value);
 
-		parameter ??= Separator; // if parameter is not assigned (aka parameter is null), default to the Separator property. 
+		parameter ??= Separator; // if the ConverterParameter is not assigned (aka parameter is null), we will default to the Separator property. 
 
 		if (parameter is not string separator)
 		{

--- a/src/CommunityToolkit.Maui/Converters/ListToStringConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ListToStringConverter.shared.cs
@@ -25,7 +25,9 @@ public class ListToStringConverter : BaseConverterOneWay<IEnumerable, string>
 	{
 		ArgumentNullException.ThrowIfNull(value);
 
-		if ((parameter ?? Separator ?? string.Empty) is not string separator)
+		parameter ??= Separator; // if parameter is not assigned (aka parameter is null), default to the Separator property. 
+
+		if (parameter is not string separator)
 		{
 			throw new ArgumentException("Parameter cannot be casted to string", nameof(parameter));
 		}

--- a/src/CommunityToolkit.Maui/Converters/ListToStringConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ListToStringConverter.shared.cs
@@ -8,12 +8,18 @@ namespace CommunityToolkit.Maui.Converters;
 /// </summary>
 public class ListToStringConverter : BaseConverterOneWay<IEnumerable, string>
 {
+	string separator = string.Empty;
+
 	/// <summary>
 	/// The value that separates each item in the collection
 	/// This value is superceded by the ConverterParameter, if provided
 	/// If ConverterParameter is null, this Separator property will be used for the <see cref="ListToStringConverter"/>
 	/// </summary>
-	public string Separator { get; set; } = string.Empty;
+	public string Separator
+	{
+		get => separator;
+		set => separator = value ?? throw new ArgumentNullException(nameof(value));
+	}
 
 	/// <summary>
 	/// Concatenates the items of a collection, using the specified <see cref="Separator"/> between each item. On each item ToString() will be called.

--- a/src/CommunityToolkit.Maui/Converters/ListToStringConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ListToStringConverter.shared.cs
@@ -12,7 +12,7 @@ public class ListToStringConverter : BaseConverterOneWay<IEnumerable, string>
 
 	/// <summary>
 	/// The value that separates each item in the collection
-	/// This value is superceded by the ConverterParameter, if provided
+	/// This value is superseded by the ConverterParameter, if provided
 	/// If ConverterParameter is null, this Separator property will be used for the <see cref="ListToStringConverter"/>
 	/// </summary>
 	public string Separator


### PR DESCRIPTION
 ### Description of Change ###

This PR updates `ListToStringConverter`, to ensure ``public string Separator { get; set; }` cannot be `null`. 

In the `ConvertFrom` logic, we can then remove the unused `??` and adding a comment explaining that the `object? parameter` takes precedence over `public string Separator { get; set; }`.

This PR also updates the XML Documentation for `public string Separator { get; set; }` to better help the user understand the order of precedence between `object? parameter` and `public string Separator { get; set; }`.


 ### Additional information ###

These updates are inspired by the documentation for `ListToStringConverter`: https://github.com/MicrosoftDocs/CommunityToolkit/blob/73bd78afad79aa07c9c8329119ca45b5688d54d4/docs/maui/converters/list-to-string-converter.md
