### PR TITLE
Handle Generic Implementations of `ITextStyle` by TextColorToGenerator 

### DIFF
--- a/src/CommunityToolkit.Maui.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.CodeAnalysis;
-
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
 namespace CommunityToolkit.Maui.SourceGenerators.Extensions;
 
 static class NamespaceSymbolExtensions
@@ -25,5 +27,125 @@ static class NamespaceSymbolExtensions
 				}
 			}
 		}
+	}
+	
+	public static string GetFullTypeString(this INamedTypeSymbol type) => 
+		type.Name + 
+		(type.NullableAnnotation == NullableAnnotation.Annotated ? "?" : string.Empty) +
+		type.TypeArguments.GetGenericTypeArgumentsString();
+
+	public static string GetGenericTypeArgumentsString(this IEnumerable<ITypeSymbol> typeArguments)
+	{
+		string result = string.Empty;
+
+		if (!typeArguments.Any())
+		{
+			return result;
+		}
+
+		result += "<";
+
+		bool isFirstArgument = true;
+		foreach (ITypeSymbol typeArg in typeArguments)
+		{
+			if (isFirstArgument)
+			{
+				isFirstArgument = false;
+			}
+			else
+			{
+				result += ", ";
+			}
+
+			switch (typeArg)
+			{
+				case ITypeParameterSymbol typeParameterSymbol:
+					result += typeParameterSymbol.Name;
+					break;
+				case INamedTypeSymbol namedTypeSymbol:
+					result += namedTypeSymbol.GetFullTypeString();
+					break;
+				default:
+					//Maybe should handle this somehow, maybe inject SourceProductionContext and call ReportDiagnostic on it?
+					break;
+			}
+
+		}
+
+		result += ">";
+
+		return result;
+	}
+
+	public static string GetWhereStatement(this INamedTypeSymbol type)
+	{
+		string result = string.Empty;
+		if (!type.TypeParameters.Any())
+		{
+			return result;
+		}
+
+		foreach (var typeParameterSymbol in type.TypeParameters)
+		{
+			string constraints = "";
+
+			bool isFirstConstraint = true;
+
+			if (typeParameterSymbol.HasNotNullConstraint)
+			{
+				constraints += "notnull";
+
+				isFirstConstraint = false;
+			}
+			else if (typeParameterSymbol.HasUnmanagedTypeConstraint)
+			{
+				constraints += "unmanaged";
+
+				isFirstConstraint = false;
+			}
+			else if (typeParameterSymbol.HasReferenceTypeConstraint)
+			{
+				constraints += "class";
+
+				isFirstConstraint = false;
+			}
+			else if (typeParameterSymbol.HasValueTypeConstraint)
+			{
+				constraints += "struct";
+
+				isFirstConstraint = false;
+			}
+
+			foreach (INamedTypeSymbol contstraintType in typeParameterSymbol.ConstraintTypes)
+			{
+				if (!isFirstConstraint)
+				{
+					constraints += ", ";
+				}
+				else
+				{
+					isFirstConstraint = false;
+				}
+
+				constraints += contstraintType.GetFullTypeString();
+			}
+
+			if (typeParameterSymbol.HasConstructorConstraint)
+			{
+				if (!isFirstConstraint)
+				{
+					constraints += ", ";
+				}
+				constraints += "new()";
+			}
+
+			if (!string.IsNullOrEmpty(constraints))
+			{
+				result += "where " + typeParameterSymbol.Name + " : " + constraints + @"
+";
+			}
+		}
+
+		return result;
 	}
 }

--- a/src/CommunityToolkit.Maui.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.CodeAnalysis;
+
 namespace CommunityToolkit.Maui.SourceGenerators.Extensions;
 
 static class NamespaceSymbolExtensions
@@ -103,6 +104,11 @@ static class NamespaceSymbolExtensions
 			else if (typeParameterSymbol.HasReferenceTypeConstraint)
 			{
 				constraints += "class";
+
+				if (typeParameterSymbol.ReferenceTypeConstraintNullableAnnotation == NullableAnnotation.Annotated)
+				{
+					constraints += "?";
+				}
 
 				isFirstConstraint = false;
 			}

