### PR TITLE
`EmailValidationBehavior`: Assign `Keyboard.Email` when Attached

### DIFF
--- a/src/CommunityToolkit.Maui.UnitTests/Behaviors/EmailValidationBehavior_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Behaviors/EmailValidationBehavior_Tests.cs
@@ -1,10 +1,22 @@
 ﻿using CommunityToolkit.Maui.Behaviors;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace CommunityToolkit.Maui.UnitTests.Behaviors;
 
 public class EmailValidationBehavior_Tests : BaseTest
 {
+	public static IReadOnlyList<object[]> KeyboardData = new[]
+	{
+		new[] { Keyboard.Plain },
+		new[] { Keyboard.Numeric },
+		new[] { Keyboard.Chat },
+		new[] { Keyboard.Email },
+		new[] { Keyboard.Telephone },
+		new[] { Keyboard.Text },
+		new[] { Keyboard.Url },
+	};
+
 	// Data from https://codefool.tumblr.com/post/15288874550/list-of-valid-and-invalid-email-addresses
 	public static IReadOnlyList<object?[]> TestData { get; } = new[]
 	{
@@ -61,5 +73,81 @@ public class EmailValidationBehavior_Tests : BaseTest
 
 		// Assert
 		Assert.Equal(expectedValue, behavior.IsValid);
+	}
+
+	[Fact]
+	public void EnsureEntryEmailKeyboardWhenDefaultKeyboardAssigned()
+	{
+		// Arrange
+		var behavior = new EmailValidationBehavior();
+
+		var entry = new Entry
+		{
+			Text = "mabuta@gmail.com"
+		};
+
+		// Act 
+		entry.Behaviors.Add(behavior);
+
+		// Assert
+		Assert.Equal(Keyboard.Email, entry.Keyboard);
+	}
+
+	[Fact]
+	public void EnsureEditorEmailKeyboardWhenDefaultKeyboardAssigned()
+	{
+		// Arrange
+		var behavior = new EmailValidationBehavior();
+
+		var editor = new Editor
+		{
+			Text = "mabuta@gmail.com"
+		};
+
+		// Act 
+		editor.Behaviors.Add(behavior);
+
+		// Assert
+		Assert.Equal(Keyboard.Email, editor.Keyboard);
+	}
+
+	[Theory]
+	[MemberData(nameof(KeyboardData))]
+	public void EnsureEntryKeyboardNotOverwrittenWhenAttached(Keyboard keyboard)
+	{
+		// Arrange
+		var behavior = new EmailValidationBehavior();
+
+		var entry = new Entry
+		{
+			Text = "mabuta@gmail.com",
+			Keyboard = keyboard
+		};
+
+		// Act 
+		entry.Behaviors.Add(behavior);
+
+		// Assert
+		Assert.Equal(keyboard, entry.Keyboard);
+	}
+
+	[Theory]
+	[MemberData(nameof(KeyboardData))]
+	public void EnsureEditorrEmailKeyboardWhenDefaultKeyboardAssigned(Keyboard keyboard)
+	{
+		// Arrange
+		var behavior = new EmailValidationBehavior();
+
+		var editor = new Editor
+		{
+			Text = "mabuta@gmail.com",
+			Keyboard = keyboard
+		};
+
+		// Act 
+		editor.Behaviors.Add(behavior);
+
+		// Assert
+		Assert.Equal(keyboard, editor.Keyboard);
 	}
 }

--- a/src/CommunityToolkit.Maui.UnitTests/Behaviors/EmailValidationBehavior_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Behaviors/EmailValidationBehavior_Tests.cs
@@ -5,12 +5,11 @@ namespace CommunityToolkit.Maui.UnitTests.Behaviors;
 
 public class EmailValidationBehavior_Tests : BaseTest
 {
-	public static IReadOnlyList<object[]> KeyboardData = new[]
+	public static IReadOnlyList<object[]> NonDefaultKeyboardData { get; } = new[]
 	{
 		new[] { Keyboard.Plain },
 		new[] { Keyboard.Numeric },
 		new[] { Keyboard.Chat },
-		new[] { Keyboard.Email },
 		new[] { Keyboard.Telephone },
 		new[] { Keyboard.Text },
 		new[] { Keyboard.Url },
@@ -90,6 +89,12 @@ public class EmailValidationBehavior_Tests : BaseTest
 
 		// Assert
 		Assert.Equal(Keyboard.Email, entry.Keyboard);
+
+		// Act
+		entry.Behaviors.Remove(behavior);
+
+		// Assert
+		Assert.Equal(Keyboard.Default, entry.Keyboard);
 	}
 
 	[Fact]
@@ -108,11 +113,17 @@ public class EmailValidationBehavior_Tests : BaseTest
 
 		// Assert
 		Assert.Equal(Keyboard.Email, editor.Keyboard);
+
+		// Act
+		editor.Behaviors.Remove(behavior);
+
+		// Assert
+		Assert.Equal(Keyboard.Default, editor.Keyboard);
 	}
 
 	[Theory]
