### PR TITLE
Add `Null` Validation to `Toast` and `Snackbar`

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Primitives/Defaults.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Primitives/Defaults.shared.cs
@@ -5,6 +5,7 @@ namespace CommunityToolkit.Maui.Core;
 /// <summary>
 /// Default Values for CommunityToolkit.Maui
 /// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
 public static class Defaults
 {
 	/// <summary>

--- a/src/CommunityToolkit.Maui.Core/Primitives/Defaults.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Primitives/Defaults.shared.cs
@@ -21,6 +21,12 @@ public static class Defaults
 	public const double CharacterSpacing = 0.0d;
 
 	/// <summary>
+	/// Default Character Spacing
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public const string ActionButtonText = "OK";
+
+	/// <summary>
 	/// Default Text Color
 	/// </summary>
 	[EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/CommunityToolkit.Maui.UnitTests/Alerts/Snackbar_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Alerts/Snackbar_Tests.cs
@@ -19,7 +19,7 @@ public class Snackbar_Tests : BaseTest
 	public void SnackbarDefautValues()
 	{
 		Assert.Null(snackbar.Action);
-		Assert.Equal(Snackbar.defaultActionButtonText, snackbar.ActionButtonText);
+		Assert.Equal(Defaults.ActionButtonText, snackbar.ActionButtonText);
 		Assert.Null(snackbar.Anchor);
 		Assert.Equal(Snackbar.GetDefaultTimeSpan(), snackbar.Duration);
 		Assert.Equal(string.Empty, snackbar.Text);

--- a/src/CommunityToolkit.Maui.UnitTests/Alerts/Snackbar_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Alerts/Snackbar_Tests.cs
@@ -155,4 +155,17 @@ public class Snackbar_Tests : BaseTest
 	{
 		await snackbar.Invoking(x => x.Dismiss(CancellationToken.None)).Should().NotThrowAsync<OperationCanceledException>();
 	}
+
+	[Fact]
+	public void SnackbarNullValuesThrowArgumentNullException()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => new Snackbar { Text = null });
+		Assert.Throws<ArgumentNullException>(() => new Snackbar { ActionButtonText = null });
+		Assert.Throws<ArgumentNullException>(() => Snackbar.Make(null));
+		Assert.Throws<ArgumentNullException>(() => Snackbar.Make(string.Empty, actionButtonText: null));
+		Assert.ThrowsAsync<ArgumentNullException>(() => new Button().DisplaySnackbar(null));
+		Assert.ThrowsAsync<ArgumentNullException>(() => new Button().DisplaySnackbar(string.Empty, actionButtonText: null));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
 }

--- a/src/CommunityToolkit.Maui.UnitTests/Alerts/Snackbar_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Alerts/Snackbar_Tests.cs
@@ -16,6 +16,23 @@ public class Snackbar_Tests : BaseTest
 	}
 
 	[Fact]
+	public void SnackbarDefautValues()
+	{
+		Assert.Null(snackbar.Action);
+		Assert.Equal(Snackbar.defaultActionButtonText, snackbar.ActionButtonText);
+		Assert.Null(snackbar.Anchor);
+		Assert.Equal(Snackbar.GetDefaultTimeSpan(), snackbar.Duration);
+		Assert.Equal(string.Empty, snackbar.Text);
+
+		Assert.Equal(Font.SystemFontOfSize(Defaults.FontSize), snackbar.VisualOptions.ActionButtonFont);
+		Assert.Equal(Defaults.BackgroundColor, snackbar.VisualOptions.BackgroundColor);
+		Assert.Equal(Defaults.CharacterSpacing, snackbar.VisualOptions.CharacterSpacing);
+		Assert.Equal(new CornerRadius(4, 4, 4, 4), snackbar.VisualOptions.CornerRadius);
+		Assert.Equal(Font.SystemFontOfSize(Defaults.FontSize), snackbar.VisualOptions.Font);
+		Assert.Equal(Defaults.TextColor, snackbar.VisualOptions.TextColor);
+	}
+
+	[Fact]
 	public async Task SnackbarShow_IsShownTrue()
 	{
 		await snackbar.Show();

--- a/src/CommunityToolkit.Maui.UnitTests/Alerts/Toast_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Alerts/Toast_Tests.cs
@@ -16,14 +16,6 @@ public class Toast_Tests : BaseTest
 	}
 
 	[Fact]
