### PR TITLE
[BUG] GetImageStream wrong when lines populated from code #649

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Handlers/DrawingView/DrawingViewHandler.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Handlers/DrawingView/DrawingViewHandler.shared.cs
@@ -15,13 +15,14 @@ public partial class DrawingViewHandler
 	/// </summary>
 	public static readonly IPropertyMapper<IDrawingView, DrawingViewHandler> DrawingViewMapper = new PropertyMapper<IDrawingView, DrawingViewHandler>(ViewMapper)
 	{
-		[nameof(IDrawingView.Lines)] = MapLines,
+		// Order is important
+		[nameof(IDrawingView.DrawAction)] = MapDrawAction,
 		[nameof(IDrawingView.ShouldClearOnFinish)] = MapShouldClearOnFinish,
+		[nameof(IDrawingView.IsMultiLineModeEnabled)] = MapIsMultiLineModeEnabled,
 		[nameof(IDrawingView.LineColor)] = MapLineColor,
 		[nameof(IDrawingView.LineWidth)] = MapLineWidth,
-		[nameof(IDrawingView.IsMultiLineModeEnabled)] = MapIsMultiLineModeEnabled,
-		[nameof(IDrawingView.DrawAction)] = MapDrawAction,
 		[nameof(IDrawingView.Background)] = MapDrawingViewBackground,
+		[nameof(IDrawingView.Lines)] = MapLines,
 	};
 
 	/// <summary>

--- a/src/CommunityToolkit.Maui.Core/Handlers/DrawingView/DrawingViewHandler.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Handlers/DrawingView/DrawingViewHandler.shared.cs
@@ -15,14 +15,14 @@ public partial class DrawingViewHandler
 	/// </summary>
 	public static readonly IPropertyMapper<IDrawingView, DrawingViewHandler> DrawingViewMapper = new PropertyMapper<IDrawingView, DrawingViewHandler>(ViewMapper)
 	{
-		// Order is important
+		// Be careful when editing the order of the mappers below. `IDrawingView.Lines` must be mapped last.
 		[nameof(IDrawingView.DrawAction)] = MapDrawAction,
 		[nameof(IDrawingView.ShouldClearOnFinish)] = MapShouldClearOnFinish,
 		[nameof(IDrawingView.IsMultiLineModeEnabled)] = MapIsMultiLineModeEnabled,
 		[nameof(IDrawingView.LineColor)] = MapLineColor,
 		[nameof(IDrawingView.LineWidth)] = MapLineWidth,
 		[nameof(IDrawingView.Background)] = MapDrawingViewBackground,
-		[nameof(IDrawingView.Lines)] = MapLines,
+		[nameof(IDrawingView.Lines)] = MapLines, // `IDrawingView.Lines` must be mapped last
 	};
 
 	/// <summary>


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

The order of mapping properties is important. Lines should be mapped last

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #649

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [ ] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
