### PR TITLE
Fix MSFTBOT Bug Causing it to Reopen Completed/Closed Proposals

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -296,10 +296,10 @@
               ]
             },
             {
-              "operator": "or",
+              "operator": "not",
               "operands": [
                 {
-                  "operator": "not",
+                  "operator": "or",
                   "operands": [
                     {
                       "name": "isInProjectColumn",
@@ -307,12 +307,7 @@
                         "projectName": "New Feature Proposals",
                         "columnName": "Closed"
                       }
-                    }
-                  ]
-                },
-                {
-                  "operator": "not",
-                  "operands": [
+                    },
                     {
                       "name": "isInProjectColumn",
                       "parameters": {


### PR DESCRIPTION
Proposals should be closed automatically by `msftbot` when moved to the `Closed` or `Completed` column in our [New Feature Proposals Project Board](https://github.com/CommunityToolkit/Maui/projects/1).

Due to a bug in the Boolean logic, `msftbot` has been incorrectly reopening Proposals that should remain closed:

![image](https://user-images.githubusercontent.com/13558917/180085075-298c0013-42bc-41df-9a19-027104944e6f.png)

```
// Previous Logic (with bug)
(`proposal` label || On New Feature Proposal project board || Title contains `[Proposal]`)
  && (!IsOpen)
  && (![Is in Closed Column] || ![Is in Completed Column]) // BUG: This would always resolve to `true` because the Proposal could never be in both columns simultaneously

// Previous Logic (with bug)
(`proposal` label || On New Feature Proposal project board || Title contains `[Proposal]`)
  && (!IsOpen)
  && !([Is in Closed Column] || [Is in Completed Column])
```
