### PR TITLE
Fix popup position

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Extensions/MathExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Extensions/MathExtensions.shared.cs
@@ -1,0 +1,14 @@
+namespace CommunityToolkit.Maui.Core.Extensions;
+
+/// <summary>
+/// Extension methods to help with Math.
+/// </summary>
+public static class MathExtensions
+{
+	/// <summary>
+	/// Check if the number is zero or NaN.
+	/// </summary>
+	/// <param name="number">The <see cref="double"/> that you want to check.</param>
+	/// <returns>A <see cref="Boolean"/> value that indicates if the number is zero or NaN.</returns>
+	public static bool IsZeroOrNaN(this double number) => number is 0 or Double.NaN;
+}

--- a/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Handlers;
 
 namespace CommunityToolkit.Maui.Core.Views;
@@ -67,6 +68,8 @@ public class MauiPopup : UIViewController
 		_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} cannot be null.");
 
 		ViewController ??= mainPage.ViewController ?? throw new InvalidOperationException($"{nameof(mainPage.ViewController)} cannot be null"); ;
+		var rootViewController = WindowStateManager.Default.GetCurrentUIViewController() ?? throw new InvalidOperationException($"{nameof(mainPage.ViewController)} cannot be null");
+		ViewController ??= rootViewController;
 	}
 
 	/// <summary>
@@ -125,16 +128,17 @@ public class MauiPopup : UIViewController
 	{
 		var popOverDelegate = new PopoverDelegate();
 		popOverDelegate.PopoverDismissedEvent += HandlePopoverDelegateDismissed;
-		((UIPopoverPresentationController)PresentationController).SourceView = ViewController?.View ?? throw new InvalidOperationException($"{nameof(ViewController.View)} cannot be null");
 
-		((UIPopoverPresentationController)PresentationController).Delegate = popOverDelegate;
+		var presentationController = ((UIPopoverPresentationController)PresentationController);
+		presentationController.SourceView = ViewController?.View ?? throw new InvalidOperationException($"{nameof(ViewController.View)} cannot be null");
+
+		presentationController.Delegate = popOverDelegate;
 	}
 
 
 	void HandlePopoverDelegateDismissed(object? sender, UIPresentationController e)
 	{
 		_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} cannot be null.");
-
 		VirtualView.Handler?.Invoke(nameof(IPopup.OnDismissedByTappingOutsideOfPopup));
 	}
 

--- a/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
@@ -67,7 +67,6 @@ public class MauiPopup : UIViewController
 		_ = View ?? throw new InvalidOperationException($"{nameof(View)} cannot be null");
 		_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} cannot be null.");
 
-		ViewController ??= mainPage.ViewController ?? throw new InvalidOperationException($"{nameof(mainPage.ViewController)} cannot be null"); ;
 		var rootViewController = WindowStateManager.Default.GetCurrentUIViewController() ?? throw new InvalidOperationException($"{nameof(mainPage.ViewController)} cannot be null");
 		ViewController ??= rootViewController;
 	}

--- a/src/CommunityToolkit.Maui.Core/Views/Popup/PopupExtensions.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Popup/PopupExtensions.macios.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Maui.Platform;
+using CommunityToolkit.Maui.Core.Extensions;
 
 namespace CommunityToolkit.Maui.Core.Views;
 /// <summary>
@@ -20,7 +21,7 @@ public static class PopupExtensions
 		else if (popup.Content is not null)
 		{
 			var content = popup.Content;
-			if (content.Width is not 0 || content.Height is not 0)
+			if (!content.Width.IsZeroOrNaN() || !content.Height.IsZeroOrNaN())
 			{
 				mauiPopup.PreferredContentSize = new CGSize(content.Width, content.Height);
 			}

--- a/src/CommunityToolkit.Maui.Core/Views/Popup/PopupExtensions.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Popup/PopupExtensions.macios.cs
@@ -70,24 +70,35 @@ public static class PopupExtensions
 	/// <param name="popup">An instance of <see cref="IPopup"/>.</param>
 	public static void SetLayout(this MauiPopup mauiPopup, in IPopup popup)
 	{
-		var presentationController = mauiPopup.PresentationController;
-		var preferredContentSize = mauiPopup.PreferredContentSize;
+		if (mauiPopup.View is null)
+		{
+			return;
+		}
 
-		((UIPopoverPresentationController)presentationController).SourceRect = new CGRect(0, 0, preferredContentSize.Width, preferredContentSize.Height);
+		CGRect frame;
+
+		if (mauiPopup.ViewController?.View?.Window is UIWindow window)
+		{
+			frame = window.Frame;
+		}
+		else
+		{
+			frame = UIScreen.MainScreen.Bounds;
+		}
 
 		if (popup.Anchor is null)
 		{
 			var originY = popup.VerticalOptions switch
 			{
 				Microsoft.Maui.Primitives.LayoutAlignment.End => UIScreen.MainScreen.Bounds.Height,
-				Microsoft.Maui.Primitives.LayoutAlignment.Center => UIScreen.MainScreen.Bounds.Height / 2,
+				Microsoft.Maui.Primitives.LayoutAlignment.Center => frame.GetMidY(),
 				_ => 0f
 			};
 
 			var originX = popup.HorizontalOptions switch
 			{
 				Microsoft.Maui.Primitives.LayoutAlignment.End => UIScreen.MainScreen.Bounds.Width,
-				Microsoft.Maui.Primitives.LayoutAlignment.Center => UIScreen.MainScreen.Bounds.Width / 2,
+				Microsoft.Maui.Primitives.LayoutAlignment.Center => frame.GetMidX(),
 				_ => 0f
 			};
 
@@ -100,6 +111,5 @@ public static class PopupExtensions
 			mauiPopup.PopoverPresentationController.SourceView = view;
 			mauiPopup.PopoverPresentationController.SourceRect = view.Bounds;
 		}
-
 	}
 }

--- a/src/CommunityToolkit.Maui.UnitTests/Extensions/MathExtensions_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Extensions/MathExtensions_Tests.cs
@@ -1,0 +1,17 @@
+using Xunit;
+using CommunityToolkit.Maui.Core.Extensions;
+namespace CommunityToolkit.Maui.UnitTests.Extensions;
+
+public class MathExtensions_Tests : BaseTest
+{
+	[Theory]
+	[InlineData(0.0,true)]
+	[InlineData(double.NaN, true)]
+	[InlineData(100.0, false)]
+	[InlineData(0.001, false)]
+	public void CheckIfNumberIsNaNOrZero(double number, bool expected)
+	{
+		var result = number.IsZeroOrNaN();
+		Assert.Equal(expected, result);
+	}
+}


### PR DESCRIPTION
 ### Description of Change ###

This PR fixes the Popup position on screen and looks like also fixed the ShellContent issue (when we present a popup the ShellContent became blank).

A note is that for macOS the popup in the `X` position is offset a little bit to the right, @PureWeen and I couldn't figure out why that happen, but it's way better than before.

Thanks, Shane for all the help❣️

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #466
  - Fixes #463
  - Fixes #428

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [x] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
Main:
![main](https://user-images.githubusercontent.com/20712372/176980305-4bdfc33c-ab2e-45a7-8ebd-048f2454a587.png)

This PR:

![PR](https://user-images.githubusercontent.com/20712372/176980308-90de5249-2f38-495a-ae0a-4e342b0e1947.png)

