### PR TITLE
FIX: AvatarView clipping on Android isn't applied correctly

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/ImageSources/GravatarImageSourcePage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/ImageSources/GravatarImageSourcePage.xaml
@@ -10,7 +10,7 @@
     x:DataType="vm:GravatarImageSourceViewModel"
     x:TypeArguments="vm:GravatarImageSourceViewModel">
     <ScrollView>
-        <VerticalStackLayout Spacing="12">
+        <VerticalStackLayout Spacing="12" Padding="0,12,0,0" >
             <VerticalStackLayout.Resources>
                 <ResourceDictionary>
                     <Style x:Key="Description" TargetType="Label">

--- a/samples/CommunityToolkit.Maui.Sample/Pages/ImageSources/GravatarImageSourcePage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/ImageSources/GravatarImageSourcePage.xaml.cs
@@ -8,6 +8,6 @@ public partial class GravatarImageSourcePage : BasePage<GravatarImageSourceViewM
 	{
 		InitializeComponent();
 
-		Padding = new Thickness(Padding.Left, Padding.Top, Padding.Right, 0);
+		Padding = new Thickness(Padding.Left, 0, Padding.Right, 0);
 	}
 }

--- a/src/CommunityToolkit.Maui/Views/AvatarView.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/AvatarView.shared.cs
@@ -355,11 +355,19 @@ public class AvatarView : Border, IAvatarView, IBorderElement, IFontElement, ITe
 			&& Height >= 0 // The default value of Height (before the view is drawn onto the page) is -1
 			&& Width >= 0 // The default value of Y (before the view is drawn onto the page) is -1
 			&& avatarImage.Source is not null)
+
 		{
+#if WINDOWS
+			double offsetX = 0;
+			double offsetY = 0;
+#else
+			double offsetX = StrokeThickness + Padding.Left;
+			double offsetY = StrokeThickness + Padding.Top;
+#endif
 			double imageWidth = Width - (StrokeThickness * 2) - Padding.Left - Padding.Right;
 			double imageHeight = Height - (StrokeThickness * 2) - Padding.Top - Padding.Bottom;
 
-			Rect rect = new(0, 0, imageWidth, imageHeight);
+			Rect rect = new(offsetX, offsetY, imageWidth, imageHeight);
 
 			avatarImage.Clip = StrokeShape switch
 			{


### PR DESCRIPTION
 ### Description of Change ###
Added clipping offset for all platforms, other than Windows.

 ### Linked Issues ###
 - Fixes #646 

 ### PR Checklist ###
 - [X] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [X] Has tests (if omitted, state reason in description) : N/A
 - [X] Has samples (if omitted, state reason in description): N/A
 - [X] Rebased on top of `main` at time of PR
 - [X] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [X] Documentation created or updated: N/A

 ### Additional information ###
Tested and verified on platforms - 
- [X] Android
- [X] Windows
- [x] Mac Catalyst
- [x] iOS

This fix must be tested on **ALL** platforms, as it is an issue for different platforms.