-	public void ToastDefaultValues()
-	{
-		Assert.Equal(string.Empty, toast.Text);
-		Assert.Equal(ToastDuration.Short, toast.Duration);
-		Assert.Equal(Defaults.FontSize, toast.TextSize);
-	}
-
-	[Fact]
 	public void ToastMake_NewToastCreatedWithValidProperties()
 	{
 		var expectedToast = new Toast
@@ -92,6 +84,7 @@ public class Toast_Tests : BaseTest
 	{
 		toast.Text.Should().BeEmpty();
 		toast.Duration.Should().Be(ToastDuration.Short);
+		toast.TextSize.Should().Be(Defaults.FontSize);
 	}
 
 	[Fact]
@@ -99,6 +92,7 @@ public class Toast_Tests : BaseTest
 	{
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
 		Assert.Throws<ArgumentNullException>(() => Toast.Make(null));
+		Assert.Throws<ArgumentNullException>(() => new Toast { Text = null });
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 
@@ -110,6 +104,7 @@ public class Toast_Tests : BaseTest
 	public void ToastMake_NewToastCreatedWithInvalidToastDuration_ShouldThrowInvalidEnumArgumentException(int duration)
 	{
 		Assert.Throws<InvalidEnumArgumentException>(() => Toast.Make("Invalid Duration", (ToastDuration)duration));
+		Assert.Throws<InvalidEnumArgumentException>(() => new Toast { Duration = (ToastDuration)duration });
 	}
 
 	[Theory]
@@ -119,14 +114,6 @@ public class Toast_Tests : BaseTest
 	public void ToastMake_NewToastCreatedWithInvalidFontSize_ShouldThrowArgumentOutOfRangeException(int textSize)
 	{
 		Assert.Throws<ArgumentOutOfRangeException>(() => Toast.Make("Invalid text size", ToastDuration.Short, textSize));
-	}
-
-	[Fact]
-	public void ToastNullValuesThrowArgumentNullException()
-	{
-#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-		Assert.Throws<ArgumentNullException>(() => new Toast { Text = null });
-		Assert.Throws<ArgumentNullException>(() => Toast.Make(null));
-#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentOutOfRangeException>(() => new Toast { TextSize = textSize });
 	}
 }

--- a/src/CommunityToolkit.Maui.UnitTests/Alerts/Toast_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Alerts/Toast_Tests.cs
@@ -16,6 +16,14 @@ public class Toast_Tests : BaseTest
 	}
 
 	[Fact]
+	public void ToastDefaultValues()
+	{
+		Assert.Equal(string.Empty, toast.Text);
+		Assert.Equal(ToastDuration.Short, toast.Duration);
+		Assert.Equal(Defaults.FontSize, toast.TextSize);
+	}
+
+	[Fact]
 	public void ToastMake_NewToastCreatedWithValidProperties()
 	{
 		var expectedToast = new Toast

--- a/src/CommunityToolkit.Maui.UnitTests/Alerts/Toast_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Alerts/Toast_Tests.cs
@@ -112,4 +112,12 @@ public class Toast_Tests : BaseTest
 	{
 		Assert.Throws<ArgumentOutOfRangeException>(() => Toast.Make("Invalid text size", ToastDuration.Short, textSize));
 	}
+
+	[Fact]
+	public void ToastNullValuesThrowArgumentNullException()
+	{
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => new Toast { Text = null });
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
 }

