### PR TITLE
[CommunityToolkit.Maui.Options] Change `DefaultReturnValue` to `abstract`

### DIFF
--- a/src/CommunityToolkit.Maui/Converters/BaseConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/BaseConverter.shared.cs
@@ -13,9 +13,10 @@ namespace CommunityToolkit.Maui.Converters;
 public abstract class BaseConverter<TFrom, TTo, TParam> : ValueConverterExtension, ICommunityToolkitValueConverter
 {
 	/// <summary>
-	/// Default value to return when the value is null.
+	/// Default value to return when the converter throws an <see cref="Exception"/>.
+	/// This value is used when <see cref="Maui.Options.ShouldSuppressExceptionsInConverters" is set to <see cref="true"/> />
 	/// </summary>
-	public abstract TTo DefaultReturnValue { get; }
+	public abstract TTo DefaultReturnValue { get; set; }
 
 	/// <inheritdoc/>
 	public Type FromType { get; } = typeof(TFrom);
@@ -95,9 +96,10 @@ public abstract class BaseConverter<TFrom, TTo, TParam> : ValueConverterExtensio
 public abstract class BaseConverter<TFrom, TTo> : ValueConverterExtension, ICommunityToolkitValueConverter
 {
 	/// <summary>
-	/// Default value to return when the value is null.
+	/// Default value to return when the converter throws an <see cref="Exception"/>.
+	/// This value is used when <see cref="Maui.Options.ShouldSuppressExceptionsInConverters" is set to <see cref="true"/> />
 	/// </summary>
-	public abstract TTo DefaultReturnValue { get; }
+	public abstract TTo DefaultReturnValue { get; set; }
 
 	/// <inheritdoc/>
 	public Type FromType { get; } = typeof(TFrom);

--- a/src/CommunityToolkit.Maui/Converters/BaseConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/BaseConverter.shared.cs
@@ -15,7 +15,7 @@ public abstract class BaseConverter<TFrom, TTo, TParam> : ValueConverterExtensio
 	/// <summary>
 	/// Default value to return when the value is null.
 	/// </summary>
-	public TTo? DefaultReturnValue { get; set; } = default;
+	public abstract TTo DefaultReturnValue { get; }
 
 	/// <inheritdoc/>
 	public Type FromType { get; } = typeof(TFrom);
@@ -97,7 +97,7 @@ public abstract class BaseConverter<TFrom, TTo> : ValueConverterExtension, IComm
 	/// <summary>
 	/// Default value to return when the value is null.
 	/// </summary>
-	public TTo? DefaultReturnValue { get; set; } = default;
+	public abstract TTo DefaultReturnValue { get; }
 
 	/// <inheritdoc/>
 	public Type FromType { get; } = typeof(TFrom);

--- a/src/CommunityToolkit.Maui/Converters/BoolToObjectConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/BoolToObjectConverter.shared.cs
@@ -14,6 +14,9 @@ public class BoolToObjectConverter : BoolToObjectConverter<object>
 /// </summary>
 public class BoolToObjectConverter<TObject> : BaseConverter<bool, TObject?>
 {
+	/// <inheritdoc/>
+	public override TObject? DefaultReturnValue { get; } = default;
+
 	/// <summary>
 	/// The object that corresponds to True value.
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/BoolToObjectConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/BoolToObjectConverter.shared.cs
@@ -15,7 +15,7 @@ public class BoolToObjectConverter : BoolToObjectConverter<object>
 public class BoolToObjectConverter<TObject> : BaseConverter<bool, TObject?>
 {
 	/// <inheritdoc/>
-	public override TObject? DefaultReturnValue { get; } = default;
+	public override TObject? DefaultReturnValue { get; set; } = default;
 
 	/// <summary>
 	/// The object that corresponds to True value.

--- a/src/CommunityToolkit.Maui/Converters/ByteArrayToImageSourceConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ByteArrayToImageSourceConverter.shared.cs
@@ -8,6 +8,9 @@ namespace CommunityToolkit.Maui.Converters;
 /// </summary>
 public class ByteArrayToImageSourceConverter : BaseConverter<byte[]?, ImageSource?>
 {
+	/// <inheritdoc/>
+	public override ImageSource? DefaultReturnValue { get; } = null;
+
 	/// <summary>
 	/// Converts the incoming value from <see cref="byte"/>[] and returns the object of a type <see cref="ImageSource"/>.
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/ByteArrayToImageSourceConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ByteArrayToImageSourceConverter.shared.cs
@@ -9,7 +9,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class ByteArrayToImageSourceConverter : BaseConverter<byte[]?, ImageSource?>
 {
 	/// <inheritdoc/>
-	public override ImageSource? DefaultReturnValue { get; } = null;
+	public override ImageSource? DefaultReturnValue { get; set; } = null;
 
 	/// <summary>
 	/// Converts the incoming value from <see cref="byte"/>[] and returns the object of a type <see cref="ImageSource"/>.

--- a/src/CommunityToolkit.Maui/Converters/ColorToColorConverters.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ColorToColorConverters.shared.cs
@@ -9,6 +9,9 @@ namespace CommunityToolkit.Maui.Converters;
 public class ColorToBlackOrWhiteConverter : BaseConverterOneWay<Color, Color>
 {
 	/// <inheritdoc/>
+	public override Color DefaultReturnValue { get; } = Colors.Transparent;
+
+	/// <inheritdoc/>
 	public override Color ConvertFrom(Color value, CultureInfo? culture = null)
 	{
 		ArgumentNullException.ThrowIfNull(value);
@@ -21,6 +24,9 @@ public class ColorToBlackOrWhiteConverter : BaseConverterOneWay<Color, Color>
 /// </summary>
 public class ColorToColorForTextConverter : BaseConverterOneWay<Color, Color>
 {
+	/// <inheritdoc/>
+	public override Color DefaultReturnValue { get; } = Colors.Transparent;
+
 	/// <inheritdoc/>
 	public override Color ConvertFrom(Color value, CultureInfo? culture = null)
 	{
@@ -35,6 +41,9 @@ public class ColorToColorForTextConverter : BaseConverterOneWay<Color, Color>
 public class ColorToGrayScaleColorConverter : BaseConverterOneWay<Color, Color>
 {
 	/// <inheritdoc/>
+	public override Color DefaultReturnValue { get; } = Colors.Transparent;
+
+	/// <inheritdoc/>
 	public override Color ConvertFrom(Color value, CultureInfo? culture = null)
 	{
 		ArgumentNullException.ThrowIfNull(value);
@@ -47,6 +56,9 @@ public class ColorToGrayScaleColorConverter : BaseConverterOneWay<Color, Color>
 /// </summary>
 public class ColorToInverseColorConverter : BaseConverterOneWay<Color, Color>
 {
+	/// <inheritdoc/>
+	public override Color DefaultReturnValue { get; } = Colors.Transparent;
+
 	/// <inheritdoc/>
 	public override Color ConvertFrom(Color value, CultureInfo? culture = null)
 	{

--- a/src/CommunityToolkit.Maui/Converters/ColorToColorConverters.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ColorToColorConverters.shared.cs
@@ -9,7 +9,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class ColorToBlackOrWhiteConverter : BaseConverterOneWay<Color, Color>
 {
 	/// <inheritdoc/>
-	public override Color DefaultReturnValue { get; } = Colors.Transparent;
+	public override Color DefaultReturnValue { get; set; } = Colors.Transparent;
 
 	/// <inheritdoc/>
 	public override Color ConvertFrom(Color value, CultureInfo? culture = null)
@@ -25,7 +25,7 @@ public class ColorToBlackOrWhiteConverter : BaseConverterOneWay<Color, Color>
 public class ColorToColorForTextConverter : BaseConverterOneWay<Color, Color>
 {
 	/// <inheritdoc/>
-	public override Color DefaultReturnValue { get; } = Colors.Transparent;
+	public override Color DefaultReturnValue { get; set; } = Colors.Transparent;
 
 	/// <inheritdoc/>
 	public override Color ConvertFrom(Color value, CultureInfo? culture = null)
@@ -41,7 +41,7 @@ public class ColorToColorForTextConverter : BaseConverterOneWay<Color, Color>
 public class ColorToGrayScaleColorConverter : BaseConverterOneWay<Color, Color>
 {
 	/// <inheritdoc/>
-	public override Color DefaultReturnValue { get; } = Colors.Transparent;
+	public override Color DefaultReturnValue { get; set; } = Colors.Transparent;
 
 	/// <inheritdoc/>
 	public override Color ConvertFrom(Color value, CultureInfo? culture = null)
@@ -57,7 +57,7 @@ public class ColorToGrayScaleColorConverter : BaseConverterOneWay<Color, Color>
 public class ColorToInverseColorConverter : BaseConverterOneWay<Color, Color>
 {
 	/// <inheritdoc/>
-	public override Color DefaultReturnValue { get; } = Colors.Transparent;
+	public override Color DefaultReturnValue { get; set; } = Colors.Transparent;
 
 	/// <inheritdoc/>
 	public override Color ConvertFrom(Color value, CultureInfo? culture = null)

--- a/src/CommunityToolkit.Maui/Converters/ColorToComponentConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ColorToComponentConverter.shared.cs
@@ -9,6 +9,9 @@ namespace CommunityToolkit.Maui.Converters;
 public class ColorToByteAlphaConverter : BaseConverterOneWay<Color, byte>
 {
 	/// <inheritdoc/>
+	public override byte DefaultReturnValue { get; } = default;
+
+	/// <inheritdoc/>
 	public override byte ConvertFrom(Color value, CultureInfo? culture = null)
 	{
 		ArgumentNullException.ThrowIfNull(value);
@@ -22,6 +25,9 @@ public class ColorToByteAlphaConverter : BaseConverterOneWay<Color, byte>
 /// </summary>
 public class ColorToByteRedConverter : BaseConverterOneWay<Color, byte>
 {
+	/// <inheritdoc/>
+	public override byte DefaultReturnValue { get; } = default;
+
 	/// <inheritdoc/>
 	public override byte ConvertFrom(Color value, CultureInfo? culture = null)
 	{
@@ -37,6 +43,9 @@ public class ColorToByteRedConverter : BaseConverterOneWay<Color, byte>
 public class ColorToByteGreenConverter : BaseConverterOneWay<Color, byte>
 {
 	/// <inheritdoc/>
+	public override byte DefaultReturnValue { get; } = default;
+
+	/// <inheritdoc/>
 	public override byte ConvertFrom(Color value, CultureInfo? culture = null)
 	{
 		ArgumentNullException.ThrowIfNull(value);
@@ -50,6 +59,9 @@ public class ColorToByteGreenConverter : BaseConverterOneWay<Color, byte>
 /// </summary>
 public class ColorToByteBlueConverter : BaseConverterOneWay<Color, byte>
 {
+	/// <inheritdoc/>
+	public override byte DefaultReturnValue { get; } = default;
+
 	/// <inheritdoc/>
 	public override byte ConvertFrom(Color value, CultureInfo? culture = null)
 	{
@@ -65,6 +77,9 @@ public class ColorToByteBlueConverter : BaseConverterOneWay<Color, byte>
 public class ColorToPercentCyanConverter : BaseConverterOneWay<Color, double>
 {
 	/// <inheritdoc/>
+	public override double DefaultReturnValue { get; } = 0.0d;
+
+	/// <inheritdoc/>
 	public override double ConvertFrom(Color value, CultureInfo? culture = null)
 	{
 		ArgumentNullException.ThrowIfNull(value);
@@ -78,6 +93,9 @@ public class ColorToPercentCyanConverter : BaseConverterOneWay<Color, double>
 /// </summary>
 public class ColorToPercentMagentaConverter : BaseConverterOneWay<Color, double>
 {
+	/// <inheritdoc/>
+	public override double DefaultReturnValue { get; } = 0.0d;
+
 	/// <inheritdoc/>
 	public override double ConvertFrom(Color value, CultureInfo? culture = null)
 	{
@@ -93,6 +111,9 @@ public class ColorToPercentMagentaConverter : BaseConverterOneWay<Color, double>
 public class ColorToPercentYellowConverter : BaseConverterOneWay<Color, double>
 {
 	/// <inheritdoc/>
+	public override double DefaultReturnValue { get; } = 0.0d;
+
+	/// <inheritdoc/>
 	public override double ConvertFrom(Color value, CultureInfo? culture = null)
 	{
 		ArgumentNullException.ThrowIfNull(value);
@@ -106,6 +127,9 @@ public class ColorToPercentYellowConverter : BaseConverterOneWay<Color, double>
 /// </summary>
 public class ColorToPercentBlackKeyConverter : BaseConverterOneWay<Color, double>
 {
+	/// <inheritdoc/>
+	public override double DefaultReturnValue { get; } = 0.0d;
+
 	/// <inheritdoc/>
 	public override double ConvertFrom(Color value, CultureInfo? culture = null)
 	{
@@ -121,6 +145,9 @@ public class ColorToPercentBlackKeyConverter : BaseConverterOneWay<Color, double
 // Hue is a degree on the color wheel from 0 to 360. 0 is red, 120 is green, 240 is blue.
 public class ColorToDegreeHueConverter : BaseConverterOneWay<Color, double>
 {
+	/// <inheritdoc/>
+	public override double DefaultReturnValue { get; } = 0.0d;
+
 	/// <inheritdoc/>
 	public override double ConvertFrom(Color value, CultureInfo? culture = null)
 	{

--- a/src/CommunityToolkit.Maui/Converters/ColorToComponentConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ColorToComponentConverter.shared.cs
@@ -9,7 +9,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class ColorToByteAlphaConverter : BaseConverterOneWay<Color, byte>
 {
 	/// <inheritdoc/>
-	public override byte DefaultReturnValue { get; } = default;
+	public override byte DefaultReturnValue { get; set; } = default;
 
 	/// <inheritdoc/>
 	public override byte ConvertFrom(Color value, CultureInfo? culture = null)
@@ -26,7 +26,7 @@ public class ColorToByteAlphaConverter : BaseConverterOneWay<Color, byte>
 public class ColorToByteRedConverter : BaseConverterOneWay<Color, byte>
 {
 	/// <inheritdoc/>
-	public override byte DefaultReturnValue { get; } = default;
+	public override byte DefaultReturnValue { get; set; } = default;
 
 	/// <inheritdoc/>
 	public override byte ConvertFrom(Color value, CultureInfo? culture = null)
@@ -43,7 +43,7 @@ public class ColorToByteRedConverter : BaseConverterOneWay<Color, byte>
 public class ColorToByteGreenConverter : BaseConverterOneWay<Color, byte>
 {
 	/// <inheritdoc/>
-	public override byte DefaultReturnValue { get; } = default;
+	public override byte DefaultReturnValue { get; set; } = default;
 
 	/// <inheritdoc/>
 	public override byte ConvertFrom(Color value, CultureInfo? culture = null)
@@ -60,7 +60,7 @@ public class ColorToByteGreenConverter : BaseConverterOneWay<Color, byte>
 public class ColorToByteBlueConverter : BaseConverterOneWay<Color, byte>
 {
 	/// <inheritdoc/>
-	public override byte DefaultReturnValue { get; } = default;
+	public override byte DefaultReturnValue { get; set; } = default;
 
 	/// <inheritdoc/>
 	public override byte ConvertFrom(Color value, CultureInfo? culture = null)
@@ -77,7 +77,7 @@ public class ColorToByteBlueConverter : BaseConverterOneWay<Color, byte>
 public class ColorToPercentCyanConverter : BaseConverterOneWay<Color, double>
 {
 	/// <inheritdoc/>
-	public override double DefaultReturnValue { get; } = 0.0d;
+	public override double DefaultReturnValue { get; set; } = 0.0d;
 
 	/// <inheritdoc/>
 	public override double ConvertFrom(Color value, CultureInfo? culture = null)
@@ -94,7 +94,7 @@ public class ColorToPercentCyanConverter : BaseConverterOneWay<Color, double>
 public class ColorToPercentMagentaConverter : BaseConverterOneWay<Color, double>
 {
 	/// <inheritdoc/>
-	public override double DefaultReturnValue { get; } = 0.0d;
+	public override double DefaultReturnValue { get; set; } = 0.0d;
 
 	/// <inheritdoc/>
 	public override double ConvertFrom(Color value, CultureInfo? culture = null)
@@ -111,7 +111,7 @@ public class ColorToPercentMagentaConverter : BaseConverterOneWay<Color, double>
 public class ColorToPercentYellowConverter : BaseConverterOneWay<Color, double>
 {
 	/// <inheritdoc/>
-	public override double DefaultReturnValue { get; } = 0.0d;
+	public override double DefaultReturnValue { get; set; } = 0.0d;
 
 	/// <inheritdoc/>
 	public override double ConvertFrom(Color value, CultureInfo? culture = null)
@@ -128,7 +128,7 @@ public class ColorToPercentYellowConverter : BaseConverterOneWay<Color, double>
 public class ColorToPercentBlackKeyConverter : BaseConverterOneWay<Color, double>
 {
 	/// <inheritdoc/>
-	public override double DefaultReturnValue { get; } = 0.0d;
+	public override double DefaultReturnValue { get; set; } = 0.0d;
 
 	/// <inheritdoc/>
 	public override double ConvertFrom(Color value, CultureInfo? culture = null)
@@ -146,7 +146,7 @@ public class ColorToPercentBlackKeyConverter : BaseConverterOneWay<Color, double
 public class ColorToDegreeHueConverter : BaseConverterOneWay<Color, double>
 {
 	/// <inheritdoc/>
-	public override double DefaultReturnValue { get; } = 0.0d;
+	public override double DefaultReturnValue { get; set; } = 0.0d;
 
 	/// <inheritdoc/>
 	public override double ConvertFrom(Color value, CultureInfo? culture = null)

--- a/src/CommunityToolkit.Maui/Converters/ColorToStringConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ColorToStringConverter.shared.cs
@@ -9,7 +9,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class ColorToRgbStringConverter : BaseConverterOneWay<Color, string>
 {
 	/// <inheritdoc/>
-	public override string DefaultReturnValue { get; } = string.Empty;
+	public override string DefaultReturnValue { get; set; } = string.Empty;
 
 	/// <inheritdoc/>
 	public override string ConvertFrom(Color value, CultureInfo? culture = null)
@@ -25,7 +25,7 @@ public class ColorToRgbStringConverter : BaseConverterOneWay<Color, string>
 public class ColorToRgbaStringConverter : BaseConverterOneWay<Color, string>
 {
 	/// <inheritdoc/>
-	public override string DefaultReturnValue { get; } = string.Empty;
+	public override string DefaultReturnValue { get; set; } = string.Empty;
 
 	/// <inheritdoc/>
 	public override string ConvertFrom(Color value, CultureInfo? culture = null)
@@ -41,7 +41,7 @@ public class ColorToRgbaStringConverter : BaseConverterOneWay<Color, string>
 public class ColorToHexRgbStringConverter : BaseConverter<Color, string>
 {
 	/// <inheritdoc/>
-	public override string DefaultReturnValue { get; } = string.Empty;
+	public override string DefaultReturnValue { get; set; } = string.Empty;
 
 	/// <inheritdoc/>
 	public override string ConvertFrom(Color value, CultureInfo? culture = null)
@@ -64,7 +64,7 @@ public class ColorToHexRgbStringConverter : BaseConverter<Color, string>
 public class ColorToHexRgbaStringConverter : BaseConverter<Color, string>
 {
 	/// <inheritdoc/>
-	public override string DefaultReturnValue { get; } = string.Empty;
+	public override string DefaultReturnValue { get; set; } = string.Empty;
 
 	/// <inheritdoc/>
 	public override string ConvertFrom(Color value, CultureInfo? culture = null)
@@ -87,7 +87,7 @@ public class ColorToHexRgbaStringConverter : BaseConverter<Color, string>
 public class ColorToCmykStringConverter : BaseConverterOneWay<Color, string>
 {
 	/// <inheritdoc/>
-	public override string DefaultReturnValue { get; } = string.Empty;
+	public override string DefaultReturnValue { get; set; } = string.Empty;
 
 	/// <inheritdoc/>
 	public override string ConvertFrom(Color value, CultureInfo? culture = null)
@@ -103,7 +103,7 @@ public class ColorToCmykStringConverter : BaseConverterOneWay<Color, string>
 public class ColorToCmykaStringConverter : BaseConverterOneWay<Color, string>
 {
 	/// <inheritdoc/>
-	public override string DefaultReturnValue { get; } = string.Empty;
+	public override string DefaultReturnValue { get; set; } = string.Empty;
 
 	/// <inheritdoc/>
 	public override string ConvertFrom(Color value, CultureInfo? culture = null)
@@ -119,7 +119,7 @@ public class ColorToCmykaStringConverter : BaseConverterOneWay<Color, string>
 public class ColorToHslStringConverter : BaseConverterOneWay<Color, string>
 {
 	/// <inheritdoc/>
-	public override string DefaultReturnValue { get; } = string.Empty;
+	public override string DefaultReturnValue { get; set; } = string.Empty;
 
 	/// <inheritdoc/>
 	public override string ConvertFrom(Color value, CultureInfo? culture = null)
@@ -135,7 +135,7 @@ public class ColorToHslStringConverter : BaseConverterOneWay<Color, string>
 public class ColorToHslaStringConverter : BaseConverterOneWay<Color, string>
 {
 	/// <inheritdoc/>
-	public override string DefaultReturnValue { get; } = string.Empty;
+	public override string DefaultReturnValue { get; set; } = string.Empty;
 
 	/// <inheritdoc/>
 	public override string ConvertFrom(Color value, CultureInfo? culture = null)

--- a/src/CommunityToolkit.Maui/Converters/ColorToStringConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ColorToStringConverter.shared.cs
@@ -9,6 +9,9 @@ namespace CommunityToolkit.Maui.Converters;
 public class ColorToRgbStringConverter : BaseConverterOneWay<Color, string>
 {
 	/// <inheritdoc/>
+	public override string DefaultReturnValue { get; } = string.Empty;
+
+	/// <inheritdoc/>
 	public override string ConvertFrom(Color value, CultureInfo? culture = null)
 	{
 		ArgumentNullException.ThrowIfNull(value);
@@ -22,6 +25,9 @@ public class ColorToRgbStringConverter : BaseConverterOneWay<Color, string>
 public class ColorToRgbaStringConverter : BaseConverterOneWay<Color, string>
 {
 	/// <inheritdoc/>
+	public override string DefaultReturnValue { get; } = string.Empty;
+
+	/// <inheritdoc/>
 	public override string ConvertFrom(Color value, CultureInfo? culture = null)
 	{
 		ArgumentNullException.ThrowIfNull(value);
@@ -34,6 +40,9 @@ public class ColorToRgbaStringConverter : BaseConverterOneWay<Color, string>
 /// </summary>
 public class ColorToHexRgbStringConverter : BaseConverter<Color, string>
 {
+	/// <inheritdoc/>
+	public override string DefaultReturnValue { get; } = string.Empty;
+
 	/// <inheritdoc/>
 	public override string ConvertFrom(Color value, CultureInfo? culture = null)
 	{
@@ -55,6 +64,9 @@ public class ColorToHexRgbStringConverter : BaseConverter<Color, string>
 public class ColorToHexRgbaStringConverter : BaseConverter<Color, string>
 {
 	/// <inheritdoc/>
+	public override string DefaultReturnValue { get; } = string.Empty;
+
+	/// <inheritdoc/>
 	public override string ConvertFrom(Color value, CultureInfo? culture = null)
 	{
 		ArgumentNullException.ThrowIfNull(value);
@@ -75,6 +87,9 @@ public class ColorToHexRgbaStringConverter : BaseConverter<Color, string>
 public class ColorToCmykStringConverter : BaseConverterOneWay<Color, string>
 {
 	/// <inheritdoc/>
+	public override string DefaultReturnValue { get; } = string.Empty;
+
+	/// <inheritdoc/>
 	public override string ConvertFrom(Color value, CultureInfo? culture = null)
 	{
 		ArgumentNullException.ThrowIfNull(value);
@@ -87,6 +102,9 @@ public class ColorToCmykStringConverter : BaseConverterOneWay<Color, string>
 /// </summary>
 public class ColorToCmykaStringConverter : BaseConverterOneWay<Color, string>
 {
+	/// <inheritdoc/>
+	public override string DefaultReturnValue { get; } = string.Empty;
+
 	/// <inheritdoc/>
 	public override string ConvertFrom(Color value, CultureInfo? culture = null)
 	{
@@ -101,6 +119,9 @@ public class ColorToCmykaStringConverter : BaseConverterOneWay<Color, string>
 public class ColorToHslStringConverter : BaseConverterOneWay<Color, string>
 {
 	/// <inheritdoc/>
+	public override string DefaultReturnValue { get; } = string.Empty;
+
+	/// <inheritdoc/>
 	public override string ConvertFrom(Color value, CultureInfo? culture = null)
 	{
 		ArgumentNullException.ThrowIfNull(value);
@@ -113,6 +134,9 @@ public class ColorToHslStringConverter : BaseConverterOneWay<Color, string>
 /// </summary>
 public class ColorToHslaStringConverter : BaseConverterOneWay<Color, string>
 {
+	/// <inheritdoc/>
+	public override string DefaultReturnValue { get; } = string.Empty;
+
 	/// <inheritdoc/>
 	public override string ConvertFrom(Color value, CultureInfo? culture = null)
 	{

--- a/src/CommunityToolkit.Maui/Converters/CompareConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/CompareConverter.shared.cs
@@ -16,7 +16,7 @@ public sealed class CompareConverter : CompareConverter<object>
 public abstract class CompareConverter<TObject> : BaseConverterOneWay<IComparable, object>
 {
 	/// <inheritdoc/>
-	public override object DefaultReturnValue { get; } = new();
+	public override object DefaultReturnValue { get; set; } = new();
 
 	/// <summary>
 	/// Math operator type

--- a/src/CommunityToolkit.Maui/Converters/CompareConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/CompareConverter.shared.cs
@@ -15,6 +15,9 @@ public sealed class CompareConverter : CompareConverter<object>
 /// </summary>
 public abstract class CompareConverter<TObject> : BaseConverterOneWay<IComparable, object>
 {
+	/// <inheritdoc/>
+	public override object DefaultReturnValue { get; } = new();
+
 	/// <summary>
 	/// Math operator type
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/DateTimeOffsetConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/DateTimeOffsetConverter.shared.cs
@@ -7,6 +7,9 @@ namespace CommunityToolkit.Maui.Converters;
 /// </summary>
 public class DateTimeOffsetConverter : BaseConverter<DateTimeOffset, DateTime>
 {
+	/// <inheritdoc/>
+	public override DateTime DefaultReturnValue { get; } = DateTime.MinValue; //`DateTime.MinValue` is the same as `new DateTime()`, but it is more-efficient
+
 	/// <summary>
 	/// Converts <see cref="DateTimeOffset"/> to <see cref="DateTime"/>
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/DateTimeOffsetConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/DateTimeOffsetConverter.shared.cs
@@ -8,7 +8,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class DateTimeOffsetConverter : BaseConverter<DateTimeOffset, DateTime>
 {
 	/// <inheritdoc/>
-	public override DateTime DefaultReturnValue { get; } = DateTime.MinValue; //`DateTime.MinValue` is the same as `new DateTime()`, but it is more-efficient
+	public override DateTime DefaultReturnValue { get; set; } = DateTime.MinValue; //`DateTime.MinValue` is the same as `new DateTime()`, but it is more-efficient
 
 	/// <summary>
 	/// Converts <see cref="DateTimeOffset"/> to <see cref="DateTime"/>

--- a/src/CommunityToolkit.Maui/Converters/DoubleToIntConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/DoubleToIntConverter.shared.cs
@@ -8,6 +8,9 @@ namespace CommunityToolkit.Maui.Converters;
 [ContentProperty(nameof(Ratio))]
 public class DoubleToIntConverter : BaseConverter<double, int, object?>
 {
+	/// <inheritdoc/>
+	public override int DefaultReturnValue { get; } = 0;
+
 	/// <summary>
 	/// Multiplier / Denominator (Equals 1 by default).
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/DoubleToIntConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/DoubleToIntConverter.shared.cs
@@ -9,7 +9,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class DoubleToIntConverter : BaseConverter<double, int, object?>
 {
 	/// <inheritdoc/>
-	public override int DefaultReturnValue { get; } = 0;
+	public override int DefaultReturnValue { get; set; } = 0;
 
 	/// <summary>
 	/// Multiplier / Denominator (Equals 1 by default).

--- a/src/CommunityToolkit.Maui/Converters/EnumToBoolConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/EnumToBoolConverter.shared.cs
@@ -8,6 +8,9 @@ namespace CommunityToolkit.Maui.Converters;
 /// </summary>
 public class EnumToBoolConverter : BaseConverterOneWay<Enum, bool, Enum?>
 {
+	/// <inheritdoc/>
+	public override bool DefaultReturnValue { get; } = false;
+
 	/// <summary>
 	///     Enum values, that converts to <c>true</c> (optional)
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/EnumToBoolConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/EnumToBoolConverter.shared.cs
@@ -9,7 +9,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class EnumToBoolConverter : BaseConverterOneWay<Enum, bool, Enum?>
 {
 	/// <inheritdoc/>
-	public override bool DefaultReturnValue { get; } = false;
+	public override bool DefaultReturnValue { get; set; } = false;
 
 	/// <summary>
 	///     Enum values, that converts to <c>true</c> (optional)

--- a/src/CommunityToolkit.Maui/Converters/EnumToIntConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/EnumToIntConverter.shared.cs
@@ -8,6 +8,9 @@ namespace CommunityToolkit.Maui.Converters;
 /// </summary>
 public class EnumToIntConverter : BaseConverter<Enum, int, Type>
 {
+	/// <inheritdoc/>
+	public override int DefaultReturnValue { get; } = 0;
+
 	/// <summary>
 	/// Convert a default <see cref="Enum"/> (i.e., extending <see cref="int"/>) to corresponding underlying <see cref="int"/>
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/EnumToIntConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/EnumToIntConverter.shared.cs
@@ -9,7 +9,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class EnumToIntConverter : BaseConverter<Enum, int, Type>
 {
 	/// <inheritdoc/>
-	public override int DefaultReturnValue { get; } = 0;
+	public override int DefaultReturnValue { get; set; } = 0;
 
 	/// <summary>
 	/// Convert a default <see cref="Enum"/> (i.e., extending <see cref="int"/>) to corresponding underlying <see cref="int"/>

--- a/src/CommunityToolkit.Maui/Converters/ICommunityToolkitValueConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ICommunityToolkitValueConverter.shared.cs
@@ -6,7 +6,8 @@ namespace CommunityToolkit.Maui.Converters;
 public interface ICommunityToolkitValueConverter : IValueConverter
 {
 	/// <summary>
-	/// Default value to return when the value is null.
+	/// Default value to return when the converter throws an <see cref="Exception"/>.
+	/// This value is used when <see cref="Maui.Options.ShouldSuppressExceptionsInConverters" is set to <see cref="true"/> />
 	/// </summary>
 	object? DefaultReturnValue { get; }
 

--- a/src/CommunityToolkit.Maui/Converters/ImageResourceConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ImageResourceConverter.shared.cs
@@ -9,6 +9,9 @@ namespace CommunityToolkit.Maui.Converters;
 /// </summary>
 public class ImageResourceConverter : BaseConverterOneWay<string?, ImageSource?>
 {
+	/// <inheritdoc/>
+	public override ImageSource? DefaultReturnValue { get; } = null;
+
 	/// <summary>
 	/// Converts embedded image resource ID to it ImageSource.
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/ImageResourceConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ImageResourceConverter.shared.cs
@@ -10,7 +10,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class ImageResourceConverter : BaseConverterOneWay<string?, ImageSource?>
 {
 	/// <inheritdoc/>
-	public override ImageSource? DefaultReturnValue { get; } = null;
+	public override ImageSource? DefaultReturnValue { get; set; } = null;
 
 	/// <summary>
 	/// Converts embedded image resource ID to it ImageSource.

--- a/src/CommunityToolkit.Maui/Converters/IndexToArrayItemConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/IndexToArrayItemConverter.shared.cs
@@ -7,6 +7,9 @@ namespace CommunityToolkit.Maui.Converters;
 /// </summary>
 public class IndexToArrayItemConverter : BaseConverter<int, object?, Array>
 {
+	/// <inheritdoc/>
+	public override object? DefaultReturnValue { get; } = null;
+
 	/// <summary>
 	/// Converts an <see cref="int"/> index to corresponding array item.
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/IndexToArrayItemConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/IndexToArrayItemConverter.shared.cs
@@ -8,7 +8,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class IndexToArrayItemConverter : BaseConverter<int, object?, Array>
 {
 	/// <inheritdoc/>
-	public override object? DefaultReturnValue { get; } = null;
+	public override object? DefaultReturnValue { get; set; } = null;
 
 	/// <summary>
 	/// Converts an <see cref="int"/> index to corresponding array item.

--- a/src/CommunityToolkit.Maui/Converters/IntToBoolConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/IntToBoolConverter.shared.cs
@@ -7,6 +7,9 @@ namespace CommunityToolkit.Maui.Converters;
 /// </summary>
 public class IntToBoolConverter : BaseConverter<int, bool>
 {
+	/// <inheritdoc/>
+	public override bool DefaultReturnValue { get; } = false;
+
 	/// <summary>
 	/// Converts the incoming <see cref="int"/> to a <see cref="bool"/> indicating whether or not the value is not equal to 0.
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/IntToBoolConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/IntToBoolConverter.shared.cs
@@ -8,7 +8,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class IntToBoolConverter : BaseConverter<int, bool>
 {
 	/// <inheritdoc/>
-	public override bool DefaultReturnValue { get; } = false;
+	public override bool DefaultReturnValue { get; set; } = false;
 
 	/// <summary>
 	/// Converts the incoming <see cref="int"/> to a <see cref="bool"/> indicating whether or not the value is not equal to 0.

--- a/src/CommunityToolkit.Maui/Converters/InvertedBoolConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/InvertedBoolConverter.shared.cs
@@ -7,6 +7,9 @@ namespace CommunityToolkit.Maui.Converters;
 /// </summary>
 public class InvertedBoolConverter : BaseConverter<bool, bool>
 {
+	/// <inheritdoc/>
+	public override bool DefaultReturnValue { get; } = false;
+
 	/// <summary>
 	/// Converts a <see cref="bool"/> to its inverse value.
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/InvertedBoolConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/InvertedBoolConverter.shared.cs
@@ -8,7 +8,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class InvertedBoolConverter : BaseConverter<bool, bool>
 {
 	/// <inheritdoc/>
-	public override bool DefaultReturnValue { get; } = false;
+	public override bool DefaultReturnValue { get; set; } = false;
 
 	/// <summary>
 	/// Converts a <see cref="bool"/> to its inverse value.

--- a/src/CommunityToolkit.Maui/Converters/IsEqualConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/IsEqualConverter.shared.cs
@@ -9,7 +9,7 @@ public class IsEqualConverter : BaseConverterOneWay<object?, bool, object?>
 {
 	/// <inheritdoc/>
 	public override bool DefaultReturnValue { get; set; } = false;
-	
+
 	/// <summary>
 	/// Checks whether the incoming value doesn't equal the provided parameter.
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/IsEqualConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/IsEqualConverter.shared.cs
@@ -7,6 +7,9 @@ namespace CommunityToolkit.Maui.Converters;
 /// </summary>
 public class IsEqualConverter : BaseConverterOneWay<object?, bool, object?>
 {
+	/// <inheritdoc/>
+	public override bool DefaultReturnValue { get; } = false;
+	
 	/// <summary>
 	/// Checks whether the incoming value doesn't equal the provided parameter.
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/IsEqualConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/IsEqualConverter.shared.cs
@@ -8,7 +8,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class IsEqualConverter : BaseConverterOneWay<object?, bool, object?>
 {
 	/// <inheritdoc/>
-	public override bool DefaultReturnValue { get; } = false;
+	public override bool DefaultReturnValue { get; set; } = false;
 	
 	/// <summary>
 	/// Checks whether the incoming value doesn't equal the provided parameter.

--- a/src/CommunityToolkit.Maui/Converters/IsListNotNullOrEmptyConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/IsListNotNullOrEmptyConverter.shared.cs
@@ -9,7 +9,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class IsListNotNullOrEmptyConverter : BaseConverterOneWay<IEnumerable?, bool>
 {
 	/// <inheritdoc/>
-	public override bool DefaultReturnValue { get; } = false;
+	public override bool DefaultReturnValue { get; set; } = false;
 
 	/// <summary>
 	/// Converts the incoming value to a <see cref="bool"/> indicating whether or not the value is not null and not empty.

--- a/src/CommunityToolkit.Maui/Converters/IsListNotNullOrEmptyConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/IsListNotNullOrEmptyConverter.shared.cs
@@ -8,6 +8,9 @@ namespace CommunityToolkit.Maui.Converters;
 /// </summary>
 public class IsListNotNullOrEmptyConverter : BaseConverterOneWay<IEnumerable?, bool>
 {
+	/// <inheritdoc/>
+	public override bool DefaultReturnValue { get; } = false;
+
 	/// <summary>
 	/// Converts the incoming value to a <see cref="bool"/> indicating whether or not the value is not null and not empty.
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/IsListNullOrEmptyConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/IsListNullOrEmptyConverter.shared.cs
@@ -8,6 +8,9 @@ namespace CommunityToolkit.Maui.Converters;
 /// </summary>
 public class IsListNullOrEmptyConverter : BaseConverterOneWay<IEnumerable?, bool>
 {
+	/// <inheritdoc/>
+	public override bool DefaultReturnValue { get; } = false;
+
 	/// <summary>
 	/// Converts the incoming value to a <see cref="bool"/> indicating whether or not the value is null or empty.
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/IsListNullOrEmptyConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/IsListNullOrEmptyConverter.shared.cs
@@ -9,7 +9,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class IsListNullOrEmptyConverter : BaseConverterOneWay<IEnumerable?, bool>
 {
 	/// <inheritdoc/>
-	public override bool DefaultReturnValue { get; } = false;
+	public override bool DefaultReturnValue { get; set; } = false;
 
 	/// <summary>
 	/// Converts the incoming value to a <see cref="bool"/> indicating whether or not the value is null or empty.

--- a/src/CommunityToolkit.Maui/Converters/IsNotEqualConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/IsNotEqualConverter.shared.cs
@@ -7,6 +7,9 @@ namespace CommunityToolkit.Maui.Converters;
 /// </summary>
 public class IsNotEqualConverter : BaseConverterOneWay<object?, bool, object?>
 {
+	/// <inheritdoc/>
+	public override bool DefaultReturnValue { get; } = false;
+
 	/// <summary>
 	/// Checks whether the incoming value doesn't equal the provided parameter.
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/IsNotEqualConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/IsNotEqualConverter.shared.cs
@@ -8,7 +8,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class IsNotEqualConverter : BaseConverterOneWay<object?, bool, object?>
 {
 	/// <inheritdoc/>
-	public override bool DefaultReturnValue { get; } = false;
+	public override bool DefaultReturnValue { get; set; } = false;
 
 	/// <summary>
 	/// Checks whether the incoming value doesn't equal the provided parameter.

--- a/src/CommunityToolkit.Maui/Converters/IsNotNullConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/IsNotNullConverter.shared.cs
@@ -7,6 +7,9 @@ namespace CommunityToolkit.Maui.Converters;
 /// </summary>
 public class IsNotNullConverter : BaseConverterOneWay<object?, bool>
 {
+	/// <inheritdoc/>
+	public override bool DefaultReturnValue { get; } = false;
+
 	/// <summary>
 	/// Converts the incoming object to a <see cref="bool"/> indicating whether or not the value is not null.
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/IsNotNullConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/IsNotNullConverter.shared.cs
@@ -8,7 +8,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class IsNotNullConverter : BaseConverterOneWay<object?, bool>
 {
 	/// <inheritdoc/>
-	public override bool DefaultReturnValue { get; } = false;
+	public override bool DefaultReturnValue { get; set; } = false;
 
 	/// <summary>
 	/// Converts the incoming object to a <see cref="bool"/> indicating whether or not the value is not null.

--- a/src/CommunityToolkit.Maui/Converters/IsNullConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/IsNullConverter.shared.cs
@@ -8,7 +8,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class IsNullConverter : BaseConverterOneWay<object?, bool>
 {
 	/// <inheritdoc/>
-	public override bool DefaultReturnValue { get; } = false;
+	public override bool DefaultReturnValue { get; set; } = false;
 
 	/// <summary>
 	/// Converts the incoming object to a <see cref="bool"/> indicating whether or not the value is null.

--- a/src/CommunityToolkit.Maui/Converters/IsNullConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/IsNullConverter.shared.cs
@@ -7,6 +7,9 @@ namespace CommunityToolkit.Maui.Converters;
 /// </summary>
 public class IsNullConverter : BaseConverterOneWay<object?, bool>
 {
+	/// <inheritdoc/>
+	public override bool DefaultReturnValue { get; } = false;
+
 	/// <summary>
 	/// Converts the incoming object to a <see cref="bool"/> indicating whether or not the value is null.
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/IsStringNotNullOrEmptyConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/IsStringNotNullOrEmptyConverter.shared.cs
@@ -8,7 +8,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class IsStringNotNullOrEmptyConverter : BaseConverterOneWay<string?, bool>
 {
 	/// <inheritdoc/>
-	public override bool DefaultReturnValue { get; } = false;
+	public override bool DefaultReturnValue { get; set; } = false;
 
 	/// <summary>
 	/// Converts the incoming string to a <see cref="bool"/> indicating whether or not the value is not null and not empty using string.IsNullOrEmpty.

--- a/src/CommunityToolkit.Maui/Converters/IsStringNotNullOrEmptyConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/IsStringNotNullOrEmptyConverter.shared.cs
@@ -7,6 +7,9 @@ namespace CommunityToolkit.Maui.Converters;
 /// </summary>
 public class IsStringNotNullOrEmptyConverter : BaseConverterOneWay<string?, bool>
 {
+	/// <inheritdoc/>
+	public override bool DefaultReturnValue { get; } = false;
+
 	/// <summary>
 	/// Converts the incoming string to a <see cref="bool"/> indicating whether or not the value is not null and not empty using string.IsNullOrEmpty.
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/IsStringNotNullOrWhiteSpaceConverter.cs
+++ b/src/CommunityToolkit.Maui/Converters/IsStringNotNullOrWhiteSpaceConverter.cs
@@ -7,6 +7,9 @@ namespace CommunityToolkit.Maui.Converters;
 /// </summary>
 public class IsStringNotNullOrWhiteSpaceConverter : BaseConverterOneWay<string?, bool>
 {
+	/// <inheritdoc/>
+	public override bool DefaultReturnValue { get; } = false;
+
 	/// <summary>
 	/// Converts the incoming string to a <see cref="bool"/> indicating whether or not the value is not null and not white space using string.IsNullOrWhiteSpace.
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/IsStringNotNullOrWhiteSpaceConverter.cs
+++ b/src/CommunityToolkit.Maui/Converters/IsStringNotNullOrWhiteSpaceConverter.cs
@@ -8,7 +8,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class IsStringNotNullOrWhiteSpaceConverter : BaseConverterOneWay<string?, bool>
 {
 	/// <inheritdoc/>
-	public override bool DefaultReturnValue { get; } = false;
+	public override bool DefaultReturnValue { get; set; } = false;
 
 	/// <summary>
 	/// Converts the incoming string to a <see cref="bool"/> indicating whether or not the value is not null and not white space using string.IsNullOrWhiteSpace.

--- a/src/CommunityToolkit.Maui/Converters/IsStringNullOrEmptyConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/IsStringNullOrEmptyConverter.shared.cs
@@ -8,7 +8,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class IsStringNullOrEmptyConverter : BaseConverterOneWay<string?, bool>
 {
 	/// <inheritdoc/>
-	public override bool DefaultReturnValue { get; } = false;
+	public override bool DefaultReturnValue { get; set; } = false;
 
 	/// <summary>
 	/// Converts the incoming string to a <see cref="bool"/> indicating whether or not the string is null or empty using string.IsNullOrEmpty.

--- a/src/CommunityToolkit.Maui/Converters/IsStringNullOrEmptyConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/IsStringNullOrEmptyConverter.shared.cs
@@ -7,6 +7,9 @@ namespace CommunityToolkit.Maui.Converters;
 /// </summary>
 public class IsStringNullOrEmptyConverter : BaseConverterOneWay<string?, bool>
 {
+	/// <inheritdoc/>
+	public override bool DefaultReturnValue { get; } = false;
+
 	/// <summary>
 	/// Converts the incoming string to a <see cref="bool"/> indicating whether or not the string is null or empty using string.IsNullOrEmpty.
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/IsStringNullOrWhiteSpaceConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/IsStringNullOrWhiteSpaceConverter.shared.cs
@@ -8,7 +8,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class IsStringNullOrWhiteSpaceConverter : BaseConverterOneWay<string?, bool>
 {
 	/// <inheritdoc/>
-	public override bool DefaultReturnValue { get; } = false;
+	public override bool DefaultReturnValue { get; set; } = false;
 
 	/// <summary>
 	/// Converts the incoming string to a <see cref="bool"/> indicating whether or not the string is null or white space using string.IsNullOrWhiteSpace.

--- a/src/CommunityToolkit.Maui/Converters/IsStringNullOrWhiteSpaceConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/IsStringNullOrWhiteSpaceConverter.shared.cs
@@ -7,6 +7,9 @@ namespace CommunityToolkit.Maui.Converters;
 /// </summary>
 public class IsStringNullOrWhiteSpaceConverter : BaseConverterOneWay<string?, bool>
 {
+	/// <inheritdoc/>
+	public override bool DefaultReturnValue { get; } = false;
+
 	/// <summary>
 	/// Converts the incoming string to a <see cref="bool"/> indicating whether or not the string is null or white space using string.IsNullOrWhiteSpace.
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/ItemTappedEventArgsConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ItemTappedEventArgsConverter.shared.cs
@@ -8,6 +8,9 @@ namespace CommunityToolkit.Maui.Converters;
 /// </summary>
 public class ItemTappedEventArgsConverter : BaseConverterOneWay<ItemTappedEventArgs?, object?>
 {
+	/// <inheritdoc/>
+	public override object? DefaultReturnValue { get; } = null;
+
 	/// <summary>
 	/// Converts/Extracts the incoming value from <see cref="ItemTappedEventArgs"/> object and returns the value of <see cref="ItemTappedEventArgs.Item"/> property from it.
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/ItemTappedEventArgsConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ItemTappedEventArgsConverter.shared.cs
@@ -9,7 +9,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class ItemTappedEventArgsConverter : BaseConverterOneWay<ItemTappedEventArgs?, object?>
 {
 	/// <inheritdoc/>
-	public override object? DefaultReturnValue { get; } = null;
+	public override object? DefaultReturnValue { get; set; } = null;
 
 	/// <summary>
 	/// Converts/Extracts the incoming value from <see cref="ItemTappedEventArgs"/> object and returns the value of <see cref="ItemTappedEventArgs.Item"/> property from it.

--- a/src/CommunityToolkit.Maui/Converters/ListToStringConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ListToStringConverter.shared.cs
@@ -11,7 +11,7 @@ public class ListToStringConverter : BaseConverterOneWay<IEnumerable, string, st
 	string separator = string.Empty;
 
 	/// <inheritdoc/>
-	public override string DefaultReturnValue { get; } = string.Empty;
+	public override string DefaultReturnValue { get; set; } = string.Empty;
 
 	/// <summary>
 	/// The value that separates each item in the collection

--- a/src/CommunityToolkit.Maui/Converters/ListToStringConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ListToStringConverter.shared.cs
@@ -10,6 +10,9 @@ public class ListToStringConverter : BaseConverterOneWay<IEnumerable, string, st
 {
 	string separator = string.Empty;
 
+	/// <inheritdoc/>
+	public override string DefaultReturnValue { get; } = string.Empty;
+
 	/// <summary>
 	/// The value that separates each item in the collection
 	/// This value is superseded by the ConverterParameter, if provided

--- a/src/CommunityToolkit.Maui/Converters/MathExpressionConverter/MathExpressionConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/MathExpressionConverter/MathExpressionConverter.shared.cs
@@ -7,6 +7,9 @@ namespace CommunityToolkit.Maui.Converters;
 /// </summary>
 public class MathExpressionConverter : BaseConverterOneWay<double, double, string>
 {
+	/// <inheritdoc/>
+	public override double DefaultReturnValue { get; } = 0.0d;
+
 	/// <summary>
 	/// Calculate the incoming expression string with one variable.
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/MathExpressionConverter/MathExpressionConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/MathExpressionConverter/MathExpressionConverter.shared.cs
@@ -8,7 +8,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class MathExpressionConverter : BaseConverterOneWay<double, double, string>
 {
 	/// <inheritdoc/>
-	public override double DefaultReturnValue { get; } = 0.0d;
+	public override double DefaultReturnValue { get; set; } = 0.0d;
 
 	/// <summary>
 	/// Calculate the incoming expression string with one variable.

--- a/src/CommunityToolkit.Maui/Converters/SelectedItemEventArgsConverter.cs
+++ b/src/CommunityToolkit.Maui/Converters/SelectedItemEventArgsConverter.cs
@@ -8,6 +8,9 @@ namespace CommunityToolkit.Maui.Converters;
 /// </summary>
 public class SelectedItemEventArgsConverter : BaseConverterOneWay<SelectedItemChangedEventArgs?, object?>
 {
+	/// <inheritdoc/>
+	public override object? DefaultReturnValue { get; } = null;
+
 	/// <summary>
 	/// Converts/Extracts the incoming value from <see cref="SelectedItemChangedEventArgs"/> object and returns the value of <see cref="SelectedItemChangedEventArgs.SelectedItem"/> property from it.
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/SelectedItemEventArgsConverter.cs
+++ b/src/CommunityToolkit.Maui/Converters/SelectedItemEventArgsConverter.cs
@@ -9,7 +9,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class SelectedItemEventArgsConverter : BaseConverterOneWay<SelectedItemChangedEventArgs?, object?>
 {
 	/// <inheritdoc/>
-	public override object? DefaultReturnValue { get; } = null;
+	public override object? DefaultReturnValue { get; set; } = null;
 
 	/// <summary>
 	/// Converts/Extracts the incoming value from <see cref="SelectedItemChangedEventArgs"/> object and returns the value of <see cref="SelectedItemChangedEventArgs.SelectedItem"/> property from it.

--- a/src/CommunityToolkit.Maui/Converters/StateToBooleanConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/StateToBooleanConverter.shared.cs
@@ -30,7 +30,7 @@ public class StateToBooleanConverter : BaseConverterOneWay<LayoutState, bool, La
 	LayoutState stateToCompare = LayoutState.None;
 
 	/// <inheritdoc/>
-	public override bool DefaultReturnValue { get; } = false;
+	public override bool DefaultReturnValue { get; set; } = false;
 
 	/// <summary>
 	/// The <see cref="LayoutState"/> to compare to.

--- a/src/CommunityToolkit.Maui/Converters/StateToBooleanConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/StateToBooleanConverter.shared.cs
@@ -29,6 +29,9 @@ public class StateToBooleanConverter : BaseConverterOneWay<LayoutState, bool, La
 {
 	LayoutState stateToCompare = LayoutState.None;
 
+	/// <inheritdoc/>
+	public override bool DefaultReturnValue { get; } = false;
+
 	/// <summary>
 	/// The <see cref="LayoutState"/> to compare to.
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/StringToListConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/StringToListConverter.shared.cs
@@ -12,7 +12,7 @@ public class StringToListConverter : BaseConverterOneWay<string?, IEnumerable, o
 	IList<string> separators = Array.Empty<string>();
 
 	/// <inheritdoc/>
-	public override IEnumerable DefaultReturnValue { get; } = Enumerable.Empty<string>();
+	public override IEnumerable DefaultReturnValue { get; } = Array.Empty<string>();
 
 	/// <summary>
 	/// The string that delimits the substrings in this string

--- a/src/CommunityToolkit.Maui/Converters/StringToListConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/StringToListConverter.shared.cs
@@ -11,6 +11,9 @@ public class StringToListConverter : BaseConverterOneWay<string?, IEnumerable, o
 	string separator = " ";
 	IList<string> separators = Array.Empty<string>();
 
+	/// <inheritdoc/>
+	public override IEnumerable DefaultReturnValue { get; } = Enumerable.Empty<string>();
+
 	/// <summary>
 	/// The string that delimits the substrings in this string
 	/// This value is superseded by the ConverterParameter, if provided

--- a/src/CommunityToolkit.Maui/Converters/StringToListConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/StringToListConverter.shared.cs
@@ -12,7 +12,7 @@ public class StringToListConverter : BaseConverterOneWay<string?, IEnumerable, o
 	IList<string> separators = Array.Empty<string>();
 
 	/// <inheritdoc/>
-	public override IEnumerable DefaultReturnValue { get; } = Array.Empty<string>();
+	public override IEnumerable DefaultReturnValue { get; set; } = Array.Empty<string>();
 
 	/// <summary>
 	/// The string that delimits the substrings in this string

--- a/src/CommunityToolkit.Maui/Converters/TextCaseConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/TextCaseConverter.shared.cs
@@ -31,7 +31,7 @@ public class TextCaseConverter : BaseConverterOneWay<string?, string?, TextCaseT
 	TextCaseType type = TextCaseType.None;
 
 	/// <inheritdoc/>
-	public override string? DefaultReturnValue { get; } = null;
+	public override string? DefaultReturnValue { get; set; } = null;
 
 	/// <summary>
 	/// The desired text case that the text should be converted to.

--- a/src/CommunityToolkit.Maui/Converters/TextCaseConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/TextCaseConverter.shared.cs
@@ -30,6 +30,9 @@ public class TextCaseConverter : BaseConverterOneWay<string?, string?, TextCaseT
 {
 	TextCaseType type = TextCaseType.None;
 
+	/// <inheritdoc/>
+	public override string? DefaultReturnValue { get; } = null;
+
 	/// <summary>
 	/// The desired text case that the text should be converted to.
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/TimeSpanToSecondsConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/TimeSpanToSecondsConverter.shared.cs
@@ -7,6 +7,9 @@ namespace CommunityToolkit.Maui.Converters;
 /// </summary>
 public class TimeSpanToSecondsConverter : BaseConverter<TimeSpan, double>
 {
+	/// <inheritdoc/>
+	public override double DefaultReturnValue { get; } = 0.0d;
+
 	/// <summary>
 	/// Converts a <see cref="TimeSpan"/> to a <see cref="double"/> value expressed in seconds.
 	/// </summary>

--- a/src/CommunityToolkit.Maui/Converters/TimeSpanToSecondsConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/TimeSpanToSecondsConverter.shared.cs
@@ -8,7 +8,7 @@ namespace CommunityToolkit.Maui.Converters;
 public class TimeSpanToSecondsConverter : BaseConverter<TimeSpan, double>
 {
 	/// <inheritdoc/>
-	public override double DefaultReturnValue { get; } = 0.0d;
+	public override double DefaultReturnValue { get; set; } = 0.0d;
 
 	/// <summary>
 	/// Converts a <see cref="TimeSpan"/> to a <see cref="double"/> value expressed in seconds.


### PR DESCRIPTION
> Note: This PR targets the `maui-options` branch, not the `main` branch. In other words, when this PR is merged, it will not be merged to `main`; it will be merged into PR #616.

Hey @VladislavAntonyuk!

I took a stab at changing `DefaultReturnValue` to `abstract` and wanted to share it with you before we add it to your PR, #616.

### Changes

```cs
public TTo DefaultReturnValue { get;  set; } = default;
```
becomes
```cs
public abstract TTo DefaultReturnValue { get; }
```

### Recommendation 
I prefer to move forward with this approach for a couple reasons:
1. It will force future contributors to make a thoughtful decision for the `DefaultReturnValue` of their new Converter (instead of just letting it default it to `DefaultReturnValue = default`)
2. It allows us to use a readonly-property
    - This matches the other readonly properties in `ICommunityToolkitValueConverter`
2. It allows us to use `TTo` instead of `TTo?` for its Type
    - This allows each Converter to decide whether or not `TTo` is nullable
      - E.g., `CompareConverter` uses `object` (not `object?`) for `TTo` type whereas `ByteArrayToImageSourceConverter` uses `ImageSource?` for its `TTo` type
4. It ensures that Converters that don't return a nullable value won't return `null`
    - E.g. `ColorToGrayScaleColorConverter` uses `Color` (not `Color?`) for its `TTo` type, so I set its `DefaultReturnValue` to `Colors.Transparant` instead of `null` to avoid returning `null`