### PR TITLE
Use `[GeneratedRegex]`

### DIFF
--- a/src/CommunityToolkit.Maui/Behaviors/Validators/EmailValidationBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/Validators/EmailValidationBehavior.shared.cs
@@ -9,7 +9,7 @@ namespace CommunityToolkit.Maui.Behaviors;
 /// The validation is achieved through a regular expression that is used to verify whether or not the text input is a valid e-mail address.
 /// It can be overridden to customize the validation through the properties it inherits from <see cref="ValidationBehavior"/>.
 /// </summary>
-public class EmailValidationBehavior : TextValidationBehavior
+public partial class EmailValidationBehavior : TextValidationBehavior
 {
 	/// <inheritdoc /> 
 	protected override async ValueTask<bool> ValidateAsync(string? value, CancellationToken token)
@@ -72,7 +72,7 @@ public class EmailValidationBehavior : TextValidationBehavior
 		try
 		{
 			// Normalize the domain
-			email = Regex.Replace(email, @"(@)(.+)$", DomainMapper, RegexOptions.None, TimeSpan.FromMilliseconds(200));
+			email = NormalizeDomainRegex().Replace(email, DomainMapper);
 		}
 		catch (RegexMatchTimeoutException)
 		{
@@ -85,9 +85,7 @@ public class EmailValidationBehavior : TextValidationBehavior
 
 		try
 		{
-			return Regex.IsMatch(email,
-				@"^[^@\s]+@[^@\s]+\.[^@\s]+$",
-				RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(250));
+			return ValidEmailRegex().IsMatch(email);
 		}
 		catch (RegexMatchTimeoutException)
 		{
@@ -104,7 +102,7 @@ public class EmailValidationBehavior : TextValidationBehavior
 			string domainName = idn.GetAscii(match.Groups[2].Value);
 
 			if (domainName.All(x => char.IsDigit(x) || x is '.')
-				&& !Regex.IsMatch(domainName, @"^([1-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(\.([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])){3}$"))
+				&& !ValidIpv4Regex().IsMatch(domainName))
 			{
 				throw new ArgumentException("Invalid IPv4 Address.");
 			}
@@ -117,4 +115,13 @@ public class EmailValidationBehavior : TextValidationBehavior
 			return match.Groups[1].Value + domainName;
 		}
 	}
+
+	[GeneratedRegex(@"^([1-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(\.([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])){3}$", RegexOptions.None, 250)]
+	private static partial Regex ValidIpv4Regex();
+
+	[GeneratedRegex(@"^[^@\s]+@[^@\s]+\.[^@\s]+$", RegexOptions.IgnoreCase, 250)]
+	private static partial Regex ValidEmailRegex();
+
+	[GeneratedRegex(@"(@)(.+)$", RegexOptions.None, 250)]
+	private static partial Regex NormalizeDomainRegex();
 }

--- a/src/CommunityToolkit.Maui/Behaviors/Validators/TextValidationBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/Validators/TextValidationBehavior.shared.cs
@@ -165,7 +165,7 @@ public class TextValidationBehavior : ValidationBehavior<string>
 
 	static void OnRegexPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 	{
-		var textValidationBehavior = ((TextValidationBehavior)bindable);
+		var textValidationBehavior = (TextValidationBehavior)bindable;
 		textValidationBehavior.OnRegexPropertyChanged(textValidationBehavior.RegexPattern, textValidationBehavior.RegexOptions);
 		OnValidationPropertyChanged(bindable, oldValue, newValue);
 	}

--- a/src/CommunityToolkit.Maui/Converters/MathExpressionConverter/MathExpression.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/MathExpressionConverter/MathExpression.shared.cs
@@ -123,6 +123,9 @@ sealed partial class MathExpression
 		return stack.Pop();
 	}
 
+	[GeneratedRegex(@"(?<!\d)\-?(?:\d+\.\d+|\d+)|\+|\-|\/|\*|\(|\)|\^|\%|\,|\w+")]
+	private static partial Regex ValidExpressionRegex();
+
 	IEnumerable<string> GetReversePolishNotation(string expression)
 	{
 		var matches = ValidExpressionRegex().Matches(expression) ?? throw new ArgumentException("Invalid math expression.");
@@ -240,7 +243,4 @@ sealed partial class MathExpression
 
 		return output;
 	}
-
-	[GeneratedRegex(@"(?<!\d)\-?(?:\d+\.\d+|\d+)|\+|\-|\/|\*|\(|\)|\^|\%|\,|\w+")]
-	private static partial Regex ValidExpressionRegex();
 }

--- a/src/CommunityToolkit.Maui/Converters/MathExpressionConverter/MathExpression.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/MathExpressionConverter/MathExpression.shared.cs
@@ -4,9 +4,8 @@ using CommunityToolkit.Maui.Core;
 
 namespace CommunityToolkit.Maui.Converters;
 