--- a/src/CommunityToolkit.Maui.UnitTests/Alerts/Toast_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Alerts/Toast_Tests.cs
@@ -118,6 +118,7 @@ public class Toast_Tests : BaseTest
 	{
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
 		Assert.Throws<ArgumentNullException>(() => new Toast { Text = null });
+		Assert.Throws<ArgumentNullException>(() => Toast.Make(null));
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 }

--- a/src/CommunityToolkit.Maui/Alerts/Snackbar/SnackBar.shared.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Snackbar/SnackBar.shared.cs
@@ -14,11 +14,10 @@ namespace CommunityToolkit.Maui.Alerts;
 /// <inheritdoc/>
 public partial class Snackbar : ISnackbar
 {
-	internal const string defaultActionButtonText = "OK";
 	static readonly WeakEventManager weakEventManager = new();
 
 	string text = string.Empty;
-	string actionButtonText = defaultActionButtonText;
+	string actionButtonText = Defaults.ActionButtonText;
 
 	/// <summary>
 	/// Initializes a new instance of <see cref="Snackbar"/>
@@ -85,7 +84,7 @@ public partial class Snackbar : ISnackbar
 	public static ISnackbar Make(
 		string message,
 		Action? action = null,
-		string actionButtonText = defaultActionButtonText,
+		string actionButtonText = Defaults.ActionButtonText,
 		TimeSpan? duration = null,
 		SnackbarOptions? visualOptions = null,
 		IView? anchor = null)
@@ -206,7 +205,7 @@ public partial class Snackbar : ISnackbar
 public static class SnackbarVisualElementExtension
 {
 	/// <summary>
-	/// Display snackbar with the anchor
+	/// Display snackbar anchored to <see cref="VisualElement"/>
 	/// </summary>
 	/// <param name="visualElement">Anchor element</param>
 	/// <param name="message">Text of the snackbar</param>
@@ -219,7 +218,7 @@ public static class SnackbarVisualElementExtension
 		this VisualElement? visualElement,
 		string message,
 		Action? action = null,
-		string actionButtonText = Snackbar.defaultActionButtonText,
+		string actionButtonText = Defaults.ActionButtonText,
 		TimeSpan? duration = null,
 		SnackbarOptions? visualOptions = null,
 		CancellationToken token = default) => Snackbar.Make(message, action, actionButtonText, duration, visualOptions, visualElement).Show(token);

--- a/src/CommunityToolkit.Maui/Alerts/Snackbar/SnackBar.shared.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Snackbar/SnackBar.shared.cs
@@ -33,9 +33,6 @@ public partial class Snackbar : ISnackbar
 	public static bool IsShown { get; private set; }
 
 	/// <inheritdoc/>
-	public SnackbarOptions VisualOptions { get; init; }
-
-	/// <inheritdoc/>
 	public string Text
 	{
 		get => text;
@@ -48,6 +45,9 @@ public partial class Snackbar : ISnackbar
 		get => actionButtonText;
 		init => actionButtonText = value ?? throw new ArgumentNullException(nameof(value));
 	}
+
+	/// <inheritdoc/>
+	public SnackbarOptions VisualOptions { get; init; }
 
 	/// <inheritdoc/>
 	public TimeSpan Duration { get; init; }

--- a/src/CommunityToolkit.Maui/Alerts/Snackbar/SnackBar.shared.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Snackbar/SnackBar.shared.cs
@@ -90,9 +90,6 @@ public partial class Snackbar : ISnackbar
 		SnackbarOptions? visualOptions = null,
 		IView? anchor = null)
 	{
-		ArgumentNullException.ThrowIfNull(message);
-		ArgumentNullException.ThrowIfNull(actionButtonText);
-
 		return new Snackbar
 		{
 			Text = message,
@@ -225,11 +222,5 @@ public static class SnackbarVisualElementExtension
 		string actionButtonText = Snackbar.defaultActionButtonText,
 		TimeSpan? duration = null,
 		SnackbarOptions? visualOptions = null,
-		CancellationToken token = default)
-	{
-		ArgumentNullException.ThrowIfNull(message);
-		ArgumentNullException.ThrowIfNull(actionButtonText);
-
-		return Snackbar.Make(message, action, actionButtonText, duration, visualOptions, visualElement).Show(token);
-	}
+		CancellationToken token = default) => Snackbar.Make(message, action, actionButtonText, duration, visualOptions, visualElement).Show(token);
 }

