### PR TITLE
[Housekeeping] Implement Expanded C# 11 `nameof` Scope

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
@@ -66,7 +66,7 @@ public class MauiPopup : UIViewController
 	[MemberNotNull(nameof(VirtualView), nameof(ViewController))]
 	public void SetElement(IPopup element)
 	{
-		if (element.Parent?.Handler is not PageHandler mainPage)
+		if (element.Parent?.Handler is not PageHandler)
 		{
 			throw new InvalidOperationException($"The {nameof(element.Parent)} must be of type {typeof(PageHandler)}.");
 		}
@@ -77,7 +77,7 @@ public class MauiPopup : UIViewController
 		_ = View ?? throw new InvalidOperationException($"{nameof(View)} cannot be null.");
 		_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} cannot be null.");
 
-		var rootViewController = WindowStateManager.Default.GetCurrentUIViewController() ?? throw new InvalidOperationException($"{nameof(mainPage.ViewController)} cannot be null.");
+		var rootViewController = WindowStateManager.Default.GetCurrentUIViewController() ?? throw new InvalidOperationException($"{nameof(PageHandler.ViewController)} cannot be null.");
 		ViewController ??= rootViewController;
 		SetDimmingBackgroundEffect();
 	}

--- a/src/CommunityToolkit.Maui/Behaviors/MaskedBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/MaskedBehavior.shared.cs
@@ -140,7 +140,7 @@ public class MaskedBehavior : BaseBehavior<InputView>, IDisposable
 		await ApplyMask(originalText, token);
 	}
 
-	[return: NotNullIfNotNull("text")]
+	[return: NotNullIfNotNull(nameof(text))]
 	string? RemoveMask(string? text)
 	{
 		if (string.IsNullOrEmpty(text))
@@ -187,7 +187,7 @@ public class MaskedBehavior : BaseBehavior<InputView>, IDisposable
 				}
 			}
 
-			if (View != null)
+			if (View is not null)
 			{
 				View.Text = text;
 			}

--- a/src/CommunityToolkit.Maui/Converters/ByteArrayToImageSourceConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ByteArrayToImageSourceConverter.shared.cs
@@ -20,7 +20,7 @@ public class ByteArrayToImageSourceConverter : BaseConverter<byte[]?, ImageSourc
 	/// <param name="value">The value to convert.</param>
 	/// <param name="culture">The culture to use in the converter. This is not implemented.</param>
 	/// <returns>An object of type <see cref="ImageSource"/>.</returns>
-	[return: NotNullIfNotNull("value")]
+	[return: NotNullIfNotNull(nameof(value))]
 	public override ImageSource? ConvertFrom(byte[]? value, CultureInfo? culture = null)
 	{
 		if (value is null)

--- a/src/CommunityToolkit.Maui/Converters/ImageResourceConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ImageResourceConverter.shared.cs
@@ -18,7 +18,7 @@ public class ImageResourceConverter : BaseConverterOneWay<string?, ImageSource?>
 	/// <param name="value">The value to convert.</param>
 	/// <param name="culture">(Not Used)</param>
 	/// <returns>The ImageSource related to the provided resource ID of the embedded image. If it's null it will returns null.</returns>
-	[return: NotNullIfNotNull("value")]
+	[return: NotNullIfNotNull(nameof(value))]
 	public override ImageSource? ConvertFrom(string? value, CultureInfo? culture = null) => value switch
 	{
 		null => null,

--- a/src/CommunityToolkit.Maui/Converters/ItemTappedEventArgsConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ItemTappedEventArgsConverter.shared.cs
@@ -17,7 +17,7 @@ public class ItemTappedEventArgsConverter : BaseConverterOneWay<ItemTappedEventA
 	/// <param name="value">The value to convert.</param>
 	/// <param name="culture">(Not Used)</param>
 	/// <returns>A <see cref="ItemTappedEventArgs.Item"/> object from object of type <see cref="ItemTappedEventArgs"/>.</returns>
-	[return: NotNullIfNotNull("value")]
+	[return: NotNullIfNotNull(nameof(value))]
 	public override object? ConvertFrom(ItemTappedEventArgs? value, CultureInfo? culture = null) => value switch
 	{
 		null => null,

--- a/src/CommunityToolkit.Maui/Converters/MathExpressionConverter/MultiMathExpressionConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/MathExpressionConverter/MultiMathExpressionConverter.shared.cs
@@ -17,7 +17,7 @@ public class MultiMathExpressionConverter : MultiValueConverterExtension, ICommu
 	/// <param name="parameter">The expression to calculate.</param>
 	/// <param name="culture">The culture to use in the converter. This is not implemented.</param>
 	/// <returns>A <see cref="double"/> The result of calculating an expression.</returns>
-	[return: NotNullIfNotNull("values")]
+	[return: NotNullIfNotNull(nameof(values))]
 	public object? Convert(object?[]? values, Type targetType, [NotNull] object? parameter, CultureInfo? culture = null)
 	{
 		ArgumentNullException.ThrowIfNull(targetType);

--- a/src/CommunityToolkit.Maui/Converters/SelectedItemEventArgsConverter.cs
+++ b/src/CommunityToolkit.Maui/Converters/SelectedItemEventArgsConverter.cs
@@ -17,7 +17,7 @@ public class SelectedItemEventArgsConverter : BaseConverterOneWay<SelectedItemCh
 	/// <param name="value">The value to convert.</param>
 	/// <param name="culture">(Not Used)</param>
 	/// <returns>A <see cref="SelectedItemChangedEventArgs.SelectedItem"/> object from object of type <see cref="SelectedItemChangedEventArgs"/>.</returns>
-	[return: NotNullIfNotNull("value")]
+	[return: NotNullIfNotNull(nameof(value))]
 	public override object? ConvertFrom(SelectedItemChangedEventArgs? value, CultureInfo? culture = null) => value switch
 	{
 		null => null,

--- a/src/CommunityToolkit.Maui/Converters/TextCaseConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/TextCaseConverter.shared.cs
@@ -57,7 +57,7 @@ public class TextCaseConverter : BaseConverterOneWay<string?, string?, TextCaseT
 	/// <param name="parameter">The desired text case that the text should be converted to. Must match <see cref="TextCaseType"/> enum value.</param>
 	/// <param name="culture">The culture to use in the converter. This is not implemented.</param>
 	/// <returns>The converted text representation with the desired casing.</returns>
-	[return: NotNullIfNotNull("value")]
+	[return: NotNullIfNotNull(nameof(value))]
 	public override string? ConvertFrom(string? value, TextCaseType? parameter = null, CultureInfo? culture = null)
 	{
 		if (string.IsNullOrWhiteSpace(value))


### PR DESCRIPTION
This PR implements the [expanded scope of the `nameof` operator in C# 11](https://learn.microsoft.com/dotnet/csharp/whats-new/csharp-11#extended-nameof-scope):

https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-11#extended-nameof-scope

It is updating syntactic sugar and does not modify any functionality.