### PR TITLE
Avoid code generation for types that can use existing extension methods

### DIFF
--- a/src/CommunityToolkit.Maui.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
@@ -33,9 +33,9 @@ static class NamespaceSymbolExtensions
 
 		while (baseType is not null)
 		{
-			var result = namedSymbolList.Any(x => x.Equals(baseType, SymbolEqualityComparer.Default));
+			var doesListContainBaseType = namedSymbolList.Any(x => x.Equals(baseType, SymbolEqualityComparer.Default));
 
-			if (result)
+			if (doesListContainBaseType)
 			{
 				return true;
 			}

--- a/src/CommunityToolkit.Maui.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
@@ -26,4 +26,23 @@ static class NamespaceSymbolExtensions
 			}
 		}
 	}
+
+	public static bool ContainsSymbolBaseType(this IEnumerable<INamedTypeSymbol> namedSymbolList, INamedTypeSymbol symbol)
+	{
+		INamedTypeSymbol? baseType = symbol.BaseType;
+
+		while (baseType is not null)
+		{
+			var result = namedSymbolList.Any(x => x.Equals(baseType, SymbolEqualityComparer.Default));
+
+			if (result)
+			{
+				return true;
+			}
+
+			baseType = baseType.BaseType;
+		}
+
+		return false;
+	}
 }

--- a/src/CommunityToolkit.Maui.SourceGenerators/Generators/TextColorToGenerator.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Generators/TextColorToGenerator.cs
@@ -74,9 +74,9 @@ class TextColorToGenerator : IIncrementalGenerator
 			// If the control is inherit from a Maui control that implements ITextStyle
 			// We don't need to generate a extension method for it.
 			// We just generate a method if the Control is a new implementation of ITextStyle and IAnimatable
-			var isMauiBaseType = IsMauiBaseType(declarationSymbol, mauiTextStyleImplementors);
+			var doesContainSymbolBaseType = mauiTextStyleImplementors.ContainsSymbolBaseType(declarationSymbol);
 
-			if (!isMauiBaseType
+			if (!doesContainSymbolBaseType
 				&& declarationSymbol.AllInterfaces.Contains(textStyleSymbol, SymbolEqualityComparer.Default)
 				&& declarationSymbol.AllInterfaces.Contains(iAnimatableSymbol, SymbolEqualityComparer.Default))
 			{
@@ -86,6 +86,7 @@ class TextColorToGenerator : IIncrementalGenerator
 					context.ReportDiagnostic(diag);
 					continue;
 				}
+
 				var nameSpace = declarationSymbol.ContainingNamespace.ToDisplayString();
 
 				var accessModifier = GetClassAccessModifier(declarationSymbol);
@@ -191,21 +192,4 @@ namespace " + textStyleClass.Namespace + @";
 		Accessibility.Internal => "internal",
 		_ => string.Empty
 	};
-
-	static bool IsMauiBaseType(INamedTypeSymbol symbol, IEnumerable<INamedTypeSymbol> mauiTypes)
-	{
-		INamedTypeSymbol? baseType = symbol.BaseType;
-		while (baseType is not null)
-		{
-			var result = mauiTypes.Any(x => x.Equals(baseType, SymbolEqualityComparer.Default));
-
-			if (result)
-			{
-				return true;
-			}
-
-			baseType = baseType.BaseType;
-		}
-		return false;
-	}
 }

--- a/src/CommunityToolkit.Maui.SourceGenerators/Generators/TextColorToGenerator.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Generators/TextColorToGenerator.cs
@@ -175,7 +175,7 @@ namespace " + textStyleClass.Namespace + @";
 }";
 			var source = textColorToBuilder.ToString();
 			SourceStringExtensions.FormatText(ref source, options);