--- a/src/CommunityToolkit.Maui/Alerts/Snackbar/SnackBar.shared.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Snackbar/SnackBar.shared.cs
@@ -114,6 +114,8 @@ public partial class Snackbar : ISnackbar
 	/// </summary>
 	public virtual Task Dismiss(CancellationToken token = default) => Dispatcher.GetForCurrentThread().DispatchIfRequiredAsync(() => DismissNative(token));
 
+	internal static TimeSpan GetDefaultTimeSpan() => TimeSpan.FromSeconds(3);
+
 #if !(IOS || ANDROID || MACCATALYST || WINDOWS)
 	/// <inheritdoc/>
 	private partial Task ShowNative(CancellationToken token)
@@ -159,8 +161,6 @@ public partial class Snackbar : ISnackbar
 		return ValueTask.CompletedTask;
 	}
 #endif
-
-	static TimeSpan GetDefaultTimeSpan() => TimeSpan.FromSeconds(3);
 
 #if ANDROID || IOS || MACCATALYST || WINDOWS
 

--- a/src/CommunityToolkit.Maui/Alerts/Snackbar/SnackBar.shared.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Snackbar/SnackBar.shared.cs
@@ -14,36 +14,46 @@ namespace CommunityToolkit.Maui.Alerts;
 /// <inheritdoc/>
 public partial class Snackbar : ISnackbar
 {
+	internal const string defaultActionButtonText = "OK";
 	static readonly WeakEventManager weakEventManager = new();
+
+	string text = string.Empty;
+	string actionButtonText = defaultActionButtonText;
 
 	/// <summary>
 	/// Initializes a new instance of <see cref="Snackbar"/>
 	/// </summary>
 	public Snackbar()
 	{
-		Text = string.Empty;
 		Duration = GetDefaultTimeSpan();
-		ActionButtonText = "OK";
 		VisualOptions = new SnackbarOptions();
 	}
+
+	/// <inheritdoc/>
+	public static bool IsShown { get; private set; }
 
 	/// <inheritdoc/>
 	public SnackbarOptions VisualOptions { get; init; }
 
 	/// <inheritdoc/>
-	public string Text { get; init; }
+	public string Text
+	{
+		get => text;
+		init => text = value ?? throw new ArgumentNullException(nameof(value));
+	}
+
+	/// <inheritdoc/>
+	public string ActionButtonText
+	{
+		get => actionButtonText;
+		init => actionButtonText = value ?? throw new ArgumentNullException(nameof(value));
+	}
 
 	/// <inheritdoc/>
 	public TimeSpan Duration { get; init; }
 
 	/// <inheritdoc/>
 	public Action? Action { get; init; }
-
-	/// <inheritdoc/>
-	public string ActionButtonText { get; init; }
-
-	/// <inheritdoc/>
-	public static bool IsShown { get; private set; }
 
 	/// <inheritdoc/>
 	public IView? Anchor { get; init; }
@@ -75,11 +85,14 @@ public partial class Snackbar : ISnackbar
 	public static ISnackbar Make(
 		string message,
 		Action? action = null,
-		string actionButtonText = "OK",
+		string actionButtonText = defaultActionButtonText,
 		TimeSpan? duration = null,
 		SnackbarOptions? visualOptions = null,
 		IView? anchor = null)
 	{
+		ArgumentNullException.ThrowIfNull(message);
+		ArgumentNullException.ThrowIfNull(actionButtonText);
+
 		return new Snackbar
 		{
 			Text = message,
@@ -209,8 +222,14 @@ public static class SnackbarVisualElementExtension
 		this VisualElement? visualElement,
 		string message,
 		Action? action = null,
-		string actionButtonText = "OK",
+		string actionButtonText = Snackbar.defaultActionButtonText,
 		TimeSpan? duration = null,
 		SnackbarOptions? visualOptions = null,
-		CancellationToken token = default) => Snackbar.Make(message, action, actionButtonText, duration, visualOptions, visualElement).Show(token);
+		CancellationToken token = default)
+	{
+		ArgumentNullException.ThrowIfNull(message);
+		ArgumentNullException.ThrowIfNull(actionButtonText);
+
+		return Snackbar.Make(message, action, actionButtonText, duration, visualOptions, visualElement).Show(token);
+	}
 }

