### PR TITLE
Update Sample App to `CommunityToolkit.Maui.Markup` v1.0.0-pre9

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/AppShell.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/AppShell.xaml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+﻿<?xml version="1.0" encoding="UTF-8" ?>
 
 <Shell x:Class="CommunityToolkit.Maui.Sample.AppShell"
        xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
@@ -10,7 +10,8 @@
        xmlns:layouts="clr-namespace:CommunityToolkit.Maui.Sample.Pages.Layouts"
        xmlns:pages="clr-namespace:CommunityToolkit.Maui.Sample.Pages"
        xmlns:views="clr-namespace:CommunityToolkit.Maui.Sample.Pages.Views"
-       xmlns:sys="clr-namespace:System;assembly=netstandard">
+       xmlns:sys="clr-namespace:System;assembly=netstandard"
+       Padding="4,0,0,0">
 
     <Shell.FlyoutHeader>
         <Label Margin="{OnPlatform Default='0,0,0,12',

--- a/samples/CommunityToolkit.Maui.Sample/CommunityToolkit.Maui.Sample.csproj
+++ b/samples/CommunityToolkit.Maui.Sample/CommunityToolkit.Maui.Sample.csproj
@@ -38,7 +38,7 @@
     <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
 
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0-preview3" />
-    <PackageReference Include="CommunityToolkit.Maui.Markup" Version="1.0.0-pre8" />
+    <PackageReference Include="CommunityToolkit.Maui.Markup" Version="1.0.0-pre9" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
   </ItemGroup>
 

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Base/BaseGalleryPage.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Base/BaseGalleryPage.cs
@@ -40,12 +40,10 @@ public abstract class BaseGalleryPage<TViewModel> : BasePage<TViewModel> where T
 		var collectionView = (CollectionView)sender;
 		collectionView.SelectedItem = null;
 
-		if (e.CurrentSelection.FirstOrDefault() is not SectionModel sectionModel)
+		if (e.CurrentSelection.FirstOrDefault() is SectionModel sectionModel)
 		{
-			return;
+			await Shell.Current.GoToAsync(AppShell.GetPageRoute(sectionModel.ViewModelType));
 		}
-
-		await Shell.Current.GoToAsync(AppShell.GetPageRoute(sectionModel.ViewModelType));
 	}
 
 	class GalleryDataTemplate : DataTemplate
@@ -62,25 +60,25 @@ public abstract class BaseGalleryPage<TViewModel> : BasePage<TViewModel> where T
 		{
 			RowDefinitions = Rows.Define(
 				(Row.TopPadding, 12),
-				(Row.Content, GridLength.Star),
+				(Row.Content, Star),
 				(Row.BottomPadding, 12)),
 
 			ColumnDefinitions = Columns.Define(
 				(Column.LeftPadding, 24),
-				(Column.Content, GridLength.Star),
+				(Column.Content, Star),
 				(Column.RightPadding, 24)),
 
 			Children =
 			{
 				new Card().Row(Row.Content).Column(Column.Content)
 			}
-		}.DynamicResource(Grid.BackgroundColorProperty, "AppBackgroundColor");
+		}.DynamicResource(BackgroundColorProperty, "AppBackgroundColor");
 
 		class Card : Frame
 		{
 			public Card()
 			{
-				SetDynamicResource(Card.StyleProperty, "card");
+				SetDynamicResource(StyleProperty, "card");
 
 				Content = new Grid
 				{
@@ -88,13 +86,14 @@ public abstract class BaseGalleryPage<TViewModel> : BasePage<TViewModel> where T
 
 					RowDefinitions = Rows.Define(
 						(CardRow.Title, 24),
-						(CardRow.Description, GridLength.Auto)),
+						(CardRow.Description, Auto)),
 
-					ColumnDefinitions = Columns.Define(GridLength.Star),
+					ColumnDefinitions = Columns.Define(Star),
 
 					Children =
 					{
-						new Label { Style = (Style)(Application.Current?.Resources["label_section_header"] ?? throw new InvalidOperationException()) }
+						new Label()
+							.DynamicResource(StyleProperty, "label_section_header")
 							.Row(CardRow.Title)
 							.Bind(Label.TextProperty, nameof(SectionModel.Title)),
 

--- a/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
@@ -141,12 +141,18 @@ public class MauiPopup : UIViewController
 
 	sealed class PopoverDelegate : UIPopoverPresentationControllerDelegate
 	{
-		public event EventHandler<UIPresentationController>? PopoverDismissedEvent;
+		readonly WeakEventManager popoverDismissedEventmanager = new();
+
+		public event EventHandler<UIPresentationController> PopoverDismissedEvent
+		{
+			add => popoverDismissedEventmanager.AddEventHandler(value);
+			remove => popoverDismissedEventmanager.RemoveEventHandler(value);
+		}
 
 		public override UIModalPresentationStyle GetAdaptivePresentationStyle(UIPresentationController forPresentationController) =>
 			UIModalPresentationStyle.None;
 
 		public override void DidDismiss(UIPresentationController presentationController) =>
-			PopoverDismissedEvent?.Invoke(this, presentationController);
+			popoverDismissedEventmanager.HandleEvent(this, presentationController, nameof(PopoverDismissedEvent));
 	}
 }


### PR DESCRIPTION
 ### Description of Change ###

This PR updates the Sample App to use `CommunityToolkit.Maui.Markup` v1.0.0-pre9.
 
 ### Additional information ###

It also adds `WeakEventManager` to `MauiPopup.PopoverDelegate.PopoverDismissedEvent` now that `WeakEventManager` lives in the `Microsoft.Maui` namespace.

(`WeakEventManager ` was previously in the `Microsoft.Maui.Controls` namespace).