-			context.AddSource($"{textStyleClass.ClassName}TextColorTo_{Guid.NewGuid()}.g.shared.cs", SourceText.From(source, Encoding.UTF8));
+			context.AddSource($"{textStyleClass.ClassName}TextColorTo.g.shared.cs", SourceText.From(source, Encoding.UTF8));
 		}
 	}
 

--- a/src/CommunityToolkit.Maui.UnitTests/Extensions/TextColorTo_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Extensions/TextColorTo_Tests.cs
@@ -164,20 +164,10 @@ namespace CommunityToolkit.Maui.UnitTests.Extensions.TextStyle
 
 	class BrandNewControl : View, ITextStyle, IAnimatable
 	{
+		public double CharacterSpacing { get; } = 0;
+
 		public Color TextColor { get; set; } = Colors.Transparent;
 
 		public Font Font { get; set; }
-
-		public double CharacterSpacing => 0;
-
-		public void BatchBegin()
-		{
-
-		}
-
-		public void BatchCommit()
-		{
-
-		}
 	}
 }

--- a/src/CommunityToolkit.Maui.UnitTests/Extensions/TextColorTo_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Extensions/TextColorTo_Tests.cs
@@ -87,6 +87,42 @@ namespace CommunityToolkit.Maui.UnitTests.Extensions
 			await Assert.ThrowsAsync<ArgumentNullException>(() => label.TextColorTo(null));
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 		}
+
+		[Fact]
+		public async Task GenericPickerShouldUseThePickerExtension()
+		{
+			var genericPicker = new MyGenericPicker<string>();
+			genericPicker.EnableAnimations();
+
+			Color updatedTextColor = Colors.Yellow;
+			var isSuccessful = await genericPicker.TextColorTo(updatedTextColor);
+
+			Assert.True(isSuccessful);
+		}
+
+		[Fact]
+		public async Task MoreGenericPickerShouldUseThePickerExtension()
+		{
+			var genericPicker = new MoreGenericPicker<string>();
+			genericPicker.EnableAnimations();
+
+			Color updatedTextColor = Colors.Yellow;
+			var isSuccessful = await genericPicker.TextColorTo(updatedTextColor);
+
+			Assert.True(isSuccessful);
+		}
+		
+		[Fact]
+		public async Task BrandNewControlShouldHaveHisOwnExtensionMethod()
+		{
+			var brandNewControl = new BrandNewControl();
+			brandNewControl.EnableAnimations();
+
+			Color updatedTextColor = Colors.Yellow;
+			var isSuccessful = await brandNewControl.TextColorTo(updatedTextColor);
+
+			Assert.True(isSuccessful);
+		}
 	}
 }
 
@@ -114,5 +150,34 @@ namespace CommunityToolkit.Maui.UnitTests.Extensions.TextStyle
 	interface ICustomTextStyle : ITextStyle
 	{
 
+	}
+
+	class MyGenericPicker<T> : Picker
+	{
+
+	}
+
+	class MoreGenericPicker<T> : MyGenericPicker<T>
+	{
+
+	}
+
+	class BrandNewControl : View, ITextStyle, IAnimatable
+	{
+		public Color TextColor { get; set; } = Colors.Transparent;
+
+		public Font Font { get; set; }
+
+		public double CharacterSpacing => 0;
+
+		public void BatchBegin()
+		{
+
+		}
+
+		public void BatchCommit()
+		{
+
+		}
 	}
 }


### PR DESCRIPTION
 ### Description of Change ###

This PR makes sure that SG will generate new extension methods for brand new controls. If the control is already inherited from a .NET MAUI type that implements `ITextStyle` and `IAnimatable` (like `Picker`), we don't generate a new extension method.

```csharp
class MyPicker<T> : Picker 
{
}

void Bla() 
{
    var myPicker = new MyPicker<string>();

   // This will use the method generated for the Picker control
    myPicker.TextColorTo(Colors.Blue);
}
```

This will reduce the amount of generated code improve the final app size and will cover more scenarios, like generic ones.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #409

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
