### PR TITLE
Fix `MediaElement` memory leak

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.android.cs
@@ -12,6 +12,12 @@ public partial class MediaElementHandler : ViewHandler<MediaElement, MauiMediaEl
 		return new(Context, playerView);
 	}
 
+	protected override void DisconnectHandler(MauiMediaElement platformView)
+	{
+		platformView.Dispose();
+		base.DisconnectHandler(platformView);
+	}
+
 	public static void MapIsLooping(MediaElementHandler handler, MediaElement mediaElement)
 	{
 		handler?.mediaManager?.UpdateIsLooping();

--- a/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.windows.cs
@@ -13,6 +13,12 @@ public partial class MediaElementHandler : ViewHandler<MediaElement, MauiMediaEl
 		return new(mediaPlatform);
 	}
 
+	protected override void DisconnectHandler(MauiMediaElement platformView)
+	{
+		platformView.Dispose();
+		base.DisconnectHandler(platformView);
+	}
+
 	public static void MapIsLooping(MediaElementHandler handler, MediaElement mediaElement)
 	{
 		handler?.mediaManager?.UpdateIsLooping();

--- a/src/CommunityToolkit.Maui.MediaElement/PlatformView/MauiMediaElement.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/PlatformView/MauiMediaElement.android.cs
@@ -33,7 +33,10 @@ public class MauiMediaElement : CoordinatorLayout
 		if (disposing)
 		{
 			if (playerView is not null)
-			{
+			{                
+				// https://github.com/google/ExoPlayer/issues/1855#issuecomment-251041500
+				playerView.Player?.Release();
+				playerView.Player?.Dispose();
 				playerView.Dispose();
 				playerView = null;
 			}

--- a/src/CommunityToolkit.Maui.MediaElement/PlatformView/MauiMediaElement.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/PlatformView/MauiMediaElement.windows.cs
@@ -9,8 +9,16 @@ namespace CommunityToolkit.Maui.MediaElement.PlatformView;
 
 public class MauiMediaElement : Grid
 {
+	private MediaPlayerElement? _mediaPlayerElement;
 	public MauiMediaElement(MediaPlayerElement mediaPlayerElement)
 	{
-		Children.Add(mediaPlayerElement);
+		_mediaPlayerElement = mediaPlayerElement;
+		Children.Add(_mediaPlayerElement);
+	}
+
+	public void Dispose()
+	{
+		_mediaPlayerElement?.MediaPlayer.Dispose();
+		_mediaPlayerElement = null;
 	}
 }

--- a/src/CommunityToolkit.Maui.MediaElement/PlatformView/MediaManager.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/PlatformView/MediaManager.windows.cs
@@ -172,6 +172,7 @@ partial class MediaManager
 		MainThread.BeginInvokeOnMainThread(() =>
 		{
 			mediaElement.Duration = player.MediaPlayer.NaturalDuration;
+			player.MediaPlayer.MediaOpened -= OnMediaPlayerMediaOpened;
 		});
 	}
 }


### PR DESCRIPTION
### Summary
This PR fixes MediaElement's memory leak on Android and Windows.