### PR TITLE
Add Additional Rules to `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -128,8 +128,5 @@ dotnet_diagnostic.CA2208.severity = error
 # CA1834: Use 'StringBuilder.Append(char)' instead of 'StringBuilder.Append(string)' when the input is a constant unit string
 dotnet_diagnostic.CA1834.severity = error
 
-# CA1309: Use ordinal string comparison
-dotnet_diagnostic.CA1309.severity = error
-
 # IDE0220: Add explicit cast
 dotnet_diagnostic.IDE0220.severity = error

--- a/.editorconfig
+++ b/.editorconfig
@@ -52,6 +52,9 @@ dotnet_style_require_accessibility_modifiers = omit_if_default:error
 # CA1063: Implement IDisposable Correctly
 dotnet_diagnostic.CA1063.severity = error
 
+# CA1001: Type owns disposable field(s) but is not disposable
+dotnet_diagnostic.CA1001.severity = error
+
 # Add braces (IDE0011)
 csharp_prefer_braces = true
 dotnet_diagnostic.IDE0011.severity = error
@@ -92,7 +95,7 @@ dotnet_naming_rule.instance_fields_should_be_camel_case.style = instance_field_s
 dotnet_naming_symbols.instance_fields.applicable_kinds = field
 
 dotnet_naming_style.instance_field_style.capitalization = camel_case
-dotnet_naming_style.instance_field_style.required_prefix = 
+dotnet_naming_style.instance_field_style.required_prefix =
 
 ## Static fields are camelCase
 dotnet_naming_rule.static_fields_should_be_camel_case.severity = error
@@ -104,8 +107,29 @@ dotnet_naming_symbols.static_fields.required_modifiers = static
 dotnet_naming_symbols.static_fields.applicable_accessibilities = internal, private, protected, protected_internal, private_protected
 
 dotnet_naming_style.static_field_style.capitalization = camel_case
-dotnet_naming_style.static_field_style.required_prefix = 
+dotnet_naming_style.static_field_style.required_prefix =
 
 # Modifier preferences
 csharp_prefer_static_local_function = true:suggestion
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:error
+
+# CA1822: Member does not access instance data and can be marked as static
+dotnet_diagnostic.CA1822.severity = error
+
+# CA1050: Declare types in namespaces
+dotnet_diagnostic.CA1050.severity = error
+
+# CA2016: Forward the 'cancellationToken' parameter methods that take one
+dotnet_diagnostic.CA2016.severity = error
+
+# CA2208: Method passes parameter as the paramName argument to a ArgumentNullException constructor. Replace this argument with one of the method's parameter names. Note that the provided parameter name should have the exact casing as declared on the method.
+dotnet_diagnostic.CA2208.severity = error
+
+# CA1834: Use 'StringBuilder.Append(char)' instead of 'StringBuilder.Append(string)' when the input is a constant unit string
+dotnet_diagnostic.CA1834.severity = error
+
+# CA1309: Use ordinal string comparison
+dotnet_diagnostic.CA1309.severity = error
+
+# IDE0220: Add explicit cast
+dotnet_diagnostic.IDE0220.severity = error

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,6 @@
     <WarningsAsErrors>nullable,CS1570,CS1571,CS1572,CS1573,CS1574,CS1734</WarningsAsErrors>
     <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
     <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
-    
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,10 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <NoWarn>NETSDK1023</NoWarn>
+    <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
+    <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <!--CS1570: XML comment has badly formed XML 'Expected an end tag for element [parameter] -->
     <!--CS1571: XML comment on [construct] has a duplicate param tag for [parameter] -->
     <!--CS1572: XML comment has a param tag for '[parameter]', but there is no parameter by that name -->
@@ -11,10 +15,6 @@
     <!--CS1574: XML comment has cref attribute that could not be resolved-->
     <!--CS1734: XML comment has a paramref tag, but there is no parameter by that name-->
     <WarningsAsErrors>nullable,CS1570,CS1571,CS1572,CS1573,CS1574,CS1734</WarningsAsErrors>
-    <NoWarn>NETSDK1023</NoWarn>
-    <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
-    <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,6 +11,7 @@
     <!--CS1574: XML comment has cref attribute that could not be resolved-->
     <!--CS1734: XML comment has a paramref tag, but there is no parameter by that name-->
     <WarningsAsErrors>nullable,CS1570,CS1571,CS1572,CS1573,CS1574,CS1734</WarningsAsErrors>
+    <NoWarn>NETSDK1023</NoWarn>
     <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
     <GenerateErrorForMissingTargetingPacks>false</GenerateErrorForMissingTargetingPacks>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/DrawingViewPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/DrawingViewPage.xaml.cs
@@ -16,6 +16,9 @@ public partial class DrawingViewPage : BasePage<DrawingViewViewModel>
 		};
 	}
 
+	static double GetSide(double value) =>
+		double.IsNaN(value) || value <= 1 ? 200 : value;
+
 	void LoadPointsButtonClicked(object sender, EventArgs e)
 	{
 		DrawingViewControl.Lines.Clear();
@@ -70,10 +73,5 @@ public partial class DrawingViewPage : BasePage<DrawingViewViewModel>
 		var height = GetSide(GestureImage.Height);
 		var stream = await e.LastDrawingLine.GetImageStream(width, height, Colors.Gray.AsPaint());
 		GestureImage.Source = ImageSource.FromStream(() => stream);
-	}
-
-	double GetSide(double value)
-	{
-		return double.IsNaN(value) || value <= 1 ? 200 : value;
 	}
 }

--- a/src/CommunityToolkit.Maui.Analyzers.CodeFixes/Properties/AssemblyInfo.cs
+++ b/src/CommunityToolkit.Maui.Analyzers.CodeFixes/Properties/AssemblyInfo.cs
@@ -1,0 +1,1 @@
+﻿[assembly: System.Resources.NeutralResourcesLanguage("en")]

--- a/src/CommunityToolkit.Maui.Analyzers.CodeFixes/UseCommunityToolkitInitializationAnalyzerCodeFixProvider.cs
+++ b/src/CommunityToolkit.Maui.Analyzers.CodeFixes/UseCommunityToolkitInitializationAnalyzerCodeFixProvider.cs
@@ -40,7 +40,7 @@ public class UseCommunityToolkitInitializationAnalyzerCodeFixProvider : CodeFixP
 			diagnostic);
 	}
 
-	async Task<Document> AddUseCommunityToolkit(Document document, InvocationExpressionSyntax invocationExpression, CancellationToken cancellationToken)
+	static async Task<Document> AddUseCommunityToolkit(Document document, InvocationExpressionSyntax invocationExpression, CancellationToken cancellationToken)
 	{
 		var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 		if (root is null)

--- a/src/CommunityToolkit.Maui.Analyzers/Properties/AssemblyInfo.cs
+++ b/src/CommunityToolkit.Maui.Analyzers/Properties/AssemblyInfo.cs
@@ -1,0 +1,1 @@
+﻿[assembly: System.Resources.NeutralResourcesLanguage("en")]

--- a/src/CommunityToolkit.Maui.Analyzers/UseCommunityToolkitInitializationAnalyzer.cs
+++ b/src/CommunityToolkit.Maui.Analyzers/UseCommunityToolkitInitializationAnalyzer.cs
@@ -48,7 +48,7 @@ public class UseCommunityToolkitInitializationAnalyzer : DiagnosticAnalyzer
 	static bool CheckIfItIsUseMauiMethod(ExpressionStatementSyntax expressionStatement) =>
 		expressionStatement.DescendantNodes()
 							.OfType<GenericNameSyntax>()
-							.Any(x => x.Identifier.ValueText.Equals("UseMauiApp", StringComparison.InvariantCulture)
+							.Any(x => x.Identifier.ValueText.Equals("UseMauiApp", StringComparison.Ordinal)
 										&& x.TypeArgumentList.Arguments.Count is 1);
 
 	static bool HasUseMauiCommunityToolkit(SyntaxNode root)

--- a/src/CommunityToolkit.Maui.Core/Views/Alert/AlertView.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Alert/AlertView.macios.cs
@@ -14,10 +14,10 @@ public class AlertView : UIView
 	/// <summary>
 	/// Parent UIView
 	/// </summary>
-	public UIView ParentView => UIApplication.SharedApplication.ConnectedScenes.ToArray()
-		.Select(x => x as UIWindowScene)
-		.FirstOrDefault()?
-		.Windows.FirstOrDefault(x => x.IsKeyWindow) ?? throw new InvalidOperationException("KeyWindow is not found");
+	public static UIView ParentView => UIApplication.SharedApplication.ConnectedScenes.ToArray()
+										.Select(x => x as UIWindowScene)
+										.FirstOrDefault()?
+										.Windows.FirstOrDefault(x => x.IsKeyWindow) ?? throw new InvalidOperationException("KeyWindow is not found");
 
 	/// <summary>
 	/// PopupView Children

--- a/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.shared.cs
@@ -6,15 +6,24 @@ namespace CommunityToolkit.Maui.Core.Views;
 /// <summary>
 /// DrawingView Platform Control
 /// </summary>
+#if !(IOS || MACCATALYST || ANDROID)
+public partial class MauiDrawingView : IDisposable
+#else
 public partial class MauiDrawingView
+#endif
 {
 	readonly WeakEventManager weakEventManager = new();
 
-	bool isDrawing;
+	bool isDrawing, isDisposed;
 	PointF previousPoint;
 	PathF currentPath = new();
 	MauiDrawingLine? currentLine;
 	Paint paint = new SolidPaint(DrawingViewDefaults.BackgroundColor);
+
+#if !(IOS || MACCATALYST || ANDROID)
+	/// <inheritdoc />
+	~MauiDrawingView() => Dispose(false);
+#endif
 
 	/// <summary>
 	/// Event raised when drawing line completed 
@@ -96,6 +105,30 @@ public partial class MauiDrawingView
 		currentPath.Dispose();
 		Lines.CollectionChanged -= OnLinesCollectionChanged;
 	}
+
+#if !(IOS || MACCATALYST || ANDROID)
+	/// <inheritdoc />
+	public void Dispose()
+	{
+		// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+		Dispose(disposing: true);
+		GC.SuppressFinalize(this);
+	}
+
+	/// <inheritdoc />
+	protected virtual void Dispose(bool disposing)
+	{
+		if (!isDisposed)
+		{
+			if (disposing)
+			{
+				currentPath.Dispose();
+			}
+
+			isDisposed = true;
+		}
+	}
+#endif
 
 	void OnStart(PointF point)
 	{
@@ -185,12 +218,17 @@ public partial class MauiDrawingView
 		currentPath = new PathF();
 	}
 
+#if IOS || ANDROID || MACCATALYST || WINDOWS
 	void Redraw()
 	{
-#if IOS || ANDROID || MACCATALYST || WINDOWS
 		Invalidate();
-#endif
 	}
+#else
+	static void Redraw()
+	{
+
+	}
+#endif
 
 	class DrawingViewDrawable : IDrawable
 	{

--- a/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.shared.cs
@@ -14,7 +14,11 @@ public partial class MauiDrawingView
 {
 	readonly WeakEventManager weakEventManager = new();
 
-	bool isDrawing, isDisposed;
+#if !(IOS || MACCATALYST || ANDROID)
+	bool isDisposed;
+#endif
+
+	bool isDrawing;
 	PointF previousPoint;
 	PathF currentPath = new();
 	MauiDrawingLine? currentLine;

--- a/src/CommunityToolkit.Maui.Core/Views/Snackbar/PlatformSnackbar.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Snackbar/PlatformSnackbar.macios.cs
@@ -7,96 +7,96 @@ namespace CommunityToolkit.Maui.Core.Views;
 /// </summary>
 public class PlatformSnackbar : PlatformToast
 {
-    readonly PaddedButton actionButton;
+	readonly PaddedButton actionButton;
 
-    /// <summary>
-    /// Initialize <see cref="PlatformSnackbar"/>
-    /// </summary>
-    /// <param name="message">Snackbar Message Text</param>
-    /// <param name="backgroundColor">Snackbar Background Color</param>
-    /// <param name="cornerRadius">Snackbar Corner Radius</param>
-    /// <param name="textColor">Snackbar Text Color</param>
-    /// <param name="textFont">Snackbar Text Font</param>
-    /// <param name="characterSpacing">Snackbar Character Spacing</param>
-    /// <param name="actionButtonText">Snackbar Action Button Text</param>
-    /// <param name="actionTextColor">Snackbar Action Button Text Color</param>
-    /// <param name="actionButtonFont">Snackbar Action Button Font</param>
-    /// <param name="padding">Snackbar Padding</param>
-    public PlatformSnackbar(
-        string message,
-        UIColor backgroundColor,
-        CGRect cornerRadius,
-        UIColor textColor,
-        UIFont textFont,
-        double characterSpacing,
-        string actionButtonText,
-        UIColor actionTextColor,
-        UIFont actionButtonFont,
-        NFloat padding)
-        : base(message, backgroundColor, cornerRadius, textColor, textFont, characterSpacing, padding)
-    {
-        padding += defaultPadding;
+	/// <summary>
+	/// Initialize <see cref="PlatformSnackbar"/>
+	/// </summary>
+	/// <param name="message">Snackbar Message Text</param>
+	/// <param name="backgroundColor">Snackbar Background Color</param>
+	/// <param name="cornerRadius">Snackbar Corner Radius</param>
+	/// <param name="textColor">Snackbar Text Color</param>
+	/// <param name="textFont">Snackbar Text Font</param>
+	/// <param name="characterSpacing">Snackbar Character Spacing</param>
+	/// <param name="actionButtonText">Snackbar Action Button Text</param>
+	/// <param name="actionTextColor">Snackbar Action Button Text Color</param>
+	/// <param name="actionButtonFont">Snackbar Action Button Font</param>
+	/// <param name="padding">Snackbar Padding</param>
+	public PlatformSnackbar(
+		string message,
+		UIColor backgroundColor,
+		CGRect cornerRadius,
+		UIColor textColor,
+		UIFont textFont,
+		double characterSpacing,
+		string actionButtonText,
+		UIColor actionTextColor,
+		UIFont actionButtonFont,
+		NFloat padding)
+		: base(message, backgroundColor, cornerRadius, textColor, textFont, characterSpacing, padding)
+	{
+		padding += defaultPadding;
 
-        actionButton = new PaddedButton(padding, padding, padding, padding);
-        actionButton.SetContentCompressionResistancePriority((float)UILayoutPriority.Required, UILayoutConstraintAxis.Horizontal);
-        actionButton.SetContentHuggingPriority((float)UILayoutPriority.Required, UILayoutConstraintAxis.Horizontal);
-        ActionButtonText = actionButtonText;
-        ActionTextColor = actionTextColor;
-        ActionButtonFont = actionButtonFont;
+		actionButton = new PaddedButton(padding, padding, padding, padding);
+		actionButton.SetContentCompressionResistancePriority((float)UILayoutPriority.Required, UILayoutConstraintAxis.Horizontal);
+		actionButton.SetContentHuggingPriority((float)UILayoutPriority.Required, UILayoutConstraintAxis.Horizontal);
+		ActionButtonText = actionButtonText;
+		ActionTextColor = actionTextColor;
+		ActionButtonFont = actionButtonFont;
 
-        actionButton.TouchUpInside += ActionButton_TouchUpInside;
-        AlertView.AddChild(actionButton);
-    }
+		actionButton.TouchUpInside += ActionButton_TouchUpInside;
+		AlertView.AddChild(actionButton);
+	}
 
-    /// <summary>
-    /// Action that executes when the user clicks the Snackbar Action Button 
-    /// </summary>
-    public Action? Action { get; init; }
+	/// <summary>
+	/// Action that executes when the user clicks the Snackbar Action Button 
+	/// </summary>
+	public Action? Action { get; init; }
 
-    /// <summary>
-    /// Text Displayed on Action Button
-    /// </summary>
-    public string ActionButtonText
-    {
-        get => actionButton.Title(UIControlState.Normal);
-        private init => actionButton.SetTitle(value, UIControlState.Normal);
-    }
+	/// <summary>
+	/// Text Displayed on Action Button
+	/// </summary>
+	public string ActionButtonText
+	{
+		get => actionButton.Title(UIControlState.Normal);
+		private init => actionButton.SetTitle(value, UIControlState.Normal);
+	}
 
-    /// <summary>
-    /// Action Button Text Color
-    /// </summary>
-    public UIColor ActionTextColor
-    {
-        get => actionButton.TitleColor(UIControlState.Normal);
-        private init => actionButton.SetTitleColor(value, UIControlState.Normal);
-    }
+	/// <summary>
+	/// Action Button Text Color
+	/// </summary>
+	public UIColor ActionTextColor
+	{
+		get => actionButton.TitleColor(UIControlState.Normal);
+		private init => actionButton.SetTitleColor(value, UIControlState.Normal);
+	}
 
-    /// <summary>
-    /// Action Button Font
-    /// </summary>
-    public UIFont ActionButtonFont
-    {
-        get => actionButton.TitleLabel.Font;
-        private init => actionButton.TitleLabel.Font = value;
-    }
+	/// <summary>
+	/// Action Button Font
+	/// </summary>
+	public UIFont ActionButtonFont
+	{
+		get => actionButton.TitleLabel.Font;
+		private init => actionButton.TitleLabel.Font = value;
+	}
 
-    /// <summary>
-    /// Dispose <see cref="PlatformSnackbar"/>
-    /// </summary>
-    /// <param name="isDisposing"></param>
-    protected override void Dispose(bool isDisposing)
-    {
-        if (isDisposing)
-        {
-            actionButton.TouchUpInside -= ActionButton_TouchUpInside;
-        }
+	/// <summary>
+	/// Dispose <see cref="PlatformSnackbar"/>
+	/// </summary>
+	/// <param name="isDisposing"></param>
+	protected override void Dispose(bool isDisposing)
+	{
+		if (isDisposing)
+		{
+			actionButton.TouchUpInside -= ActionButton_TouchUpInside;
+		}
 
-        base.Dispose(isDisposing);
-    }
+		base.Dispose(isDisposing);
+	}
 
-    void ActionButton_TouchUpInside(object? sender, EventArgs e)
-    {
-        Action?.Invoke();
-        AlertView.Dismiss();
-    }
+	void ActionButton_TouchUpInside(object? sender, EventArgs e)
+	{
+		Action?.Invoke();
+		AlertView.Dismiss();
+	}
 }

--- a/src/CommunityToolkit.Maui.Core/Views/Snackbar/PlatformSnackbar.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Snackbar/PlatformSnackbar.macios.cs
@@ -5,116 +5,98 @@ namespace CommunityToolkit.Maui.Core.Views;
 /// <summary>
 /// UIView for Snackbar on iOS
 /// </summary>
-public class PlatformSnackbar : PlatformToast, IDisposable
+public class PlatformSnackbar : PlatformToast
 {
-	readonly PaddedButton actionButton;
+    readonly PaddedButton actionButton;
 
-	bool isDisposed;
+    /// <summary>
+    /// Initialize <see cref="PlatformSnackbar"/>
+    /// </summary>
+    /// <param name="message">Snackbar Message Text</param>
+    /// <param name="backgroundColor">Snackbar Background Color</param>
+    /// <param name="cornerRadius">Snackbar Corner Radius</param>
+    /// <param name="textColor">Snackbar Text Color</param>
+    /// <param name="textFont">Snackbar Text Font</param>
+    /// <param name="characterSpacing">Snackbar Character Spacing</param>
+    /// <param name="actionButtonText">Snackbar Action Button Text</param>
+    /// <param name="actionTextColor">Snackbar Action Button Text Color</param>
+    /// <param name="actionButtonFont">Snackbar Action Button Font</param>
+    /// <param name="padding">Snackbar Padding</param>
+    public PlatformSnackbar(
+        string message,
+        UIColor backgroundColor,
+        CGRect cornerRadius,
+        UIColor textColor,
+        UIFont textFont,
+        double characterSpacing,
+        string actionButtonText,
+        UIColor actionTextColor,
+        UIFont actionButtonFont,
+        NFloat padding)
+        : base(message, backgroundColor, cornerRadius, textColor, textFont, characterSpacing, padding)
+    {
+        padding += defaultPadding;
 
-	/// <summary>
-	/// Initialize <see cref="PlatformSnackbar"/>
-	/// </summary>
-	/// <param name="message">Snackbar Message Text</param>
-	/// <param name="backgroundColor">Snackbar Background Color</param>
-	/// <param name="cornerRadius">Snackbar Corner Radius</param>
-	/// <param name="textColor">Snackbar Text Color</param>
-	/// <param name="textFont">Snackbar Text Font</param>
-	/// <param name="characterSpacing">Snackbar Character Spacing</param>
-	/// <param name="actionButtonText">Snackbar Action Button Text</param>
-	/// <param name="actionTextColor">Snackbar Action Button Text Color</param>
-	/// <param name="actionButtonFont">Snackbar Action Button Font</param>
-	/// <param name="padding">Snackbar Padding</param>
-	public PlatformSnackbar(
-		string message,
-		UIColor backgroundColor,
-		CGRect cornerRadius,
-		UIColor textColor,
-		UIFont textFont,
-		double characterSpacing,
-		string actionButtonText,
-		UIColor actionTextColor,
-		UIFont actionButtonFont,
-		NFloat padding)
-		: base(message, backgroundColor, cornerRadius, textColor, textFont, characterSpacing, padding)
-	{
-		padding += defaultPadding;
+        actionButton = new PaddedButton(padding, padding, padding, padding);
+        actionButton.SetContentCompressionResistancePriority((float)UILayoutPriority.Required, UILayoutConstraintAxis.Horizontal);
+        actionButton.SetContentHuggingPriority((float)UILayoutPriority.Required, UILayoutConstraintAxis.Horizontal);
+        ActionButtonText = actionButtonText;
+        ActionTextColor = actionTextColor;
+        ActionButtonFont = actionButtonFont;
 
-		actionButton = new PaddedButton(padding, padding, padding, padding);
-		actionButton.SetContentCompressionResistancePriority((float)UILayoutPriority.Required, UILayoutConstraintAxis.Horizontal);
-		actionButton.SetContentHuggingPriority((float)UILayoutPriority.Required, UILayoutConstraintAxis.Horizontal);
-		ActionButtonText = actionButtonText;
-		ActionTextColor = actionTextColor;
-		ActionButtonFont = actionButtonFont;
+        actionButton.TouchUpInside += ActionButton_TouchUpInside;
+        AlertView.AddChild(actionButton);
+    }
 
-		actionButton.TouchUpInside += ActionButton_TouchUpInside;
-		AlertView.AddChild(actionButton);
-	}
+    /// <summary>
+    /// Action that executes when the user clicks the Snackbar Action Button 
+    /// </summary>
+    public Action? Action { get; init; }
 
-	/// <summary>
-	/// Finalizer for <see cref="PlatformSnackbar"/>
-	/// </summary>
-	~PlatformSnackbar() => Dispose(false);
+    /// <summary>
+    /// Text Displayed on Action Button
+    /// </summary>
+    public string ActionButtonText
+    {
+        get => actionButton.Title(UIControlState.Normal);
+        private init => actionButton.SetTitle(value, UIControlState.Normal);
+    }
 
-	/// <summary>
-	/// Action that executes when the user clicks the Snackbar Action Button 
-	/// </summary>
-	public Action? Action { get; init; }
+    /// <summary>
+    /// Action Button Text Color
+    /// </summary>
+    public UIColor ActionTextColor
+    {
+        get => actionButton.TitleColor(UIControlState.Normal);
+        private init => actionButton.SetTitleColor(value, UIControlState.Normal);
+    }
 
-	/// <summary>
-	/// Text Displayed on Action Button
-	/// </summary>
-	public string ActionButtonText
-	{
-		get => actionButton.Title(UIControlState.Normal);
-		private init => actionButton.SetTitle(value, UIControlState.Normal);
-	}
+    /// <summary>
+    /// Action Button Font
+    /// </summary>
+    public UIFont ActionButtonFont
+    {
+        get => actionButton.TitleLabel.Font;
+        private init => actionButton.TitleLabel.Font = value;
+    }
 
-	/// <summary>
-	/// Action Button Text Color
-	/// </summary>
-	public UIColor ActionTextColor
-	{
-		get => actionButton.TitleColor(UIControlState.Normal);
-		private init => actionButton.SetTitleColor(value, UIControlState.Normal);
-	}
+    /// <summary>
+    /// Dispose <see cref="PlatformSnackbar"/>
+    /// </summary>
+    /// <param name="isDisposing"></param>
+    protected override void Dispose(bool isDisposing)
+    {
+        if (isDisposing)
+        {
+            actionButton.TouchUpInside -= ActionButton_TouchUpInside;
+        }
 
-	/// <summary>
-	/// Action Button Font
-	/// </summary>
-	public UIFont ActionButtonFont
-	{
-		get => actionButton.TitleLabel.Font;
-		private init => actionButton.TitleLabel.Font = value;
-	}
+        base.Dispose(isDisposing);
+    }
 
-	/// <summary>
-	/// Dispose <see cref="PlatformSnackbar"/>
-	/// </summary>
-	public void Dispose()
-	{
-		Dispose(true);
-		GC.SuppressFinalize(this);
-	}
-
-	/// <summary>
-	/// Dispose <see cref="PlatformSnackbar"/>
-	/// </summary>
-	/// <param name="isDisposing"></param>
-	protected virtual void Dispose(bool isDisposing)
-	{
-		if (isDisposed)
-		{
-			return;
-		}
-
-		actionButton.TouchUpInside -= ActionButton_TouchUpInside;
-
-		isDisposed = true;
-	}
-
-	void ActionButton_TouchUpInside(object? sender, EventArgs e)
-	{
-		Action?.Invoke();
-		AlertView.Dismiss();
-	}
+    void ActionButton_TouchUpInside(object? sender, EventArgs e)
+    {
+        Action?.Invoke();
+        AlertView.Dismiss();
+    }
 }

--- a/src/CommunityToolkit.Maui.Core/Views/Toast/PlatformToast.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Toast/PlatformToast.macios.cs
@@ -49,15 +49,15 @@ public class PlatformToast : Alert, IDisposable
 		AlertView.AddChild(messageLabel);
 	}
 
-    /// <summary>
-    /// Finalizer for <see cref="PlatformToast"/>
-    /// </summary>
-    ~PlatformToast() => Dispose(false);
+	/// <summary>
+	/// Finalizer for <see cref="PlatformToast"/>
+	/// </summary>
+	~PlatformToast() => Dispose(false);
 
-    /// <summary>
-    /// Toast Message
-    /// </summary>
-    public string Message
+	/// <summary>
+	/// Toast Message
+	/// </summary>
+	public string Message
 	{
 		get => messageLabel.Text ??= string.Empty;
 		private init => messageLabel.Text = value;
@@ -94,25 +94,25 @@ public class PlatformToast : Alert, IDisposable
 	}
 
 	/// <inheritdoc />
-    public void Dispose()
-    {
-        Dispose(true);
-        GC.SuppressFinalize(this);
-    }
+	public void Dispose()
+	{
+		Dispose(true);
+		GC.SuppressFinalize(this);
+	}
 
-    /// <inheritdoc />
-    protected virtual void Dispose(bool isDisposing)
-    {
-        if (!isDisposed)
-        {
-            if (isDisposing)
-            {
-                messageLabel.Dispose();
-            }
+	/// <inheritdoc />
+	protected virtual void Dispose(bool isDisposing)
+	{
+		if (!isDisposed)
+		{
+			if (isDisposing)
+			{
+				messageLabel.Dispose();
+			}
 
-            isDisposed = true;
-        }
-    }
+			isDisposed = true;
+		}
+	}
 
-    static NFloat GetEmFromPx(NFloat defaultFontSize, double currentValue) => 100 * (NFloat)currentValue / defaultFontSize;
+	static NFloat GetEmFromPx(NFloat defaultFontSize, double currentValue) => 100 * (NFloat)currentValue / defaultFontSize;
 }

--- a/src/CommunityToolkit.Maui.Core/Views/Toast/PlatformToast.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Toast/PlatformToast.macios.cs
@@ -7,10 +7,12 @@ namespace CommunityToolkit.Maui.Core.Views;
 /// <summary>
 /// Toast for iOS + MacCatalyst
 /// </summary>
-public class PlatformToast : Alert
+public class PlatformToast : Alert, IDisposable
 {
 	readonly PaddedLabel messageLabel;
 	internal const float defaultPadding = 10;
+
+	bool disposedValue;
 
 	/// <summary>
 	/// Initialize <see cref="PlatformToast"/>
@@ -47,10 +49,15 @@ public class PlatformToast : Alert
 		AlertView.AddChild(messageLabel);
 	}
 
-	/// <summary>
-	/// Toast Message
-	/// </summary>
-	public string Message
+    /// <summary>
+    /// Finalizer for <see cref="PlatformToast"/>
+    /// </summary>
+    ~PlatformToast() => Dispose(false);
+
+    /// <summary>
+    /// Toast Message
+    /// </summary>
+    public string Message
 	{
 		get => messageLabel.Text ??= string.Empty;
 		private init => messageLabel.Text = value;
@@ -86,5 +93,26 @@ public class PlatformToast : Alert
 		}
 	}
 
-	static NFloat GetEmFromPx(NFloat defaultFontSize, double currentValue) => 100 * (NFloat)currentValue / defaultFontSize;
+	/// <inheritdoc />
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <inheritdoc />
+    protected virtual void Dispose(bool isDisposing)
+    {
+        if (!disposedValue)
+        {
+            if (disposing)
+            {
+                messageLabel.Dispose();
+            }
+
+            disposedValue = true;
+        }
+    }
+
+    static NFloat GetEmFromPx(NFloat defaultFontSize, double currentValue) => 100 * (NFloat)currentValue / defaultFontSize;
 }

--- a/src/CommunityToolkit.Maui.Core/Views/Toast/PlatformToast.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Toast/PlatformToast.macios.cs
@@ -12,7 +12,7 @@ public class PlatformToast : Alert, IDisposable
 	readonly PaddedLabel messageLabel;
 	internal const float defaultPadding = 10;
 
-	bool disposedValue;
+	bool isDisposed;
 
 	/// <summary>
 	/// Initialize <see cref="PlatformToast"/>
@@ -103,14 +103,14 @@ public class PlatformToast : Alert, IDisposable
     /// <inheritdoc />
     protected virtual void Dispose(bool isDisposing)
     {
-        if (!disposedValue)
+        if (!isDisposed)
         {
             if (isDisposing)
             {
                 messageLabel.Dispose();
             }
 
-            disposedValue = true;
+            isDisposed = true;
         }
     }
 

--- a/src/CommunityToolkit.Maui.Core/Views/Toast/PlatformToast.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Toast/PlatformToast.macios.cs
@@ -105,7 +105,7 @@ public class PlatformToast : Alert, IDisposable
     {
         if (!disposedValue)
         {
-            if (disposing)
+            if (isDisposing)
             {
                 messageLabel.Dispose();
             }

--- a/src/CommunityToolkit.Maui.UnitTests/Behaviors/IconTintColorBehavior_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Behaviors/IconTintColorBehavior_Tests.cs
@@ -3,6 +3,7 @@ using Xunit;
 
 namespace CommunityToolkit.Maui.UnitTests.Behaviors;
 
+#pragma warning disable CA1416 // Validate platform compatibility
 public class IconTintColorBehavior_Tests : BaseTest
 {
 	[Fact]
@@ -25,4 +26,5 @@ public class IconTintColorBehavior_Tests : BaseTest
 
 		Assert.Equal(Colors.Blue, iconTintColorBehavior.TintColor);
 	}
+#pragma warning restore CA1416 // Validate platform compatibility
 }

--- a/src/CommunityToolkit.Maui.UnitTests/Behaviors/ImpliedOrderGridBehavior_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Behaviors/ImpliedOrderGridBehavior_Tests.cs
@@ -130,7 +130,7 @@ public class ImpliedOrderGridBehavior_Tests : BaseTest
 		Assert.Throws<Exception>(() => grid.Children.Add(throwLabel));
 	}
 
-	Grid CreateExceptionTestGrid()
+	static Grid CreateExceptionTestGrid()
 	{
 		var grid = new Grid();
 		grid.Behaviors.Add(new ImpliedOrderGridBehavior { ThrowOnLayoutWarning = true });
@@ -144,7 +144,7 @@ public class ImpliedOrderGridBehavior_Tests : BaseTest
 		return grid;
 	}
 
-	void AssertExpectedCoordinates(Grid grid, View view, int row, int column)
+	static void AssertExpectedCoordinates(Grid grid, View view, int row, int column)
 	{
 		grid.Children.Add(view);
 		Assert.Equal(row, Grid.GetRow(view));

--- a/src/CommunityToolkit.Maui.UnitTests/Behaviors/SetFocusOnEntryCompleted_Tests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Behaviors/SetFocusOnEntryCompleted_Tests.cs
@@ -35,7 +35,7 @@ public class SetFocusOnEntryCompleted_Tests : BaseTest
 		Assert.True(entry2.IsFocused);
 	}
 
-	public Entry CreateEntry(VisualElement? nextElement = null)
+	static Entry CreateEntry(VisualElement? nextElement = null)
 	{
 		var entry = new Entry();
 

--- a/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.macios.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.macios.cs
@@ -11,7 +11,7 @@ public partial class Snackbar
 	/// <summary>
 	/// Dismiss Snackbar
 	/// </summary>
-	private partial Task DismissPlatform(CancellationToken token)
+	private static partial Task DismissPlatform(CancellationToken token)
 	{
 		if (PlatformSnackbar is not null)
 		{

--- a/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
@@ -100,10 +100,23 @@ public partial class Snackbar : ISnackbar
 		};
 	}
 
-	/// <summary>
-	/// Show Snackbar
-	/// </summary>
-	public virtual Task Show(CancellationToken token = default) => ShowPlatform(token);
+#if ANDROID || IOS || MACCATALYST || WINDOWS
+	static PlatformSnackbar? PlatformSnackbar { get; set; }
+#endif
+
+    /// <summary>
+    /// Dispose Snackbar
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Show Snackbar
+    /// </summary>
+    public virtual Task Show(CancellationToken token = default) => ShowPlatform(token);
 
 	/// <summary>
 	/// Dismiss Snackbar
@@ -112,9 +125,29 @@ public partial class Snackbar : ISnackbar
 
 	internal static TimeSpan GetDefaultTimeSpan() => TimeSpan.FromSeconds(3);
 
+    /// <summary>
+    /// Dispose Snackbar
+    /// </summary>
+    protected virtual void Dispose(bool isDisposing)
+    {
+        if (isDisposed)
+        {
+            return;
+        }
+
+        if (isDisposing)
+        {
+#if ANDROID || IOS || MACCATALYST
+			PlatformSnackbar?.Dispose();
+#endif
+        }
+
+        isDisposed = true;
+    }
+
 #if !(IOS || ANDROID || MACCATALYST || WINDOWS)
-	/// <inheritdoc/>
-	private partial Task ShowPlatform(CancellationToken token)
+    /// <inheritdoc/>
+    private partial Task ShowPlatform(CancellationToken token)
 	{
 		token.ThrowIfCancellationRequested();
 
@@ -134,39 +167,6 @@ public partial class Snackbar : ISnackbar
 	}
 #endif
 
-	/// <summary>
-	/// Dispose Snackbar
-	/// </summary>
-	public void Dispose()
-	{
-		Dispose(true);
-		GC.SuppressFinalize(this);
-	}
-
-	/// <summary>
-	/// Dispose Snackbar
-	/// </summary>
-	protected virtual void Dispose(bool isDisposing)
-	{
-		if (isDisposed)
-		{
-			return;
-		}
-
-		if (isDisposing)
-		{
-#if ANDROID || IOS || MACCATALYST
-			PlatformSnackbar?.Dispose();
-#endif
-		}
-
-		isDisposed = true;
-	}
-
-#if ANDROID || IOS || MACCATALYST || WINDOWS
-	static PlatformSnackbar? PlatformSnackbar { get; set; }
-#endif
-
 	void OnShown()
 	{
 		IsShown = true;
@@ -181,7 +181,11 @@ public partial class Snackbar : ISnackbar
 
 	private partial Task ShowPlatform(CancellationToken token);
 
-	private partial Task DismissPlatform(CancellationToken token);
+#if IOS || MACCATALYST
+	private static partial Task DismissPlatform(CancellationToken token);
+#else
+    private partial Task DismissPlatform(CancellationToken token);
+#endif
 }
 
 /// <summary>

--- a/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
@@ -104,19 +104,19 @@ public partial class Snackbar : ISnackbar
 	static PlatformSnackbar? PlatformSnackbar { get; set; }
 #endif
 
-    /// <summary>
-    /// Dispose Snackbar
-    /// </summary>
-    public void Dispose()
-    {
-        Dispose(true);
-        GC.SuppressFinalize(this);
-    }
+	/// <summary>
+	/// Dispose Snackbar
+	/// </summary>
+	public void Dispose()
+	{
+		Dispose(true);
+		GC.SuppressFinalize(this);
+	}
 
-    /// <summary>
-    /// Show Snackbar
-    /// </summary>
-    public virtual Task Show(CancellationToken token = default) => ShowPlatform(token);
+	/// <summary>
+	/// Show Snackbar
+	/// </summary>
+	public virtual Task Show(CancellationToken token = default) => ShowPlatform(token);
 
 	/// <summary>
 	/// Dismiss Snackbar
@@ -125,29 +125,29 @@ public partial class Snackbar : ISnackbar
 
 	internal static TimeSpan GetDefaultTimeSpan() => TimeSpan.FromSeconds(3);
 
-    /// <summary>
-    /// Dispose Snackbar
-    /// </summary>
-    protected virtual void Dispose(bool isDisposing)
-    {
-        if (isDisposed)
-        {
-            return;
-        }
+	/// <summary>
+	/// Dispose Snackbar
+	/// </summary>
+	protected virtual void Dispose(bool isDisposing)
+	{
+		if (isDisposed)
+		{
+			return;
+		}
 
-        if (isDisposing)
-        {
+		if (isDisposing)
+		{
 #if ANDROID || IOS || MACCATALYST
 			PlatformSnackbar?.Dispose();
 #endif
-        }
+		}
 
-        isDisposed = true;
-    }
+		isDisposed = true;
+	}
 
 #if !(IOS || ANDROID || MACCATALYST || WINDOWS)
-    /// <inheritdoc/>
-    private partial Task ShowPlatform(CancellationToken token)
+	/// <inheritdoc/>
+	private partial Task ShowPlatform(CancellationToken token)
 	{
 		token.ThrowIfCancellationRequested();
 
@@ -184,7 +184,7 @@ public partial class Snackbar : ISnackbar
 #if IOS || MACCATALYST
 	private static partial Task DismissPlatform(CancellationToken token);
 #else
-    private partial Task DismissPlatform(CancellationToken token);
+	private partial Task DismissPlatform(CancellationToken token);
 #endif
 }
 

--- a/src/CommunityToolkit.Maui/Alerts/Toast/Toast.android.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Toast/Toast.android.cs
@@ -6,7 +6,7 @@ namespace CommunityToolkit.Maui.Alerts;
 
 public partial class Toast
 {
-	private partial void DismissPlatform(CancellationToken token)
+	private static partial void DismissPlatform(CancellationToken token)
 	{
 		if (PlatformToast is not null)
 		{

--- a/src/CommunityToolkit.Maui/Alerts/Toast/Toast.macios.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Toast/Toast.macios.cs
@@ -9,7 +9,7 @@ namespace CommunityToolkit.Maui.Alerts;
 
 public partial class Toast
 {
-	private partial void DismissPlatform(CancellationToken token)
+	private static partial void DismissPlatform(CancellationToken token)
 	{
 		if (PlatformToast is not null)
 		{

--- a/src/CommunityToolkit.Maui/Alerts/Toast/Toast.shared.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Toast/Toast.shared.cs
@@ -116,7 +116,7 @@ public partial class Toast : IToast
 		if (isDisposing)
 		{
 #if ANDROID
-            PlatformToast?.Dispose();
+			PlatformToast?.Dispose();
 #endif
 		}
 
@@ -136,13 +136,13 @@ public partial class Toast : IToast
 #endif
 
 #if ANDROID || IOS || MACCATALYST || WINDOWS
-    static PlatformToast? PlatformToast { get; set; }
+	static PlatformToast? PlatformToast { get; set; }
 #endif
 
 #if !(IOS || ANDROID || MACCATALYST || WINDOWS)
 	private static partial void ShowPlatform(CancellationToken token);
 #else
-    private partial void ShowPlatform(CancellationToken token);
+	private partial void ShowPlatform(CancellationToken token);
 #endif
 
 	private static partial void DismissPlatform(CancellationToken token);

--- a/src/CommunityToolkit.Maui/Alerts/Toast/Toast.shared.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Toast/Toast.shared.cs
@@ -13,115 +13,115 @@ namespace CommunityToolkit.Maui.Alerts;
 /// <inheritdoc/>
 public partial class Toast : IToast
 {
-    bool isDisposed;
+	bool isDisposed;
 
-    string text = string.Empty;
-    ToastDuration duration = ToastDuration.Short;
-    double textSize = AlertDefaults.FontSize;
+	string text = string.Empty;
+	ToastDuration duration = ToastDuration.Short;
+	double textSize = AlertDefaults.FontSize;
 
-    /// <inheritdoc/>
-    public string Text
-    {
-        get => text;
-        init => text = value ?? throw new ArgumentNullException(nameof(value));
-    }
+	/// <inheritdoc/>
+	public string Text
+	{
+		get => text;
+		init => text = value ?? throw new ArgumentNullException(nameof(value));
+	}
 
-    /// <inheritdoc/>
-    public ToastDuration Duration
-    {
-        get => duration;
-        init
-        {
-            if (!Enum.IsDefined(typeof(ToastDuration), value))
-            {
-                throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ToastDuration));
-            }
+	/// <inheritdoc/>
+	public ToastDuration Duration
+	{
+		get => duration;
+		init
+		{
+			if (!Enum.IsDefined(typeof(ToastDuration), value))
+			{
+				throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ToastDuration));
+			}
 
-            duration = value;
-        }
-    }
+			duration = value;
+		}
+	}
 
-    /// <inheritdoc/>
-    public double TextSize
-    {
-        get => textSize;
-        init
-        {
-            if (value <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(value), "Toast font size must be positive");
-            }
+	/// <inheritdoc/>
+	public double TextSize
+	{
+		get => textSize;
+		init
+		{
+			if (value <= 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(value), "Toast font size must be positive");
+			}
 
-            textSize = value;
-        }
-    }
+			textSize = value;
+		}
+	}
 
-    /// <summary>
-    /// Create new Toast
-    /// </summary>
-    /// <param name="message">Toast message</param>
-    /// <param name="duration">Toast duration</param>
-    /// <param name="textSize">Toast font size</param>
-    /// <returns>New instance of Toast</returns>
-    public static IToast Make(
-        string message,
-        ToastDuration duration = ToastDuration.Short,
-        double textSize = AlertDefaults.FontSize)
-    {
-        return new Toast
-        {
-            Text = message,
-            Duration = duration,
-            TextSize = textSize
-        };
-    }
+	/// <summary>
+	/// Create new Toast
+	/// </summary>
+	/// <param name="message">Toast message</param>
+	/// <param name="duration">Toast duration</param>
+	/// <param name="textSize">Toast font size</param>
+	/// <returns>New instance of Toast</returns>
+	public static IToast Make(
+		string message,
+		ToastDuration duration = ToastDuration.Short,
+		double textSize = AlertDefaults.FontSize)
+	{
+		return new Toast
+		{
+			Text = message,
+			Duration = duration,
+			TextSize = textSize
+		};
+	}
 
-    /// <summary>
-    /// Show Toast
-    /// </summary>
-    public virtual Task Show(CancellationToken token = default)
-    {
-        ShowPlatform(token);
-        return Task.CompletedTask;
-    }
+	/// <summary>
+	/// Show Toast
+	/// </summary>
+	public virtual Task Show(CancellationToken token = default)
+	{
+		ShowPlatform(token);
+		return Task.CompletedTask;
+	}
 
-    /// <summary>
-    /// Dismiss Toast
-    /// </summary>
-    public virtual Task Dismiss(CancellationToken token = default)
-    {
-        DismissPlatform(token);
-        return Task.CompletedTask;
-    }
+	/// <summary>
+	/// Dismiss Toast
+	/// </summary>
+	public virtual Task Dismiss(CancellationToken token = default)
+	{
+		DismissPlatform(token);
+		return Task.CompletedTask;
+	}
 
-    /// <summary>
-    /// Dispose Toast
-    /// </summary>
-    public void Dispose()
-    {
-        Dispose(true);
-        GC.SuppressFinalize(this);
-    }
+	/// <summary>
+	/// Dispose Toast
+	/// </summary>
+	public void Dispose()
+	{
+		Dispose(true);
+		GC.SuppressFinalize(this);
+	}
 
-    /// <summary>
-    /// Dispose Toast
-    /// </summary>
-    protected virtual void Dispose(bool isDisposing)
-    {
-        if (isDisposed)
-        {
-            return;
-        }
+	/// <summary>
+	/// Dispose Toast
+	/// </summary>
+	protected virtual void Dispose(bool isDisposing)
+	{
+		if (isDisposed)
+		{
+			return;
+		}
 
-        if (isDisposing)
-        {
+		if (isDisposing)
+		{
 #if ANDROID
             PlatformToast?.Dispose();
 #endif
-        }
+		}
 
-        isDisposed = true;
-    }
+		isDisposed = true;
+	}
 
 #if IOS || MACCATALYST || WINDOWS
 	static TimeSpan GetDuration(ToastDuration duration)
@@ -140,28 +140,28 @@ public partial class Toast : IToast
 #endif
 
 #if !(IOS || ANDROID || MACCATALYST || WINDOWS)
-    private static partial void ShowPlatform(CancellationToken token);
+	private static partial void ShowPlatform(CancellationToken token);
 #else
     private partial void ShowPlatform(CancellationToken token);
 #endif
 
-    private static partial void DismissPlatform(CancellationToken token);
+	private static partial void DismissPlatform(CancellationToken token);
 
 #if !(IOS || ANDROID || MACCATALYST || WINDOWS)
-    /// <summary>
-    /// Show Toast
-    /// </summary>
-    private static partial void ShowPlatform(CancellationToken token)
-    {
-        token.ThrowIfCancellationRequested();
-    }
+	/// <summary>
+	/// Show Toast
+	/// </summary>
+	private static partial void ShowPlatform(CancellationToken token)
+	{
+		token.ThrowIfCancellationRequested();
+	}
 
-    /// <summary>
-    /// Dismiss Toast
-    /// </summary>
-    private static partial void DismissPlatform(CancellationToken token)
-    {
-        token.ThrowIfCancellationRequested();
-    }
+	/// <summary>
+	/// Dismiss Toast
+	/// </summary>
+	private static partial void DismissPlatform(CancellationToken token)
+	{
+		token.ThrowIfCancellationRequested();
+	}
 #endif
 }

--- a/src/CommunityToolkit.Maui/Alerts/Toast/Toast.shared.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Toast/Toast.shared.cs
@@ -142,21 +142,23 @@ public partial class Toast : IToast
 
 	private partial void ShowPlatform(CancellationToken token);
 
-	private partial void DismissPlatform(CancellationToken token);
+	private static partial void DismissPlatform(CancellationToken token);
 
 #if !(IOS || ANDROID || MACCATALYST || WINDOWS)
 	/// <summary>
 	/// Show Toast
 	/// </summary>
+#pragma warning disable CA1822 // Cannot mark as static as Toast.android.cs requires instance
 	private partial void ShowPlatform(CancellationToken token)
-	{
-		token.ThrowIfCancellationRequested();
+#pragma warning restore CA1822 // Cannot mark as static as Toast.android.cs requires instance
+    {
+        token.ThrowIfCancellationRequested();
 	}
 
 	/// <summary>
 	/// Dismiss Toast
 	/// </summary>
-	private partial void DismissPlatform(CancellationToken token)
+	private static partial void DismissPlatform(CancellationToken token)
 	{
 		token.ThrowIfCancellationRequested();
 	}

--- a/src/CommunityToolkit.Maui/Alerts/Toast/Toast.shared.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Toast/Toast.shared.cs
@@ -13,115 +13,115 @@ namespace CommunityToolkit.Maui.Alerts;
 /// <inheritdoc/>
 public partial class Toast : IToast
 {
-	bool isDisposed;
+    bool isDisposed;
 
-	string text = string.Empty;
-	ToastDuration duration = ToastDuration.Short;
-	double textSize = AlertDefaults.FontSize;
+    string text = string.Empty;
+    ToastDuration duration = ToastDuration.Short;
+    double textSize = AlertDefaults.FontSize;
 
-	/// <inheritdoc/>
-	public string Text
-	{
-		get => text;
-		init => text = value ?? throw new ArgumentNullException(nameof(value));
-	}
+    /// <inheritdoc/>
+    public string Text
+    {
+        get => text;
+        init => text = value ?? throw new ArgumentNullException(nameof(value));
+    }
 
-	/// <inheritdoc/>
-	public ToastDuration Duration
-	{
-		get => duration;
-		init
-		{
-			if (!Enum.IsDefined(typeof(ToastDuration), value))
-			{
-				throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ToastDuration));
-			}
+    /// <inheritdoc/>
+    public ToastDuration Duration
+    {
+        get => duration;
+        init
+        {
+            if (!Enum.IsDefined(typeof(ToastDuration), value))
+            {
+                throw new InvalidEnumArgumentException(nameof(value), (int)value, typeof(ToastDuration));
+            }
 
-			duration = value;
-		}
-	}
+            duration = value;
+        }
+    }
 
-	/// <inheritdoc/>
-	public double TextSize
-	{
-		get => textSize;
-		init
-		{
-			if (value <= 0)
-			{
-				throw new ArgumentOutOfRangeException(nameof(value), "Toast font size must be positive");
-			}
+    /// <inheritdoc/>
+    public double TextSize
+    {
+        get => textSize;
+        init
+        {
+            if (value <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value), "Toast font size must be positive");
+            }
 
-			textSize = value;
-		}
-	}
+            textSize = value;
+        }
+    }
 
-	/// <summary>
-	/// Create new Toast
-	/// </summary>
-	/// <param name="message">Toast message</param>
-	/// <param name="duration">Toast duration</param>
-	/// <param name="textSize">Toast font size</param>
-	/// <returns>New instance of Toast</returns>
-	public static IToast Make(
-		string message,
-		ToastDuration duration = ToastDuration.Short,
-		double textSize = AlertDefaults.FontSize)
-	{
-		return new Toast
-		{
-			Text = message,
-			Duration = duration,
-			TextSize = textSize
-		};
-	}
+    /// <summary>
+    /// Create new Toast
+    /// </summary>
+    /// <param name="message">Toast message</param>
+    /// <param name="duration">Toast duration</param>
+    /// <param name="textSize">Toast font size</param>
+    /// <returns>New instance of Toast</returns>
+    public static IToast Make(
+        string message,
+        ToastDuration duration = ToastDuration.Short,
+        double textSize = AlertDefaults.FontSize)
+    {
+        return new Toast
+        {
+            Text = message,
+            Duration = duration,
+            TextSize = textSize
+        };
+    }
 
-	/// <summary>
-	/// Show Toast
-	/// </summary>
-	public virtual Task Show(CancellationToken token = default)
-	{
-		ShowPlatform(token);
-		return Task.CompletedTask;
-	}
+    /// <summary>
+    /// Show Toast
+    /// </summary>
+    public virtual Task Show(CancellationToken token = default)
+    {
+        ShowPlatform(token);
+        return Task.CompletedTask;
+    }
 
-	/// <summary>
-	/// Dismiss Toast
-	/// </summary>
-	public virtual Task Dismiss(CancellationToken token = default)
-	{
-		DismissPlatform(token);
-		return Task.CompletedTask;
-	}
+    /// <summary>
+    /// Dismiss Toast
+    /// </summary>
+    public virtual Task Dismiss(CancellationToken token = default)
+    {
+        DismissPlatform(token);
+        return Task.CompletedTask;
+    }
 
-	/// <summary>
-	/// Dispose Toast
-	/// </summary>
-	public void Dispose()
-	{
-		Dispose(true);
-		GC.SuppressFinalize(this);
-	}
+    /// <summary>
+    /// Dispose Toast
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
 
-	/// <summary>
-	/// Dispose Toast
-	/// </summary>
-	protected virtual void Dispose(bool isDisposing)
-	{
-		if (isDisposed)
-		{
-			return;
-		}
+    /// <summary>
+    /// Dispose Toast
+    /// </summary>
+    protected virtual void Dispose(bool isDisposing)
+    {
+        if (isDisposed)
+        {
+            return;
+        }
 
-		if (isDisposing)
-		{
+        if (isDisposing)
+        {
 #if ANDROID
-			PlatformToast?.Dispose();
+            PlatformToast?.Dispose();
 #endif
-		}
+        }
 
-		isDisposed = true;
-	}
+        isDisposed = true;
+    }
 
 #if IOS || MACCATALYST || WINDOWS
 	static TimeSpan GetDuration(ToastDuration duration)
@@ -136,31 +136,32 @@ public partial class Toast : IToast
 #endif
 
 #if ANDROID || IOS || MACCATALYST || WINDOWS
-	static PlatformToast? PlatformToast { get; set; }
+    static PlatformToast? PlatformToast { get; set; }
 #endif
 
+#if !(IOS || ANDROID || MACCATALYST || WINDOWS)
+    private static partial void ShowPlatform(CancellationToken token);
+#else
+    private partial void ShowPlatform(CancellationToken token);
+#endif
 
-	private partial void ShowPlatform(CancellationToken token);
-
-	private static partial void DismissPlatform(CancellationToken token);
+    private static partial void DismissPlatform(CancellationToken token);
 
 #if !(IOS || ANDROID || MACCATALYST || WINDOWS)
-	/// <summary>
-	/// Show Toast
-	/// </summary>
-#pragma warning disable CA1822 // Cannot mark as static as Toast.android.cs requires instance
-	private partial void ShowPlatform(CancellationToken token)
-#pragma warning restore CA1822 // Cannot mark as static as Toast.android.cs requires instance
+    /// <summary>
+    /// Show Toast
+    /// </summary>
+    private static partial void ShowPlatform(CancellationToken token)
     {
         token.ThrowIfCancellationRequested();
-	}
+    }
 
-	/// <summary>
-	/// Dismiss Toast
-	/// </summary>
-	private static partial void DismissPlatform(CancellationToken token)
-	{
-		token.ThrowIfCancellationRequested();
-	}
+    /// <summary>
+    /// Dismiss Toast
+    /// </summary>
+    private static partial void DismissPlatform(CancellationToken token)
+    {
+        token.ThrowIfCancellationRequested();
+    }
 #endif
 }

--- a/src/CommunityToolkit.Maui/Alerts/Toast/Toast.windows.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Toast/Toast.windows.cs
@@ -5,7 +5,7 @@ namespace CommunityToolkit.Maui.Alerts;
 
 public partial class Toast
 {
-	private partial void DismissPlatform(CancellationToken token)
+	private static partial void DismissPlatform(CancellationToken token)
 	{
 		if (PlatformToast is not null)
 		{

--- a/src/CommunityToolkit.Maui/Behaviors/UserStoppedTypingBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/UserStoppedTypingBehavior.shared.cs
@@ -6,7 +6,7 @@ namespace CommunityToolkit.Maui.Behaviors;
 /// <summary>
 /// The <see cref="UserStoppedTypingBehavior"/> is a behavior that allows the user to trigger an action when a user has stopped data input any <see cref="InputView"/> derivate like <see cref="Entry"/> or <see cref="SearchBar"/>. Examples of its usage include triggering a search when a user has stopped entering their search query.
 /// </summary>
-public class UserStoppedTypingBehavior : BaseBehavior<InputView>
+public class UserStoppedTypingBehavior : BaseBehavior<InputView>, IDisposable
 {
 	/// <summary>
 	/// Backing BindableProperty for the <see cref="Command"/> property.
@@ -39,6 +39,10 @@ public class UserStoppedTypingBehavior : BaseBehavior<InputView>
 		= BindableProperty.Create(nameof(ShouldDismissKeyboardAutomatically), typeof(bool), typeof(UserStoppedTypingBehavior), false);
 
 	CancellationTokenSource? tokenSource;
+	bool isDisposed;
+
+	/// <inheritdoc />
+	~UserStoppedTypingBehavior() => Dispose(false);
 
 	/// <summary>
 	/// Command that is triggered when the <see cref="StoppedTypingTimeThreshold" /> is reached. When <see cref="MinimumLengthThreshold"/> is set, it's only triggered when both conditions are met. This is a bindable property.
@@ -85,6 +89,14 @@ public class UserStoppedTypingBehavior : BaseBehavior<InputView>
 		set => SetValue(ShouldDismissKeyboardAutomaticallyProperty, value);
 	}
 
+	/// <inheritdoc />
+	public void Dispose()
+	{
+		// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+		Dispose(disposing: true);
+		GC.SuppressFinalize(this);
+	}
+
 	/// <inheritdoc/>
 	protected override void OnViewPropertyChanged(InputView sender, PropertyChangedEventArgs e)
 	{
@@ -93,6 +105,20 @@ public class UserStoppedTypingBehavior : BaseBehavior<InputView>
 		if (e.PropertyName == InputView.TextProperty.PropertyName)
 		{
 			OnTextPropertyChanged();
+		}
+	}
+
+	/// <inheritdoc />
+	protected virtual void Dispose(bool disposing)
+	{
+		if (!isDisposed)
+		{
+			if (disposing)
+			{
+				tokenSource?.Dispose();
+			}
+
+			isDisposed = true;
 		}
 	}
 

--- a/src/CommunityToolkit.Maui/Behaviors/UserStoppedTypingBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/UserStoppedTypingBehavior.shared.cs
@@ -92,7 +92,6 @@ public class UserStoppedTypingBehavior : BaseBehavior<InputView>, IDisposable
 	/// <inheritdoc />
 	public void Dispose()
 	{
-		// Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
 		Dispose(disposing: true);
 		GC.SuppressFinalize(this);
 	}

--- a/src/CommunityToolkit.Maui/Converters/MathExpressionConverter/MathExpression.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/MathExpressionConverter/MathExpression.shared.cs
@@ -140,7 +140,7 @@ sealed class MathExpression
 		var output = new List<string>();
 		var stack = new Stack<(string Name, MathOperatorPrecedence Precedence)>();
 
-		foreach (Match? match in matches)
+		foreach (var match in matches.Cast<Match?>())
 		{
 			if (match == null || string.IsNullOrEmpty(match.Value))
 			{

--- a/src/CommunityToolkit.Maui/Converters/MathExpressionConverter/MathExpression.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/MathExpressionConverter/MathExpression.shared.cs
@@ -140,7 +140,7 @@ sealed class MathExpression
 		var output = new List<string>();
 		var stack = new Stack<(string Name, MathOperatorPrecedence Precedence)>();
 
-		foreach (var match in matches.Cast<Match?>())
+		foreach (var match in matches.Cast<Match>())
 		{
 			if (match == null || string.IsNullOrEmpty(match.Value))
 			{


### PR DESCRIPTION
 ### Description of Change ###

This PR adds the following rules:
- `.editorconfig`
  - CA1001: Type owns disposable field(s) but is not disposable
    - Ensures that we continue to implement `IDisposable` correctly
  - CA1822: Member does not access instance data and can be marked as static
    - Improve performance to avoid unnecessary stack allocations
  - CA1050: Declare types in namespaces
    - Ensures each file has a namespace declared
  - CA2016: Forward the 'CancellationToken' parameter methods that take one
    - Ensures we properly propagate `CancellationToken`
  - CA2208: Method passes parameter as the paramName argument to a ArgumentNullException constructor. Replace this argument with one of the method's parameter names. Note that the provided parameter name should have the exact casing as declared on the method.
    -  Ensures we properly pass in the arguments to `ArgumentNullException`; the constructor accepts `(string paramName, string message)` and sometimes the parameters can be accidentally swapped
  - CA1834: Use 'StringBuilder.Append(char)' instead of 'StringBuilder.Append(string)' when the input is a constant unit string
    - Small performance improvement for `StringBuilder`
  - IDE0220: Add explicit cast
    - Prevents implicit casting
    - Example:
      ```cs
      foreach (Match? match in matches) // `MatchCollection matches` is an `IEnumerable` whose content can be implicitly cast to `Match`
      // changes to
      foreach (var match in matches.Cast<Match?>()) // Ensures we continue to cast to `Match` if/when the implicit cast in `MatchCollection` changes
      ```
- `Directory.build.props`
  - <NoWarn>NETSDK1023</NoWarn>
  - Resolves #558

 ### Additional information ###