### PR TITLE
Add `/dotnet format` Capability to Pull Request Comments

### DIFF
--- a/.github/workflows/dotnet-format-command.yml
+++ b/.github/workflows/dotnet-format-command.yml
@@ -1,0 +1,57 @@
+name: Format on slash command
+on:
+  issue_comment:
+    types: created
+jobs:
+  dotnet-format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for command
+        id: command
+        uses: xt0rted/slash-command-action@v1
+        continue-on-error: true
+        with:
+          command: dotnet
+          reaction-type: "eyes"
+
+      - name: Get branch info
+        if: steps.command.outputs.command-name
+        id: comment-branch
+        uses: xt0rted/pull-request-comment-branch@v1
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout repo
+        if: steps.command.outputs.command-name
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.comment-branch.outputs.ref }}
+          persist-credentials: false
+
+      - name: Restore dotnet tools
+        if: steps.command.outputs.command-name
+        uses: xt0rted/dotnet-tool-restore@v1
+
+      - name: Run dotnet format
+        if: steps.command.outputs.command-name && steps.command.outputs.command-arguments == 'format'
+        id: format
+        uses: xt0rted/dotnet-format@v1
+        with:
+          action: "fix"
+          only-changed-files: true
+
+      - name: Commit files
+        if: steps.command.outputs.command-name && steps.command.outputs.command-arguments == 'format' && steps.format.outputs.has-changes == 'true'
+        run: |
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -a -m 'Automated dotnet-format update
+
+          Co-authored-by: ${{ github.event.comment.user.login }} <${{ github.event.comment.user.id }}+${{ github.event.comment.user.login }}@users.noreply.github.com>'
+
+      - name: Push changes
+        if: steps.command.outputs.command-name && steps.command.outputs.command-arguments == 'format' && steps.format.outputs.has-changes == 'true'
+        uses: ad-m/github-push-action@v0.5.0
+        with:
+          branch: ${{ steps.comment-branch.outputs.ref }}
+          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
This PR adds the ability to call `/dotnet format` from a Pull Request comment