--- a/src/CommunityToolkit.Maui.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
@@ -1,7 +1,4 @@
 ﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 namespace CommunityToolkit.Maui.SourceGenerators.Extensions;
 
 static class NamespaceSymbolExtensions

--- a/src/CommunityToolkit.Maui.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
@@ -27,8 +27,8 @@ static class NamespaceSymbolExtensions
 			}
 		}
 	}
-	
-	public static string GetFullTypeString(this INamedTypeSymbol type) => 
+
+	public static string GetFullTypeString(this INamedTypeSymbol type) =>
 		$"{type.Name}{(type.NullableAnnotation == NullableAnnotation.Annotated ? "?" : string.Empty)}{type.TypeArguments.GetGenericTypeArgumentsString()}";
 
 	public static string GetGenericTypeArgumentsString(this IEnumerable<ITypeSymbol> typeArguments)
@@ -39,7 +39,7 @@ static class NamespaceSymbolExtensions
 		}
 
 		StringBuilder result = new StringBuilder("<");
-		
+
 		bool isFirstArgument = true;
 		foreach (ITypeSymbol typeArg in typeArguments)
 		{
@@ -74,7 +74,7 @@ static class NamespaceSymbolExtensions
 
 	public static string GetWhereStatement(this INamedTypeSymbol type)
 	{
-		
+
 		if (!type.TypeParameters.Any())
 		{
 			return string.Empty;
@@ -84,9 +84,9 @@ static class NamespaceSymbolExtensions
 		StringBuilder constraints = new StringBuilder();
 		foreach (var typeParameterSymbol in type.TypeParameters)
 		{
-			
+
 			bool isFirstConstraint = true;
-			
+
 			if (typeParameterSymbol.HasNotNullConstraint)
 			{
 				constraints.Append("notnull");
@@ -143,15 +143,13 @@ static class NamespaceSymbolExtensions
 			if (constraints.Length > 0)
 			{
 				result.Append($"where " + typeParameterSymbol.Name + " : " + constraints + @"
-"); 
+");
 				constraints.Clear();
 			}
 		}
 
 		return result.ToString();
 	}
-	
-}
 
 	public static bool ContainsSymbolBaseType(this IEnumerable<INamedTypeSymbol> namedSymbolList, INamedTypeSymbol symbol)
 	{

--- a/src/CommunityToolkit.Maui.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
@@ -72,19 +72,23 @@ static class NamespaceSymbolExtensions
 		return result.ToString();
 	}
 
-	public static string GetWhereStatement(this INamedTypeSymbol type)
+	/// <summary>
+	/// Find all generic type constraints for <see cref="INamedTypeSymbol"/> and return the results as a complete string
+	/// </summary>
+	/// <param name="type"></param>
+	/// <returns>A text string contiaining all Generic Type Constraints for <see cref="INamedTypeSymbol"/, eg "where T : ITextStyle, notnull". Returns <see cref="string.Empty"/> if no generic type constrants found</returns>
+	public static string GetGenericTypeConstraintsAsText(this INamedTypeSymbol type)
 	{
-
 		if (!type.TypeParameters.Any())
 		{
 			return string.Empty;
 		}
 
-		StringBuilder result = new StringBuilder();
-		StringBuilder constraints = new StringBuilder();
+		StringBuilder result = new();
+		StringBuilder constraints = new();
+
 		foreach (var typeParameterSymbol in type.TypeParameters)
 		{
-
 			bool isFirstConstraint = true;
 
 			if (typeParameterSymbol.HasNotNullConstraint)
@@ -117,7 +121,7 @@ static class NamespaceSymbolExtensions
 				isFirstConstraint = false;
 			}
 
-			foreach (INamedTypeSymbol contstraintType in typeParameterSymbol.ConstraintTypes)
+			foreach (INamedTypeSymbol contstraintType in typeParameterSymbol.ConstraintTypes.Cast<INamedTypeSymbol>())
 			{
 				if (!isFirstConstraint)
 				{

--- a/src/CommunityToolkit.Maui.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
@@ -77,7 +77,7 @@ static class NamespaceSymbolExtensions
 	/// </summary>
 	/// <param name="type"></param>
 	/// <returns>A text string contiaining all Generic Type Constraints for <see cref="INamedTypeSymbol"/, eg "where T : ITextStyle, notnull". Returns <see cref="string.Empty"/> if no generic type constrants found</returns>
-	public static string GetGenericTypeConstraintsAsText(this INamedTypeSymbol type)
+	public static string GetGenericTypeConstraintsAsString(this INamedTypeSymbol type)
 	{
 		if (!type.TypeParameters.Any())
 		{

--- a/src/CommunityToolkit.Maui.SourceGenerators/Generators/TextColorToGenerator.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Generators/TextColorToGenerator.cs
@@ -57,7 +57,7 @@ class TextColorToGenerator : IIncrementalGenerator
 
 		foreach (var namedTypeSymbol in mauiTextStyleImplementors)
 		{
-			textStyleClassList.Add((namedTypeSymbol.Name, "public", namedTypeSymbol.ContainingNamespace.ToDisplayString(), namedTypeSymbol.TypeArguments.GetGenericTypeArgumentsString(), namedTypeSymbol.GetGenericTypeConstraintsAsText()));
+			textStyleClassList.Add((namedTypeSymbol.Name, "public", namedTypeSymbol.ContainingNamespace.ToDisplayString(), namedTypeSymbol.TypeArguments.GetGenericTypeArgumentsString(), namedTypeSymbol.GetGenericTypeConstraintsAsString()));
 		}
 
 		// Collect All Classes in User Library that Implement ITextStyle
@@ -98,7 +98,7 @@ class TextColorToGenerator : IIncrementalGenerator
 					continue;
 				}
 
-				textStyleClassList.Add((declarationSymbol.Name, accessModifier, nameSpace, declarationSymbol.TypeArguments.GetGenericTypeArgumentsString(), declarationSymbol.GetGenericTypeConstraintsAsText()));
+				textStyleClassList.Add((declarationSymbol.Name, accessModifier, nameSpace, declarationSymbol.TypeArguments.GetGenericTypeArgumentsString(), declarationSymbol.GetGenericTypeConstraintsAsString()));
 			}
 		}
 

--- a/src/CommunityToolkit.Maui.SourceGenerators/Generators/TextColorToGenerator.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Generators/TextColorToGenerator.cs
@@ -49,7 +49,7 @@ class TextColorToGenerator : IIncrementalGenerator
 			return;
 		}
 
-		var textStyleClassList = new List<(string ClassName, string ClassAcessModifier, string Namespace)>();
+		var textStyleClassList = new List<(string ClassName, string ClassAcessModifier, string Namespace, string GenericArguments, string WhereStatement)>();
 
 		// Collect Microsoft.Maui.Controls that Implement ITextStyle
 		var mauiTextStyleImplementors = mauiControlsAssemblySymbolProvider.GlobalNamespace.GetNamedTypeSymbols().Where(x => x.AllInterfaces.Contains(textStyleSymbol, SymbolEqualityComparer.Default)
@@ -57,7 +57,7 @@ class TextColorToGenerator : IIncrementalGenerator
 
 		foreach (var namedTypeSymbol in mauiTextStyleImplementors)
 		{
-			textStyleClassList.Add((namedTypeSymbol.Name, "public", namedTypeSymbol.ContainingNamespace.ToDisplayString()));
+			textStyleClassList.Add((namedTypeSymbol.Name, "public", namedTypeSymbol.ContainingNamespace.ToDisplayString(), namedTypeSymbol.TypeArguments.GetGenericTypeArgumentsString(), namedTypeSymbol.GetWhereStatement()));
 		}
 
 		// Collect All Classes in User Library that Implement ITextStyle
@@ -91,7 +91,7 @@ class TextColorToGenerator : IIncrementalGenerator
 					continue;
 				}
 
-				textStyleClassList.Add((declarationSymbol.Name, accessModifier, nameSpace));
+				textStyleClassList.Add((declarationSymbol.Name, accessModifier, nameSpace, declarationSymbol.TypeArguments.GetGenericTypeArgumentsString(), declarationSymbol.GetWhereStatement()));
 			}
 		}
 
@@ -124,7 +124,8 @@ namespace " + textStyleClass.Namespace + @";
 	/// <param name=""length"">The duration, in milliseconds, of the animation</param>
 	/// <param name=""easing"">The easing function to be used in the animation</param>
 	/// <returns>Value indicating if the animation completed successfully or not</returns>
-	public static Task<bool> TextColorTo(this " + textStyleClass.Namespace + "." + textStyleClass.ClassName + @" element, Color color, uint rate = 16u, uint length = 250u, Easing? easing = null)
+	public static Task<bool> TextColorTo" + textStyleClass.GenericArguments + "(this " + textStyleClass.Namespace + "." + textStyleClass.ClassName + textStyleClass.GenericArguments + @" element, Color color, uint rate = 16u, uint length = 250u, Easing? easing = null)
+" + textStyleClass.WhereStatement + @"
 	{
 		ArgumentNullException.ThrowIfNull(element);
 		ArgumentNullException.ThrowIfNull(color);
@@ -160,16 +161,16 @@ namespace " + textStyleClass.Namespace + @";
 		return animationCompletionSource.Task;
 
 
-		static Animation GetRedTransformAnimation(" + textStyleClass.Namespace + "." + textStyleClass.ClassName + @"  element, float targetRed) =>
+		static Animation GetRedTransformAnimation(" + textStyleClass.Namespace + "." + textStyleClass.ClassName + textStyleClass.GenericArguments + @"  element, float targetRed) =>
 			new(v => element.TextColor = element.TextColor.WithRed(v), element.TextColor.Red, targetRed);
 
-		static Animation GetGreenTransformAnimation(" + textStyleClass.Namespace + "." + textStyleClass.ClassName + @"  element, float targetGreen) =>
+		static Animation GetGreenTransformAnimation(" + textStyleClass.Namespace + "." + textStyleClass.ClassName + textStyleClass.GenericArguments + @"  element, float targetGreen) =>
 			new(v => element.TextColor = element.TextColor.WithGreen(v), element.TextColor.Green, targetGreen);
 
-		static Animation GetBlueTransformAnimation(" + textStyleClass.Namespace + "." + textStyleClass.ClassName + @"  element, float targetBlue) =>
+		static Animation GetBlueTransformAnimation(" + textStyleClass.Namespace + "." + textStyleClass.ClassName + textStyleClass.GenericArguments + @"  element, float targetBlue) =>
 			new(v => element.TextColor = element.TextColor.WithBlue(v), element.TextColor.Blue, targetBlue);
 
-		static Animation GetAlphaTransformAnimation(" + textStyleClass.Namespace + "." + textStyleClass.ClassName + @"  element, float targetAlpha) =>
+		static Animation GetAlphaTransformAnimation(" + textStyleClass.Namespace + "." + textStyleClass.ClassName + textStyleClass.GenericArguments + @"  element, float targetAlpha) =>
 			new(v => element.TextColor = element.TextColor.WithAlpha((float)v), element.TextColor.Alpha, targetAlpha);
 	}
 }";

--- a/src/CommunityToolkit.Maui.SourceGenerators/Generators/TextColorToGenerator.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Generators/TextColorToGenerator.cs
@@ -49,7 +49,7 @@ class TextColorToGenerator : IIncrementalGenerator
 			return;
 		}
 
