### PR TITLE
Moved SemanticProperites.Description setting out of ImageSource

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/ImageSources/GravatarImageSourcePage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/ImageSources/GravatarImageSourcePage.xaml
@@ -63,36 +63,33 @@
             </Label>
             <Line Style="{StaticResource HR}" />
             <Label SemanticProperties.HeadingLevel="Level2" Text="with Image control" />
-            <Image HeightRequest="128" WidthRequest="128">
+            <Image HeightRequest="128" WidthRequest="128" SemanticProperties.Description="GravatarImageSource for an Image control, binding all properties.">
                 <Image.Source>
                     <mct:GravatarImageSource
                         CacheValidity="{Binding CacheValidityTimespan}"
                         CachingEnabled="{Binding EnableCache}"
                         Email="{Binding Email}"
-                        Image="{Binding DefaultGravatarSelected}"
-                        SemanticProperties.Description="GravatarImageSource for an Image control, binding all properties." />
+                        Image="{Binding DefaultGravatarSelected}"/>
                 </Image.Source>
             </Image>
             <Label SemanticProperties.HeadingLevel="Level2" Text="with Button control" />
-            <Button Text="Button">
+            <Button Text="Button" SemanticProperties.Description="GravatarImageSource for a Button control, binding all properties." >
                 <Button.ImageSource>
                     <mct:GravatarImageSource
                         CacheValidity="{Binding CacheValidityTimespan}"
                         CachingEnabled="{Binding EnableCache}"
                         Email="{Binding Email}"
-                        Image="{Binding DefaultGravatarSelected}"
-                        SemanticProperties.Description="GravatarImageSource for a Button control, binding all properties." />
+                        Image="{Binding DefaultGravatarSelected}"/>
                 </Button.ImageSource>
             </Button>
             <Label SemanticProperties.HeadingLevel="Level2" Text="with ImageButton control" />
-            <ImageButton HeightRequest="73" WidthRequest="72">
+            <ImageButton HeightRequest="73" WidthRequest="72" SemanticProperties.Description="GravatarImageSource for an ImageButton control, binding all properties." >
                 <ImageButton.Source>
                     <mct:GravatarImageSource
                         CacheValidity="{Binding CacheValidityTimespan}"
                         CachingEnabled="{Binding EnableCache}"
                         Email="{Binding Email}"
-                        Image="{Binding DefaultGravatarSelected}"
-                        SemanticProperties.Description="GravatarImageSource for an ImageButton control, binding all properties." />
+                        Image="{Binding DefaultGravatarSelected}"/>
                 </ImageButton.Source>
             </ImageButton>
             <Label SemanticProperties.HeadingLevel="Level2" Text="with AvatarView Control" />
@@ -100,7 +97,8 @@
                 BorderWidth="2"
                 CornerRadius="32,0,0,32"
                 HeightRequest="128"
-                WidthRequest="128">
+                WidthRequest="128"
+                SemanticProperties.Description="GravatarImageSourse used with AvatarView.">
                 <mct:AvatarView.Stroke>
                     <LinearGradientBrush EndPoint="0,1">
                         <GradientStop Offset="0.1" Color="Blue" />
@@ -112,8 +110,7 @@
                         CacheValidity="{Binding CacheValidityTimespan}"
                         CachingEnabled="{Binding EnableCache}"
                         Email="{Binding Email}"
-                        Image="{Binding DefaultGravatarSelected}"
-                        SemanticProperties.Description="GravatarImageSourse used with AvatarView." />
+                        Image="{Binding DefaultGravatarSelected}"/>
                 </mct:AvatarView.ImageSource>
             </mct:AvatarView>
             <Label x:Name="LabelEmail" Text="Email:" />


### PR DESCRIPTION
Sample app was using SemanticProperties.Description inside the GravatarImageSource - SemeanticProperties.Description is an AttachedProperty for a VisualElement. this was causing the sample app to crash on Windows

 ### Description of Change ###
Fixes issue with Sample app crashing on Windows.

 ### Linked Issues ###

 - Fixes #655 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
