### PR TITLE
Removed the MauiContext from ToPlatform call

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Views/Popup/PopupExtensions.android.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Popup/PopupExtensions.android.cs
@@ -30,11 +30,10 @@ public static class PopupExtensions
 
 		if (popup.Anchor is not null)
 		{
-			var anchorView = popup.Anchor.ToPlatform(popup.Handler.MauiContext);
+			var anchorView = popup.Anchor.ToPlatform();
 
 			var locationOnScreen = new int[2];
 			anchorView.GetLocationOnScreen(locationOnScreen);
-
 			window.SetGravity(GravityFlags.Top | GravityFlags.Left);
 			window.DecorView.Measure((int)MeasureSpecMode.Unspecified, (int)MeasureSpecMode.Unspecified);
 


### PR DESCRIPTION
 ### Description of Change ###

Remove the MauiContext from the equation. Not sure why, but the popup.Handler.MauiContext isn't equal to popup.Anchor.Handler.MauiContext, and that was causing the issue.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #682

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