-sealed class MathExpression
+sealed partial class MathExpression
 {
-	const string regexPattern = @"(?<!\d)\-?(?:\d+\.\d+|\d+)|\+|\-|\/|\*|\(|\)|\^|\%|\,|\w+";
 	const NumberStyles numberStyle = NumberStyles.Float | NumberStyles.AllowThousands;
 
 	static readonly IFormatProvider formatProvider = new CultureInfo("en-US");
@@ -14,14 +13,9 @@ sealed class MathExpression
 	readonly IReadOnlyList<MathOperator> operators;
 	readonly IReadOnlyList<double> arguments;
 
-	internal string Expression { get; }
-
 	internal MathExpression(string expression, IEnumerable<double>? arguments = null)
 	{
-		if (string.IsNullOrEmpty(expression))
-		{
-			throw new ArgumentNullException(nameof(expression), "Expression can't be null or empty.");
-		}
+		ArgumentNullException.ThrowIfNullOrEmpty(expression, "Expression can't be null or empty.");
 
 		Expression = expression.ToLower();
 		this.arguments = arguments?.ToList() ?? new List<double>();
@@ -78,6 +72,8 @@ sealed class MathExpression
 		this.operators = operators;
 	}
 
+	internal string Expression { get; }
+
 	public double Calculate()
 	{
 		var rpn = GetReversePolishNotation(Expression);
@@ -95,7 +91,7 @@ sealed class MathExpression
 			var mathOperator = operators.FirstOrDefault(x => x.Name == value) ??
 				throw new ArgumentException($"Invalid math expression. Can't find operator or value with name \"{value}\".");
 
-			if (mathOperator.Precedence == MathOperatorPrecedence.Constant)
+			if (mathOperator.Precedence is MathOperatorPrecedence.Constant)
 			{
 				stack.Push(mathOperator.CalculateFunc(Array.Empty<double>()));
 				continue;
@@ -129,13 +125,7 @@ sealed class MathExpression
 
 	IEnumerable<string> GetReversePolishNotation(string expression)
 	{
-		var regex = new Regex(regexPattern);
-
-		var matches = regex.Matches(expression);
-		if (matches == null)
-		{
-			throw new ArgumentException("Invalid math expression.");
-		}
+		var matches = ValidExpressionRegex().Matches(expression) ?? throw new ArgumentException("Invalid math expression.");
 
 		var output = new List<string>();
 		var stack = new Stack<(string Name, MathOperatorPrecedence Precedence)>();
@@ -170,7 +160,7 @@ sealed class MathExpression
 			var @operator = operators.FirstOrDefault(x => x.Name == value);
 			if (@operator != null)
 			{
-				if (@operator.Precedence == MathOperatorPrecedence.Constant)
+				if (@operator.Precedence is MathOperatorPrecedence.Constant)
 				{
 					output.Add(value);
 					continue;
@@ -191,11 +181,11 @@ sealed class MathExpression
 
 				stack.Push((value, @operator.Precedence));
 			}
-			else if (value == "(")
+			else if (value is "(")
 			{
 				stack.Push((value, MathOperatorPrecedence.Lowest));
 			}
-			else if (value == ")")
+			else if (value is ")")
 			{
 				var isFound = false;
 				for (var i = stack.Count - 1; i >= 0; i--)
@@ -206,7 +196,7 @@ sealed class MathExpression
 					}
 
 					var stackValue = stack.Pop().Name;
-					if (stackValue == "(")
+					if (stackValue is "(")
 					{
 						isFound = true;
 						break;
@@ -220,7 +210,7 @@ sealed class MathExpression
 					throw new ArgumentException("Invalid math expression.");
 				}
 			}
-			else if (value == ",")
+			else if (value is ",")
 			{
 				while (stack.Count > 0)
 				{
@@ -240,7 +230,7 @@ sealed class MathExpression
 		for (var i = stack.Count - 1; i >= 0; i--)
 		{
 			var (name, precedence) = stack.Pop();
-			if (name == "(")
+			if (name is "(")
 			{
 				throw new ArgumentException("Invalid math expression.");
 			}
@@ -250,4 +240,7 @@ sealed class MathExpression
 
 		return output;
 	}
+
+	[GeneratedRegex(@"(?<!\d)\-?(?:\d+\.\d+|\d+)|\+|\-|\/|\*|\(|\)|\^|\%|\,|\w+")]
+	private static partial Regex ValidExpressionRegex();
 }


### PR DESCRIPTION
New in .NET 7.0 is [.NET regular expression source generators](https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-source-generators). 

Using `[GeneratedRegex]` uses source generators to bring large performance improvements, as noted in the [documentation](https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-source-generators):
> But as can be seen, it's not just doing new Regex(...). Rather, the source generator is emitting as C# code a custom Regex-derived implementation with logic similar to what RegexOptions.Compiled emits in IL. You get all the throughput performance benefits of RegexOptions.Compiled (more, in fact) and the start-up benefits of Regex.CompileToAssembly, but without the complexity of CompileToAssembly. The source that's emitted is part of your project, which means it's also easily viewable and debuggable.

### Additional Info
This PR also adds the `RegexOptions.Compiled` flag. As noted by [Jonathan Peppers at .NET Conf](https://www.youtube.com/watch?v=J7bWH9LyaoU), the `RegexOptions.Compiled` flag previously was unused by Mono prior to .NET 7.0