-		var textStyleClassList = new List<(string ClassName, string ClassAcessModifier, string Namespace, string GenericArguments, string WhereStatement)>();
+		var textStyleClassList = new List<(string ClassName, string ClassAcessModifier, string Namespace, string GenericArguments, string GenericConstraints)>();
 
 		// Collect Microsoft.Maui.Controls that Implement ITextStyle
 		var mauiTextStyleImplementors = mauiControlsAssemblySymbolProvider.GlobalNamespace.GetNamedTypeSymbols().Where(x => x.AllInterfaces.Contains(textStyleSymbol, SymbolEqualityComparer.Default)
@@ -132,7 +132,7 @@ namespace " + textStyleClass.Namespace + @";
 	/// <param name=""easing"">The easing function to be used in the animation</param>
 	/// <returns>Value indicating if the animation completed successfully or not</returns>
 	public static Task<bool> TextColorTo" + textStyleClass.GenericArguments + "(this " + textStyleClass.Namespace + "." + textStyleClass.ClassName + textStyleClass.GenericArguments + @" element, Color color, uint rate = 16u, uint length = 250u, Easing? easing = null)
-" + textStyleClass.WhereStatement + @"
+" + textStyleClass.GenericConstraints + @"
 	{
 		ArgumentNullException.ThrowIfNull(element);
 		ArgumentNullException.ThrowIfNull(color);

--- a/src/CommunityToolkit.Maui.SourceGenerators/Generators/TextColorToGenerator.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Generators/TextColorToGenerator.cs
@@ -57,7 +57,7 @@ class TextColorToGenerator : IIncrementalGenerator
 
 		foreach (var namedTypeSymbol in mauiTextStyleImplementors)
 		{
-			textStyleClassList.Add((namedTypeSymbol.Name, "public", namedTypeSymbol.ContainingNamespace.ToDisplayString(), namedTypeSymbol.TypeArguments.GetGenericTypeArgumentsString(), namedTypeSymbol.GetWhereStatement()));
+			textStyleClassList.Add((namedTypeSymbol.Name, "public", namedTypeSymbol.ContainingNamespace.ToDisplayString(), namedTypeSymbol.TypeArguments.GetGenericTypeArgumentsString(), namedTypeSymbol.GetGenericTypeConstraintsAsText()));
 		}
 
 		// Collect All Classes in User Library that Implement ITextStyle
@@ -98,7 +98,7 @@ class TextColorToGenerator : IIncrementalGenerator
 					continue;
 				}
 
-				textStyleClassList.Add((declarationSymbol.Name, accessModifier, nameSpace, declarationSymbol.TypeArguments.GetGenericTypeArgumentsString(), declarationSymbol.GetWhereStatement()));
+				textStyleClassList.Add((declarationSymbol.Name, accessModifier, nameSpace, declarationSymbol.TypeArguments.GetGenericTypeArgumentsString(), declarationSymbol.GetGenericTypeConstraintsAsText()));
 			}
 		}
 

