### PR TITLE
Add `Popup.Color` Null Validation

### DIFF
--- a/src/CommunityToolkit.Maui.UnitTests/Views/PopupTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/PopupTests.cs
@@ -1,4 +1,5 @@
-﻿using CommunityToolkit.Maui.Core;
+﻿using System.ComponentModel;
+using CommunityToolkit.Maui.Core;
 using CommunityToolkit.Maui.UnitTests.Mocks;
 using CommunityToolkit.Maui.Views;
 using Xunit;
@@ -179,11 +180,48 @@ public class PopupTests : BaseHandlerTest
 		Assert.Null(result);
 	}
 
+	[Fact]
+	public void NullColorThrowsArgumentNullException()
+	{
+		var popupViewModel = new PopupViewModel();
+		var popupWithBinding = new Popup
+		{
+			BindingContext = popupViewModel
+		};
+		popupWithBinding.SetBinding(Popup.ColorProperty, nameof(PopupViewModel.Color));
+
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		Assert.Throws<ArgumentNullException>(() => new Popup { Color = null });
+		Assert.Throws<ArgumentNullException>(() => new Popup().Color = null);
+		Assert.Throws<ArgumentNullException>(() => popupViewModel.Color = null);
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
 	class MockPopup : Popup
 	{
 		public MockPopup()
 		{
 			ResultWhenUserTapsOutsideOfPopup = resultWhenUserTapsOutsideOfPopup;
+		}
+	}
+
+	class PopupViewModel : INotifyPropertyChanged
+	{
+		Color? color = new();
+
+		public event PropertyChangedEventHandler? PropertyChanged;
+
+		public Color? Color
+		{
+			get => color;
+			set
+			{
+				if(value != color)
+				{
+					color = value;
+					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Color)));
+				}
+			}
 		}
 	}
 

--- a/src/CommunityToolkit.Maui/Views/Popup/Popup.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/Popup.shared.cs
@@ -17,7 +17,7 @@ public partial class Popup : Element, IPopup
 	/// <summary>
 	///  Backing BindableProperty for the <see cref="Color"/> property.
 	/// </summary>
-	public static readonly BindableProperty ColorProperty = BindableProperty.Create(nameof(Color), typeof(Color), typeof(Popup), Colors.LightGray);
+	public static readonly BindableProperty ColorProperty = BindableProperty.Create(nameof(Color), typeof(Color), typeof(Popup), Colors.LightGray, propertyChanged: OnColorChanged);
 
 	/// <summary>
 	///  Backing BindableProperty for the <see cref="Size"/> property.
@@ -238,6 +238,11 @@ public partial class Popup : Element, IPopup
 	{
 		var popup = (Popup)bindable;
 		popup.OnBindingContextChanged();
+	}
+
+	static void OnColorChanged(BindableObject bindable, object oldValue, object newValue)
+	{
+		ArgumentNullException.ThrowIfNull(newValue);
 	}
 
 	void IPopup.OnClosed(object? result) => Handler.Invoke(nameof(IPopup.OnClosed), result);

--- a/src/CommunityToolkit.Maui/Views/WrapperControl.windows.cs
+++ b/src/CommunityToolkit.Maui/Views/WrapperControl.windows.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Maui.Platform;
+﻿using System;
+using Microsoft.Maui.Platform;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using WRect = Windows.Foundation.Rect;
@@ -13,6 +14,9 @@ class WrapperControl : Panel
 
 	public WrapperControl(View view, IMauiContext mauiContext)
 	{
+		ArgumentNullException.ThrowIfNull(view);
+		ArgumentNullException.ThrowIfNull(mauiContext);
+
 		this.view = view;
 		this.view.MeasureInvalidated += OnMeasureInvalidated;
 

--- a/src/CommunityToolkit.Maui/Views/WrapperControl.windows.cs
+++ b/src/CommunityToolkit.Maui/Views/WrapperControl.windows.cs
@@ -1,4 +1,3 @@
-﻿using System;
 using Microsoft.Maui.Platform;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;


### PR DESCRIPTION
### Description of Change ###

This PR ensures that `Popup.Color` cannot be set to `null`.

Because `Popup.Color` can be used as a bindable property, I implemented the `null` validation on `public static readonly BindableProperty ColorProperty` to ensure validation also happens if a `null` value is passed in via a binding.

 ### Additional information ###

I also added `ArgumentNullException.ThrowIfNull` to `WrapperControl` which is used by `Popup` on Windows.