-	[MemberData(nameof(KeyboardData))]
-	public void EnsureEntryKeyboardNotOverwrittenWhenAttached(Keyboard keyboard)
+	[MemberData(nameof(NonDefaultKeyboardData))]
+	public void EnsureEntryKeyboardNotOverwritten(Keyboard keyboard)
 	{
 		// Arrange
 		var behavior = new EmailValidationBehavior();
@@ -128,11 +139,17 @@ public class EmailValidationBehavior_Tests : BaseTest
 
 		// Assert
 		Assert.Equal(keyboard, entry.Keyboard);
+
+		// Act
+		entry.Behaviors.Remove(behavior);
+
+		// Assert
+		Assert.Equal(keyboard, entry.Keyboard);
 	}
 
 	[Theory]
-	[MemberData(nameof(KeyboardData))]
-	public void EnsureEditorrEmailKeyboardWhenDefaultKeyboardAssigned(Keyboard keyboard)
+	[MemberData(nameof(NonDefaultKeyboardData))]
+	public void EnsureEditorEmailKeyboardNotOverwritten(Keyboard keyboard)
 	{
 		// Arrange
 		var behavior = new EmailValidationBehavior();
@@ -145,6 +162,12 @@ public class EmailValidationBehavior_Tests : BaseTest
 
 		// Act 
 		editor.Behaviors.Add(behavior);
+
+		// Assert
+		Assert.Equal(keyboard, editor.Keyboard);
+
+		// Act
+		editor.Behaviors.Remove(behavior);
 
 		// Assert
 		Assert.Equal(keyboard, editor.Keyboard);

--- a/src/CommunityToolkit.Maui.UnitTests/Behaviors/EmailValidationBehavior_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Behaviors/EmailValidationBehavior_Tests.cs
@@ -1,5 +1,4 @@
 ﻿using CommunityToolkit.Maui.Behaviors;
-using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace CommunityToolkit.Maui.UnitTests.Behaviors;

--- a/src/CommunityToolkit.Maui/Behaviors/Validators/EmailValidationBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/Validators/EmailValidationBehavior.shared.cs
@@ -49,6 +49,18 @@ public class EmailValidationBehavior : TextValidationBehavior
 		base.OnAttachedTo(bindable);
 	}
 
+	/// <inheritdoc /> 
+	protected override void OnDetachingFrom(VisualElement bindable)
+	{
+		// Assign Keyboard.Default if the user has not specified a different Keyboard layout
+		if (bindable is InputView inputView && inputView.Keyboard == Keyboard.Email)
+		{
+			inputView.Keyboard = Keyboard.Default;
+		}
+
+		base.OnDetachingFrom(bindable);
+	}
+
 	// https://docs.microsoft.com/dotnet/standard/base-types/how-to-verify-that-strings-are-in-valid-email-format
 	static bool IsValidEmail(string? email)
 	{

--- a/src/CommunityToolkit.Maui/Behaviors/Validators/EmailValidationBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/Validators/EmailValidationBehavior.shared.cs
@@ -37,6 +37,18 @@ public class EmailValidationBehavior : TextValidationBehavior
 		return IsValidEmail(value) && await base.ValidateAsync(value, token);
 	}
 
+	/// <inheritdoc /> 
+	protected override void OnAttachedTo(VisualElement bindable)
+	{
+		// Assign Keyboard.Email if the user has not specified a specific Keyboard layout
+		if (bindable is InputView inputView && inputView.Keyboard == Keyboard.Default)
+		{
+			inputView.Keyboard = Keyboard.Email;
+		}
+
+		base.OnAttachedTo(bindable);
+	}
+
 	// https://docs.microsoft.com/dotnet/standard/base-types/how-to-verify-that-strings-are-in-valid-email-format
 	static bool IsValidEmail(string? email)
 	{
@@ -93,6 +105,4 @@ public class EmailValidationBehavior : TextValidationBehavior
 			return match.Groups[1].Value + domainName;
 		}
 	}
-
-
 }


### PR DESCRIPTION
 ### Description of Change ###

This PR assigns `InputView.Keyboard = Keyboard.Email` when `EmailValidationBehavior` is attached to a control and the default keyboard is in use: 

```cs
/// <inheritdoc /> 
protected override void OnAttachedTo(VisualElement bindable)
{
  // Assign Keyboard.Email if the user has not specified a specific Keyboard layout
  if (bindable is InputView inputView && inputView.Keyboard == Keyboard.Default)
  {
    inputView.Keyboard = Keyboard.Email;
  }

  base.OnAttachedTo(bindable);
}
```

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #545 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests
 - [x] Has sample
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [x] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/131


 ### Additional information ###

~Documentation will also need to be updated.~

I've also updated `[EmailValidationBehavior_Tests.cs](https://github.com/CommunityToolkit/Maui/pull/547#diff-c8d8498486665de32295100cda8b342b39eeebedad3fea646fbd201e05a431f3)` to reflect this new expected behavior.
 