--- a/src/CommunityToolkit.Maui.UnitTests/Extensions/TextColorTo_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Extensions/TextColorTo_Tests.cs
@@ -87,6 +87,34 @@ namespace CommunityToolkit.Maui.UnitTests.Extensions
 			await Assert.ThrowsAsync<ArgumentNullException>(() => label.TextColorTo(null));
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 		}
+
+		[Fact]
+		public async Task Extensions_For_Generic_Class()
+		{
+			Color originalTextColor = Colors.Blue, updatedTextColor = Colors.Red;
+
+			var textStyleView = new GenericPicker<
+				ClassConstraintWithInterface, 
+				ClassConstraint,
+				StructConstraint,
+				ClassConstraintWithInterface,
+				string,
+				int,
+				bool,
+				ClassConstraintWithInterface?,
+				ClassConstraint?,
+				ClassConstraintWithInterface,
+				ClassConstraint
+			> { TextColor = originalTextColor };
+			textStyleView.EnableAnimations();
+
+			Assert.Equal(originalTextColor, textStyleView.TextColor);
+
+			var isSuccessful = await textStyleView.TextColorTo(updatedTextColor);
+
+			Assert.True(isSuccessful);
+			Assert.Equal(updatedTextColor, textStyleView.TextColor);
+		}
 	}
 }
 
