### PR TITLE
[CommunityToolkit.Maui.Sample] Add `Microsoft.Extensions.Http.Polly` and implement `.AddTransientWithShellRoute()`

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/AppShell.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/AppShell.xaml.cs
@@ -101,14 +101,14 @@ public partial class AppShell : Shell
 
 	public AppShell() => InitializeComponent();
 
-	public static string GetPageRoute<TViewModel>()  where TViewModel : BaseViewModel
+	public static string GetPageRoute<TViewModel>() where TViewModel : BaseViewModel
 	{
 		return GetPageRoute(typeof(TViewModel));
 	}
 
 	public static string GetPageRoute(Type viewModelType)
 	{
-		if(!viewModelType.IsAssignableTo(typeof(BaseViewModel)))
+		if (!viewModelType.IsAssignableTo(typeof(BaseViewModel)))
 		{
 			throw new ArgumentException($"{nameof(viewModelType)} must implement {nameof(BaseViewModel)}", nameof(viewModelType));
 		}

--- a/samples/CommunityToolkit.Maui.Sample/AppShell.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/AppShell.xaml.cs
@@ -101,8 +101,18 @@ public partial class AppShell : Shell
 
 	public AppShell() => InitializeComponent();
 
+	public static string GetPageRoute<TViewModel>()  where TViewModel : BaseViewModel
+	{
+		return GetPageRoute(typeof(TViewModel));
+	}
+
 	public static string GetPageRoute(Type viewModelType)
 	{
+		if(!viewModelType.IsAssignableTo(typeof(BaseViewModel)))
+		{
+			throw new ArgumentException($"{nameof(viewModelType)} must implement {nameof(BaseViewModel)}", nameof(viewModelType));
+		}
+
 		if (!viewModelMappings.TryGetValue(viewModelType, out (Type GalleryPageType, Type ContentPageType) mapping))
 		{
 			throw new KeyNotFoundException($"No map for ${viewModelType} was found on navigation mappings. Please register your ViewModel in {nameof(AppShell)}.{nameof(viewModelMappings)}");
@@ -119,9 +129,6 @@ public partial class AppShell : Shell
 																																							where TGalleryPage : BaseGalleryPage<TGalleryViewModel>
 																																							where TGalleryViewModel : BaseGalleryViewModel
 	{
-		var route = GetPageRoute(typeof(TGalleryPage), typeof(TPage));
-		Routing.RegisterRoute(route, typeof(TPage));
-
 		return new KeyValuePair<Type, (Type GalleryPageType, Type ContentPageType)>(typeof(TViewModel), (typeof(TGalleryPage), typeof(TPage)));
 	}
 }

--- a/samples/CommunityToolkit.Maui.Sample/CommunityToolkit.Maui.Sample.csproj
+++ b/samples/CommunityToolkit.Maui.Sample/CommunityToolkit.Maui.Sample.csproj
@@ -42,7 +42,7 @@
 
     <PackageReference Include="CommunityToolkit.Maui.Markup" Version="1.0.1" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.2-mauipre.1.22102.15" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.9" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/samples/CommunityToolkit.Maui.Sample/MauiProgram.cs
+++ b/samples/CommunityToolkit.Maui.Sample/MauiProgram.cs
@@ -1,17 +1,20 @@
 ﻿using CommunityToolkit.Maui.Markup;
 using CommunityToolkit.Maui.Sample.Models;
+using CommunityToolkit.Maui.Sample.Pages;
 using CommunityToolkit.Maui.Sample.Pages.Alerts;
 using CommunityToolkit.Maui.Sample.Pages.Behaviors;
 using CommunityToolkit.Maui.Sample.Pages.Converters;
 using CommunityToolkit.Maui.Sample.Pages.Extensions;
 using CommunityToolkit.Maui.Sample.Pages.Layouts;
 using CommunityToolkit.Maui.Sample.Pages.Views;
+using CommunityToolkit.Maui.Sample.ViewModels;
 using CommunityToolkit.Maui.Sample.ViewModels.Alerts;
 using CommunityToolkit.Maui.Sample.ViewModels.Behaviors;
 using CommunityToolkit.Maui.Sample.ViewModels.Converters;
 using CommunityToolkit.Maui.Sample.ViewModels.Layouts;
 using CommunityToolkit.Maui.Sample.ViewModels.Views;
 using CommunityToolkit.Maui.Sample.ViewModels.Views.AvatarView;
+using Polly;
 
 [assembly: XamlCompilation(XamlCompilationOptions.Compile)]
 
@@ -35,13 +38,17 @@ public static class MauiProgram
 								.UseMauiCommunityToolkitMarkup()
 								.UseMauiApp<App>();
 
-		builder.Services.AddHttpClient<ByteArrayToImageSourceConverterViewModel>();
+		builder.Services.AddHttpClient<ByteArrayToImageSourceConverterViewModel>()
+						.AddTransientHttpErrorPolicy(builder => builder.WaitAndRetryAsync(3, sleepDurationProvider));
+
 		builder.Services.AddSingleton<PopupSizeConstants>();
 
 		RegisterViewsAndViewModels(builder.Services);
 		RegisterEssentials(builder.Services);
 
 		return builder.Build();
+
+		static TimeSpan sleepDurationProvider(int attemptNumber) => TimeSpan.FromSeconds(Math.Pow(2, attemptNumber));
 	}
 
 	static void RegisterViewsAndViewModels(in IServiceCollection services)
@@ -55,85 +62,85 @@ public static class MauiProgram
 		services.AddTransient<ViewsGalleryPage, ViewsGalleryViewModel>();
 
 		// Add Alerts Pages + ViewModels
-		services.AddTransient<SnackbarPage, SnackbarViewModel>();
-		services.AddTransient<ToastPage, ToastViewModel>();
+		services.AddTransientWithShellRoute<SnackbarPage, SnackbarViewModel>();
+		services.AddTransientWithShellRoute<ToastPage, ToastViewModel>();
 
 		// Add AvatarView pages + ViewModels
-		services.AddTransient<AvatarViewBindablePropertiesPage, AvatarViewBindablePropertiesViewModel>();
-		services.AddTransient<AvatarViewBordersPage, AvatarViewBordersViewModel>();
-		services.AddTransient<AvatarViewColorsPage, AvatarViewColorsViewModel>();
-		services.AddTransient<AvatarViewDayOfWeekPage, AvatarViewDayOfWeekViewModel>();
-		services.AddTransient<AvatarViewGesturesPage, AvatarViewGesturesViewModel>();
-		services.AddTransient<AvatarViewImagesPage, AvatarViewImagesViewModel>();
-		services.AddTransient<AvatarViewKeyboardPage, AvatarViewKeyboardViewModel>();
-		services.AddTransient<AvatarViewRatingPage, AvatarViewRatingViewModel>();
-		services.AddTransient<AvatarViewShadowsPage, AvatarViewShadowsViewModel>();
-		services.AddTransient<AvatarViewShapesPage, AvatarViewShapesViewModel>();
-		services.AddTransient<AvatarViewSizesPage, AvatarViewSizesViewModel>();
+		services.AddTransientWithShellRoute<AvatarViewBindablePropertiesPage, AvatarViewBindablePropertiesViewModel>();
+		services.AddTransientWithShellRoute<AvatarViewBordersPage, AvatarViewBordersViewModel>();
+		services.AddTransientWithShellRoute<AvatarViewColorsPage, AvatarViewColorsViewModel>();
+		services.AddTransientWithShellRoute<AvatarViewDayOfWeekPage, AvatarViewDayOfWeekViewModel>();
+		services.AddTransientWithShellRoute<AvatarViewGesturesPage, AvatarViewGesturesViewModel>();
+		services.AddTransientWithShellRoute<AvatarViewImagesPage, AvatarViewImagesViewModel>();
+		services.AddTransientWithShellRoute<AvatarViewKeyboardPage, AvatarViewKeyboardViewModel>();
+		services.AddTransientWithShellRoute<AvatarViewRatingPage, AvatarViewRatingViewModel>();
+		services.AddTransientWithShellRoute<AvatarViewShadowsPage, AvatarViewShadowsViewModel>();
+		services.AddTransientWithShellRoute<AvatarViewShapesPage, AvatarViewShapesViewModel>();
+		services.AddTransientWithShellRoute<AvatarViewSizesPage, AvatarViewSizesViewModel>();
 
 		// Add Behaviors Pages + ViewModels
-		services.AddTransient<AnimationBehaviorPage, AnimationBehaviorViewModel>();
-		services.AddTransient<CharactersValidationBehaviorPage, CharactersValidationBehaviorViewModel>();
-		services.AddTransient<EmailValidationBehaviorPage, EmailValidationBehaviorViewModel>();
-		services.AddTransient<EventToCommandBehaviorPage, EventToCommandBehaviorViewModel>();
-		services.AddTransient<IconTintColorBehaviorPage, IconTintColorBehaviorViewModel>();
-		services.AddTransient<MaskedBehaviorPage, MaskedBehaviorViewModel>();
-		services.AddTransient<MaxLengthReachedBehaviorPage, MaxLengthReachedBehaviorViewModel>();
-		services.AddTransient<MultiValidationBehaviorPage, MultiValidationBehaviorViewModel>();
-		services.AddTransient<NumericValidationBehaviorPage, NumericValidationBehaviorViewModel>();
-		services.AddTransient<ProgressBarAnimationBehaviorPage, ProgressBarAnimationBehaviorViewModel>();
-		services.AddTransient<RequiredStringValidationBehaviorPage, RequiredStringValidationBehaviorViewModel>();
-		services.AddTransient<SelectAllTextBehaviorPage, SelectAllTextBehaviorViewModel>();
-		services.AddTransient<SetFocusOnEntryCompletedBehaviorPage, SetFocusOnEntryCompletedBehaviorViewModel>();
-		services.AddTransient<TextValidationBehaviorPage, TextValidationBehaviorViewModel>();
-		services.AddTransient<UriValidationBehaviorPage, UriValidationBehaviorViewModel>();
-		services.AddTransient<UserStoppedTypingBehaviorPage, UserStoppedTypingBehaviorViewModel>();
+		services.AddTransientWithShellRoute<AnimationBehaviorPage, AnimationBehaviorViewModel>();
+		services.AddTransientWithShellRoute<CharactersValidationBehaviorPage, CharactersValidationBehaviorViewModel>();
+		services.AddTransientWithShellRoute<EmailValidationBehaviorPage, EmailValidationBehaviorViewModel>();
+		services.AddTransientWithShellRoute<EventToCommandBehaviorPage, EventToCommandBehaviorViewModel>();
+		services.AddTransientWithShellRoute<IconTintColorBehaviorPage, IconTintColorBehaviorViewModel>();
+		services.AddTransientWithShellRoute<MaskedBehaviorPage, MaskedBehaviorViewModel>();
+		services.AddTransientWithShellRoute<MaxLengthReachedBehaviorPage, MaxLengthReachedBehaviorViewModel>();
+		services.AddTransientWithShellRoute<MultiValidationBehaviorPage, MultiValidationBehaviorViewModel>();
+		services.AddTransientWithShellRoute<NumericValidationBehaviorPage, NumericValidationBehaviorViewModel>();
+		services.AddTransientWithShellRoute<ProgressBarAnimationBehaviorPage, ProgressBarAnimationBehaviorViewModel>();
+		services.AddTransientWithShellRoute<RequiredStringValidationBehaviorPage, RequiredStringValidationBehaviorViewModel>();
+		services.AddTransientWithShellRoute<SelectAllTextBehaviorPage, SelectAllTextBehaviorViewModel>();
+		services.AddTransientWithShellRoute<SetFocusOnEntryCompletedBehaviorPage, SetFocusOnEntryCompletedBehaviorViewModel>();
+		services.AddTransientWithShellRoute<TextValidationBehaviorPage, TextValidationBehaviorViewModel>();
+		services.AddTransientWithShellRoute<UriValidationBehaviorPage, UriValidationBehaviorViewModel>();
+		services.AddTransientWithShellRoute<UserStoppedTypingBehaviorPage, UserStoppedTypingBehaviorViewModel>();
 
 		// Add Converters Pages + ViewModels
-		services.AddTransient<BoolToObjectConverterPage, BoolToObjectConverterViewModel>();
-		services.AddTransient<ByteArrayToImageSourceConverterPage, ByteArrayToImageSourceConverterViewModel>();
-		services.AddTransient<ColorsConverterPage, ColorsConverterViewModel>();
-		services.AddTransient<CompareConverterPage, CompareConverterViewModel>();
-		services.AddTransient<DateTimeOffsetConverterPage, DateTimeOffsetConverterViewModel>();
-		services.AddTransient<DoubleToIntConverterPage, DoubleToIntConverterViewModel>();
-		services.AddTransient<EnumToBoolConverterPage, EnumToBoolConverterViewModel>();
-		services.AddTransient<EnumToIntConverterPage, EnumToIntConverterViewModel>();
-		services.AddTransient<ImageResourceConverterPage, ImageResourceConverterViewModel>();
-		services.AddTransient<IndexToArrayItemConverterPage, IndexToArrayItemConverterViewModel>();
-		services.AddTransient<IntToBoolConverterPage, IntToBoolConverterViewModel>();
-		services.AddTransient<InvertedBoolConverterPage, InvertedBoolConverterViewModel>();
-		services.AddTransient<IsEqualConverterPage, IsEqualConverterViewModel>();
-		services.AddTransient<IsListNotNullOrEmptyConverterPage, IsListNotNullOrEmptyConverterViewModel>();
-		services.AddTransient<IsListNullOrEmptyConverterPage, IsListNullOrEmptyConverterViewModel>();
-		services.AddTransient<IsNotEqualConverterPage, IsNotEqualConverterViewModel>();
-		services.AddTransient<IsNotNullConverterPage, IsNotNullConverterViewModel>();
-		services.AddTransient<IsNullConverterPage, IsNullConverterViewModel>();
-		services.AddTransient<IsStringNotNullOrEmptyConverterPage, IsStringNotNullOrEmptyConverterViewModel>();
-		services.AddTransient<IsStringNotNullOrWhiteSpaceConverterPage, IsStringNotNullOrWhiteSpaceConverterViewModel>();
-		services.AddTransient<IsStringNullOrEmptyConverterPage, IsStringNullOrEmptyConverterViewModel>();
-		services.AddTransient<IsStringNullOrWhiteSpaceConverterPage, IsStringNullOrWhiteSpaceConverterViewModel>();
-		services.AddTransient<ItemTappedEventArgsConverterPage, ItemTappedEventArgsConverterViewModel>();
-		services.AddTransient<ListToStringConverterPage, ListToStringConverterViewModel>();
-		services.AddTransient<MathExpressionConverterPage, MathExpressionConverterViewModel>();
-		services.AddTransient<MultiConverterPage, MultiConverterViewModel>();
-		services.AddTransient<MultiMathExpressionConverterPage, MultiMathExpressionConverterViewModel>();
-		services.AddTransient<SelectedItemEventArgsConverterPage, SelectedItemEventArgsConverterViewModel>();
-		services.AddTransient<StateToBooleanConverterPage, StateToBooleanConverterViewModel>();
-		services.AddTransient<StringToListConverterPage, StringToListConverterViewModel>();
-		services.AddTransient<TextCaseConverterPage, TextCaseConverterViewModel>();
-		services.AddTransient<VariableMultiValueConverterPage, VariableMultiValueConverterViewModel>();
+		services.AddTransientWithShellRoute<BoolToObjectConverterPage, BoolToObjectConverterViewModel>();
+		services.AddTransientWithShellRoute<ByteArrayToImageSourceConverterPage, ByteArrayToImageSourceConverterViewModel>();
+		services.AddTransientWithShellRoute<ColorsConverterPage, ColorsConverterViewModel>();
+		services.AddTransientWithShellRoute<CompareConverterPage, CompareConverterViewModel>();
+		services.AddTransientWithShellRoute<DateTimeOffsetConverterPage, DateTimeOffsetConverterViewModel>();
+		services.AddTransientWithShellRoute<DoubleToIntConverterPage, DoubleToIntConverterViewModel>();
+		services.AddTransientWithShellRoute<EnumToBoolConverterPage, EnumToBoolConverterViewModel>();
+		services.AddTransientWithShellRoute<EnumToIntConverterPage, EnumToIntConverterViewModel>();
+		services.AddTransientWithShellRoute<ImageResourceConverterPage, ImageResourceConverterViewModel>();
+		services.AddTransientWithShellRoute<IndexToArrayItemConverterPage, IndexToArrayItemConverterViewModel>();
+		services.AddTransientWithShellRoute<IntToBoolConverterPage, IntToBoolConverterViewModel>();
+		services.AddTransientWithShellRoute<InvertedBoolConverterPage, InvertedBoolConverterViewModel>();
+		services.AddTransientWithShellRoute<IsEqualConverterPage, IsEqualConverterViewModel>();
+		services.AddTransientWithShellRoute<IsListNotNullOrEmptyConverterPage, IsListNotNullOrEmptyConverterViewModel>();
+		services.AddTransientWithShellRoute<IsListNullOrEmptyConverterPage, IsListNullOrEmptyConverterViewModel>();
+		services.AddTransientWithShellRoute<IsNotEqualConverterPage, IsNotEqualConverterViewModel>();
+		services.AddTransientWithShellRoute<IsNotNullConverterPage, IsNotNullConverterViewModel>();
+		services.AddTransientWithShellRoute<IsNullConverterPage, IsNullConverterViewModel>();
+		services.AddTransientWithShellRoute<IsStringNotNullOrEmptyConverterPage, IsStringNotNullOrEmptyConverterViewModel>();
+		services.AddTransientWithShellRoute<IsStringNotNullOrWhiteSpaceConverterPage, IsStringNotNullOrWhiteSpaceConverterViewModel>();
+		services.AddTransientWithShellRoute<IsStringNullOrEmptyConverterPage, IsStringNullOrEmptyConverterViewModel>();
+		services.AddTransientWithShellRoute<IsStringNullOrWhiteSpaceConverterPage, IsStringNullOrWhiteSpaceConverterViewModel>();
+		services.AddTransientWithShellRoute<ItemTappedEventArgsConverterPage, ItemTappedEventArgsConverterViewModel>();
+		services.AddTransientWithShellRoute<ListToStringConverterPage, ListToStringConverterViewModel>();
+		services.AddTransientWithShellRoute<MathExpressionConverterPage, MathExpressionConverterViewModel>();
+		services.AddTransientWithShellRoute<MultiConverterPage, MultiConverterViewModel>();
+		services.AddTransientWithShellRoute<MultiMathExpressionConverterPage, MultiMathExpressionConverterViewModel>();
+		services.AddTransientWithShellRoute<SelectedItemEventArgsConverterPage, SelectedItemEventArgsConverterViewModel>();
+		services.AddTransientWithShellRoute<StateToBooleanConverterPage, StateToBooleanConverterViewModel>();
+		services.AddTransientWithShellRoute<StringToListConverterPage, StringToListConverterViewModel>();
+		services.AddTransientWithShellRoute<TextCaseConverterPage, TextCaseConverterViewModel>();
+		services.AddTransientWithShellRoute<VariableMultiValueConverterPage, VariableMultiValueConverterViewModel>();
 
 		// Add Extensions Pages + ViewModels
-		services.AddTransient<ColorAnimationExtensionsPage, ColorAnimationExtensionsViewModel>();
+		services.AddTransientWithShellRoute<ColorAnimationExtensionsPage, ColorAnimationExtensionsViewModel>();
 
 		// Add Layouts Pages + ViewModels
-		services.AddTransient<UniformItemsLayoutPage, UniformItemsLayoutViewModel>();
+		services.AddTransientWithShellRoute<UniformItemsLayoutPage, UniformItemsLayoutViewModel>();
 
 		// Add Views Pages + ViewModels
-		services.AddTransient<DrawingViewPage, DrawingViewViewModel>();
-		services.AddTransient<MultiplePopupPage, MultiplePopupViewModel>();
-		services.AddTransient<PopupAnchorPage, PopupAnchorViewModel>();
-		services.AddTransient<PopupPositionPage, PopupPositionViewModel>();
+		services.AddTransientWithShellRoute<DrawingViewPage, DrawingViewViewModel>();
+		services.AddTransientWithShellRoute<MultiplePopupPage, MultiplePopupViewModel>();
+		services.AddTransientWithShellRoute<PopupAnchorPage, PopupAnchorViewModel>();
+		services.AddTransientWithShellRoute<PopupPositionPage, PopupPositionViewModel>();
 
 		// Add Popups
 		services.AddTransient<CsharpBindingPopup, CsharpBindingPopupViewModel>();
@@ -144,5 +151,11 @@ public static class MauiProgram
 	{
 		services.AddSingleton<IDeviceInfo>(DeviceInfo.Current);
 		services.AddSingleton<IDeviceDisplay>(DeviceDisplay.Current);
+	}
+
+	static IServiceCollection AddTransientWithShellRoute<TPage, TViewModel>(this IServiceCollection services) where TPage : BasePage<TViewModel>
+																												where TViewModel : BaseViewModel
+	{
+		return services.AddTransientWithShellRoute<TPage, TViewModel>(AppShell.GetPageRoute<TViewModel>());
 	}
 }

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Converters/ByteArrayToImageSourceConverterViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Converters/ByteArrayToImageSourceConverterViewModel.cs
@@ -8,7 +8,6 @@ public sealed partial class ByteArrayToImageSourceConverterViewModel : BaseViewM
 {
 	readonly WeakEventManager imageDownloadFailedEventManager = new();
 	readonly HttpClient client;
-	readonly IDispatcher dispatcher;
 
 	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(DownloadDotNetBotImageCommand))]
 	bool isDownloadingImage;
