### PR TITLE
For Source Generators, Ensure `GetGenericTypeConstraintsAsString` Includes Namespace for Type

### DIFF
--- a/src/CommunityToolkit.Maui.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
@@ -134,6 +134,11 @@ static class NamespaceSymbolExtensions
 
 				var symbolDisplayFormat = new SymbolDisplayFormat(typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces);
 				constraints.Append(contstraintType.ToDisplayString(symbolDisplayFormat));
+
+				if (contstraintType.NullableAnnotation is NullableAnnotation.Annotated)
+				{
+					constraints.Append("?");
+				}
 			}
 
 			if (typeParameterSymbol.HasConstructorConstraint)

--- a/src/CommunityToolkit.Maui.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
@@ -89,19 +89,13 @@ static class NamespaceSymbolExtensions
 
 		foreach (var typeParameterSymbol in type.TypeParameters)
 		{
-			bool isFirstConstraint = true;
-
 			if (typeParameterSymbol.HasNotNullConstraint)
 			{
 				constraints.Append("notnull");
-
-				isFirstConstraint = false;
 			}
 			else if (typeParameterSymbol.HasUnmanagedTypeConstraint)
 			{
 				constraints.Append("unmanaged");
-
-				isFirstConstraint = false;
 			}
 			else if (typeParameterSymbol.HasReferenceTypeConstraint)
 			{
@@ -111,25 +105,17 @@ static class NamespaceSymbolExtensions
 				{
 					constraints.Append("?");
 				}
-
-				isFirstConstraint = false;
 			}
 			else if (typeParameterSymbol.HasValueTypeConstraint)
 			{
 				constraints.Append("struct");
-
-				isFirstConstraint = false;
 			}
 
 			foreach (INamedTypeSymbol contstraintType in typeParameterSymbol.ConstraintTypes.Cast<INamedTypeSymbol>())
 			{
-				if (!isFirstConstraint)
+				if (constraints.Length > 0)
 				{
 					constraints.Append(", ");
-				}
-				else
-				{
-					isFirstConstraint = false;
 				}
 
 				var symbolDisplayFormat = new SymbolDisplayFormat(typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces);
@@ -143,7 +129,7 @@ static class NamespaceSymbolExtensions
 
 			if (typeParameterSymbol.HasConstructorConstraint)
 			{
-				if (!isFirstConstraint)
+				if (constraints.Length > 0)
 				{
 					constraints.Append(", ");
 				}

--- a/src/CommunityToolkit.Maui.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
@@ -132,7 +132,8 @@ static class NamespaceSymbolExtensions
 					isFirstConstraint = false;
 				}
 
-				constraints.Append(contstraintType.GetFullTypeString());
+				var symbolDisplayFormat = new SymbolDisplayFormat(typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces);
+				constraints.Append(contstraintType.ToDisplayString(symbolDisplayFormat));
 			}
 
 			if (typeParameterSymbol.HasConstructorConstraint)

--- a/src/CommunityToolkit.Maui.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Extensions/NamespaceSymbolExtensions.cs
@@ -118,13 +118,9 @@ static class NamespaceSymbolExtensions
 					constraints.Append(", ");
 				}
 
-				var symbolDisplayFormat = new SymbolDisplayFormat(typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces);
+				var symbolDisplayFormat = new SymbolDisplayFormat(typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
+																	miscellaneousOptions: SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier);
 				constraints.Append(contstraintType.ToDisplayString(symbolDisplayFormat));
-
-				if (contstraintType.NullableAnnotation is NullableAnnotation.Annotated)
-				{
-					constraints.Append("?");
-				}
 			}
 
 			if (typeParameterSymbol.HasConstructorConstraint)

--- a/src/CommunityToolkit.Maui.UnitTests/Extensions/TextColorToTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Extensions/TextColorToTests.cs
@@ -1,5 +1,6 @@
-﻿using CommunityToolkit.Maui.UnitTests.Extensions.TextStyle;
-using CommunityToolkit.Maui.UnitTests.Mocks;
+﻿using CommunityToolkit.Maui.UnitTests.Mocks;
+using Unique.Interface.Namespace.TextStyle;
+using Unique.Namespace.TextStyle;
 using Xunit;
 using Font = Microsoft.Maui.Font;
 
@@ -159,7 +160,7 @@ namespace CommunityToolkit.Maui.UnitTests.Extensions
 	}
 }
 
-namespace CommunityToolkit.Maui.UnitTests.Extensions.TextStyle
+namespace Unique.Namespace.TextStyle
 {
 	public class PublicTextStyleView : View, ICustomTextStyle
 	{
@@ -181,11 +182,6 @@ namespace CommunityToolkit.Maui.UnitTests.Extensions.TextStyle
 
 	// Ensures custom ITextStyle interfaces are supported
 	interface ICustomTextStyle : ITextStyle
-	{
-
-	}
-
-	public interface ISomeInterface
 	{
 
 	}
@@ -255,5 +251,13 @@ namespace CommunityToolkit.Maui.UnitTests.Extensions.TextStyle
 		public Color TextColor { get; set; } = Colors.Transparent;
 
 		public Font Font { get; set; }
+	}
+}
+
+namespace Unique.Interface.Namespace.TextStyle
+{
+	public interface ISomeInterface
+	{
+
 	}
 }


### PR DESCRIPTION
 ### Description of Change ###

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #719 

 ### PR Checklist ###
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)


 ### Additional information ###

This PR updates the Unit Tests to test this new code by moving `public interface ISomeInterface` into its own unique namespace.

This PR also removes `bool isFirstConstraint`, replacing `if(!isFirstConstraint)` with `if(constraints.Length > 0)`.
