### PR TITLE
Changed PopupHandler.PropertyMapper -> IPropertyMapper

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Handlers/Popup/PopupHandler.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Handlers/Popup/PopupHandler.shared.cs
@@ -8,7 +8,7 @@ public partial class PopupHandler
 	/// <summary>
 	/// PropertyMapper for Popup Control
 	/// </summary>
-	public static PropertyMapper<IPopup, PopupHandler> PopUpMapper = new(ElementMapper)
+	public static IPropertyMapper<IPopup, PopupHandler> PopUpMapper = new PropertyMapper<IPopup, PopupHandler>(ElementMapper)
 	{
 		[nameof(IPopup.Anchor)] = MapAnchor,
 		[nameof(IPopup.Color)] = MapColor,
@@ -35,7 +35,7 @@ public partial class PopupHandler
 	/// </summary>
 	/// <param name="mapper">Custom instance of <see cref="PropertyMapper"/>, if it's null the <see cref="PopUpMapper"/> will be used</param>
 	/// <param name="commandMapper">Custom instance of <see cref="CommandMapper"/>, if it's null the <see cref="PopUpCommandMapper"/> will be used</param>
-	public PopupHandler(PropertyMapper? mapper, CommandMapper? commandMapper)
+	public PopupHandler(IPropertyMapper? mapper, CommandMapper? commandMapper)
 		: base(mapper ?? PopUpMapper, commandMapper ?? PopUpCommandMapper)
 	{
 	}


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

On `Core` we should use the abstractions when it's possible. During the implementation of `PopupView` we missed a small detail, we're using `PropertyMapper` instead of `IPropertyMapper`

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #368 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [x] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