@@ -19,10 +18,9 @@ public sealed partial class ByteArrayToImageSourceConverterViewModel : BaseViewM
 	[ObservableProperty]
 	string labelText = "Tap the Download Image Button to download an Image as a byte[]";
 
-	public ByteArrayToImageSourceConverterViewModel(HttpClient client, IDispatcher dispatcher)
+	public ByteArrayToImageSourceConverterViewModel(HttpClient client)
 	{
 		this.client = client;
-		this.dispatcher = dispatcher;
 	}
 
 	public event EventHandler<string> ImageDownloadFailed


### PR DESCRIPTION
### Microsoft.Extensions.Http.Polly

To demonstrate best practices for .NET MAUI apps that utilize HttpClient, this PR replaces the following NuGet Package:
- `Microsoft.Extensions.Http` -> [`Microsoft.Extensions.Http.Polly`](https://www.nuget.org/packages/Microsoft.Extensions.Http.Polly)
  - (`Microsoft.Extensions.Http.Polly` includes a dependency on `Microsoft.Extensions.Http`)

Because .NET MAUI supports dependency injection, we can leverage `Microsoft.Extensions.Http.Polly` to add automatic error handling policies. In the updated code below, when HttpClient fails it will now automatically retry to connect to the URL 3 times using an exponential backoff of 2<sup>n</sup> seconds. This is ideal for flaky mobile internet connections where a user's device may switch cellular towers or lose a Wifi connection.

```cs
builder.Services.AddHttpClient<ByteArrayToImageSourceConverterViewModel>()
  .AddTransientHttpErrorPolicy(builder => builder.WaitAndRetryAsync(3, sleepDurationProvider));

static TimeSpan sleepDurationProvider(int attemptNumber) => TimeSpan.FromSeconds(Math.Pow(2, attemptNumber));
```

### `.AddTransientWithShellRoute()`

This PR also implements `.AddTransientWithShellRoute()`, a feature recently added to `CommunityToolkit.Maui`.

Previously, the Shell Page Routes were registered in `AppShell.CreateViewModelMapping()`.