@@ -112,6 +140,39 @@ namespace CommunityToolkit.Maui.UnitTests.Extensions.TextStyle
 
 	// Ensures custom ITextStyle interfaces are supported
 	interface ICustomTextStyle : ITextStyle
+	{
+
+	}
+
+	public interface ISomeInterface
+	{
+
+	}
+	public class ClassConstraintWithInterface : ISomeInterface
+	{
+
+	}
+	public class ClassConstraint
+	{
+
+	}
+
+	public struct StructConstraint
+	{
+
+	}
+	public class GenericPicker<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK> : Picker
+		where TA : notnull, ISomeInterface
+		where TB : class
+		where TC : struct
+		where TD : class, ISomeInterface, new()
+		//TE has no constraints 
+		where TF : notnull
+		where TG : unmanaged
+		where TH : ISomeInterface?
+		where TI : class?
+		where TJ : ISomeInterface
+		where TK : new()
 	{
 
 	}

--- a/src/CommunityToolkit.Maui.UnitTests/Extensions/TextColorTo_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Extensions/TextColorTo_Tests.cs
@@ -92,7 +92,7 @@ namespace CommunityToolkit.Maui.UnitTests.Extensions
 		public async Task Extensions_For_Generic_Class()
 		{
 			Color originalTextColor = Colors.Blue, updatedTextColor = Colors.Red;
-
+			
 			var textStyleView = new GenericPicker<
 				ClassConstraintWithInterface, 
 				ClassConstraint,
@@ -102,9 +102,11 @@ namespace CommunityToolkit.Maui.UnitTests.Extensions
 				int,
 				bool,
 				ClassConstraintWithInterface?,
-				ClassConstraint?,
+				ClassConstraint[],
 				ClassConstraintWithInterface,
-				ClassConstraint
+				RecordClassContstraint,
+				RecordClassContstraint[],
+				RecordStructContstraint
 			> { TextColor = originalTextColor };
 			textStyleView.EnableAnimations();
 
@@ -157,11 +159,22 @@ namespace CommunityToolkit.Maui.UnitTests.Extensions.TextStyle
 
 	}
 