--- a/src/CommunityToolkit.Maui/Alerts/Toast/Toast.shared.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Toast/Toast.shared.cs
@@ -14,8 +14,14 @@ namespace CommunityToolkit.Maui.Alerts;
 /// <inheritdoc/>
 public partial class Toast : IToast
 {
+	string text = string.Empty;
+
 	/// <inheritdoc/>
-	public string Text { get; init; } = string.Empty;
+	public string Text
+	{
+		get => text;
+		init => text = value ?? throw new ArgumentNullException(nameof(value));
+	}
 
 	/// <inheritdoc/>
 	public ToastDuration Duration { get; init; } = ToastDuration.Short;

--- a/src/CommunityToolkit.Maui/Alerts/Toast/Toast.shared.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Toast/Toast.shared.cs
@@ -15,6 +15,8 @@ namespace CommunityToolkit.Maui.Alerts;
 public partial class Toast : IToast
 {
 	string text = string.Empty;
+	ToastDuration duration = ToastDuration.Short;
+	double textSize = Defaults.FontSize;
 
 	/// <inheritdoc/>
 	public string Text
@@ -24,10 +26,34 @@ public partial class Toast : IToast
 	}
 
 	/// <inheritdoc/>
-	public ToastDuration Duration { get; init; } = ToastDuration.Short;
+	public ToastDuration Duration
+	{
+		get => duration;
+		init
+		{
+			if (!Enum.IsDefined(typeof(ToastDuration), value))
+			{
+				throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ToastDuration));
+			}
+
+			duration = value;
+		}
+	}
 
 	/// <inheritdoc/>
-	public double TextSize { get; init; } = Defaults.FontSize;
+	public double TextSize
+	{
+		get => textSize;
+		init
+		{
+			if (value <= 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(value), "Toast font size must be positive");
+			}
+
+			textSize = value;
+		}
+	}
 
 	/// <summary>
 	/// Create new Toast
@@ -40,19 +66,7 @@ public partial class Toast : IToast
 		string message,
 		ToastDuration duration = ToastDuration.Short,
 		double textSize = Defaults.FontSize)
-	{
-		ArgumentNullException.ThrowIfNull(message);
-
-		if (!Enum.IsDefined(typeof(ToastDuration), duration))
-		{
-			throw new InvalidEnumArgumentException(nameof(duration), (int)duration, typeof(ToastDuration));
-		}
-
-		if (textSize <= 0)
-		{
-			throw new ArgumentOutOfRangeException(nameof(textSize), "Toast font size must be positive");
-		}
-
+	{	
 		return new Toast
 		{
 			Text = message,


### PR DESCRIPTION
 ### Description of Change ###

This PR adds `null` validation checks for the following:
- `Snackbar.Text `
- `Snackbar.ActionButtonText `
- `Toast.Text `

This PR also added `ArgumentNullException` Unit Tests for these properties in `Snackbar_Tests` and `Toast_Tests`.

 ### Additional information ###

I added Unit Tests to verify both `Snackbar` and `Toast` default values.

I also added `[EditorBrowsable(EditorBrowsableState.Never)]` to `CommunityToolkit.Maui.Core.Defaults`
 
