### PR TITLE
Fixed the size calculation for iOS

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Views/Popup/PopupExtensions.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Popup/PopupExtensions.macios.cs
@@ -19,10 +19,10 @@ public static class PopupExtensions
 		}
 		else if (popup.Content is not null)
 		{
-			if (!popup.Content.DesiredSize.IsZero)
+			var content = popup.Content;
+			if (content.Width is not 0 || content.Height is not 0)
 			{
-				var contentSize = popup.Content.DesiredSize;
-				mauiPopup.PreferredContentSize = new CGSize(contentSize.Width, contentSize.Height);
+				mauiPopup.PreferredContentSize = new CGSize(content.Width, content.Height);
 			}
 			else
 			{


### PR DESCRIPTION
 ### Description of Change ###

This PR fixes how we calculate the size before we're using the platform values which seems to not be the best approach, so now we're using the xplat values, and looks like that fixes the issue.

 ### Linked Issues ###

This fixes one of the bugs in the related issue.

 - Related to #428 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [x] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###

Main (the wrong behavior):
![Screen Shot 2022-06-28 at 19 20 15](https://user-images.githubusercontent.com/20712372/176314447-bd8d125f-2d37-4819-a372-479a78e706ed.png)

This PR (the expected behavior):
![Screen Shot 2022-06-28 at 19 19 05](https://user-images.githubusercontent.com/20712372/176314522-ea0e6384-8f34-4863-aa18-5dc36e22b5c8.png)