+	public record RecordClassContstraint
+	{
+
+	}
+	
+
+	public readonly record struct RecordStructContstraint
+	{
+
+	}
+
 	public struct StructConstraint
 	{
 
 	}
-	public class GenericPicker<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK> : Picker
+	public class GenericPicker<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM> : Picker
 		where TA : notnull, ISomeInterface
 		where TB : class
 		where TC : struct
@@ -173,6 +186,8 @@ namespace CommunityToolkit.Maui.UnitTests.Extensions.TextStyle
 		where TI : class?
 		where TJ : ISomeInterface
 		where TK : new()
+		where TL : class
+		where TM : struct
 	{
 
 	}

--- a/src/CommunityToolkit.Maui.UnitTests/Extensions/TextColorTo_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Extensions/TextColorTo_Tests.cs
@@ -186,11 +186,17 @@ namespace CommunityToolkit.Maui.UnitTests.Extensions.TextStyle
 	{
 
 	}
+
 	public class ClassConstraintWithInterface : ISomeInterface
 	{
 
 	}
+
 	public class ClassConstraint
+	{
+
+	}
+
 	class MyGenericPicker<T> : Picker
 	{
 
@@ -203,6 +209,10 @@ namespace CommunityToolkit.Maui.UnitTests.Extensions.TextStyle
 	
 
 	public readonly record struct RecordStructContstraint
+	{
+
+	}
+
 	class MoreGenericPicker<T> : MyGenericPicker<T>
 	{
 
@@ -212,6 +222,7 @@ namespace CommunityToolkit.Maui.UnitTests.Extensions.TextStyle
 	{
 
 	}
+
 	public class GenericPicker<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM> : Picker
 		where TA : notnull, ISomeInterface
 		where TB : class
@@ -227,6 +238,8 @@ namespace CommunityToolkit.Maui.UnitTests.Extensions.TextStyle
 		where TL : class
 		where TM : struct
 	{
+
+	}
 
 	class BrandNewControl : View, ITextStyle, IAnimatable
 	{

--- a/src/CommunityToolkit.Maui.UnitTests/Extensions/TextColorTo_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Extensions/TextColorTo_Tests.cs
@@ -223,7 +223,7 @@ namespace CommunityToolkit.Maui.UnitTests.Extensions.TextStyle
 
 	}
 
-	public class GenericPicker<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM> : Picker
+	public class GenericPicker<TA, TB, TC, TD, TE, TF, TG, TH, TI, TJ, TK, TL, TM> : View, ITextStyle, IAnimatable
 		where TA : notnull, ISomeInterface
 		where TB : class
 		where TC : struct
@@ -238,7 +238,11 @@ namespace CommunityToolkit.Maui.UnitTests.Extensions.TextStyle
 		where TL : class
 		where TM : struct
 	{
+		public double CharacterSpacing { get; } = 0;
 
+		public Color TextColor { get; set; } = Colors.Transparent;
+
+		public Font Font { get; set; }
 	}
 
 	class BrandNewControl : View, ITextStyle, IAnimatable


### PR DESCRIPTION
 ### Description of Change ###
- Added extensions to serialize generic type arguments 
- Using new extensions in TextColorToGenerator 
 ### Linked Issues ###
#409 

 - Fixes #409

 ### PR Checklist ###
 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [X] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [ ] Rebased on top of `main` at time of PR
 - [X] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
