### PR TITLE
Fix background issue on apple platform

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
@@ -114,6 +114,11 @@ public class MauiPopup : UIViewController
 		view.AddSubview(control.ViewController?.View ?? throw new InvalidOperationException($"{nameof(control.ViewController.View)} cannot be null"));
 		view.Bounds = new(0, 0, PreferredContentSize.Width, PreferredContentSize.Height);
 		AddChildViewController(control.ViewController);
+
+		if (VirtualView is not null)
+		{
+			this.SetBackgroundColor(VirtualView);
+		}
 	}
 
 	void SetPresentationController()

--- a/src/CommunityToolkit.Maui.Core/Views/Popup/PopupExtensions.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Popup/PopupExtensions.macios.cs
@@ -46,6 +46,11 @@ public static class PopupExtensions
 
 		var color = popup.Color?.ToPlatform();
 		mauiPopup.Control.PlatformView.BackgroundColor = color;
+
+		if (mauiPopup.Control.ViewController?.View is UIView view)
+		{
+			view.BackgroundColor = color;
+		}
 	}
 
 	/// <summary>


### PR DESCRIPTION
 ### Description of Change ###

Make sure to change the correct backgroundColor View on Apple platform. And make sure to call the `SetBackgroundColor` when the `View` isn't `null`.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #450

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
<img width="990" alt="Screen Shot 2022-06-10 at 15 32 29" src="https://user-images.githubusercontent.com/20712372/173164841-6759695b-3c88-4988-ba6b-700d4c5e686c.png">
