### PR TITLE
Fix MediaElement Androids' player.Duration OverflowException and PlaybackState

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/PlatformView/MediaManager.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/PlatformView/MediaManager.android.cs
@@ -162,7 +162,7 @@ public partial class MediaManager : Java.Lang.Object, IPlayer.IListener
 		switch ((PlaybackStateCode)player.PlaybackState)
 		{
 			case PlaybackStateCode.Playing:
-				videoStatus = MediaElementState.Playing;
+				videoStatus = player.PlayWhenReady ? MediaElementState.Playing : MediaElementState.Paused;
 				break;
 
 			case PlaybackStateCode.Paused:

--- a/src/CommunityToolkit.Maui.MediaElement/PlatformView/MediaManager.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/PlatformView/MediaManager.android.cs
@@ -210,7 +210,8 @@ public partial class MediaManager : Java.Lang.Object, IPlayer.IListener
 
 		if (playbackState == IPlayer.StateReady)
 		{
-			mediaElement.Duration = TimeSpan.FromMilliseconds(player.Duration);
+			mediaElement.Duration = TimeSpan.FromMilliseconds(
+				player.Duration == C.TimeUnset ? 0 : player.Duration);		
 		}
 	}
 


### PR DESCRIPTION
When streaming from an URL it is possible that ExoPlayer does not receive the information necessary to set the duration of a title. 
If this is the case, the ExoPlayers' duration property is set to TIME_UNSET which is a constant defined as Long.MIN_VALUE +1 (-9223372036854775807). 

However, the current MediaManager implementation for Android defined in **MediaManager.android.cs** handles the **OnPlayerStateChanged** event by setting the mediaElements' duration property if the playback state equals StateReady. It does so by converting the underlying players' duration property to  a TimeSpan.

In case ExoPlayers' duration property equals TIME_UNSET in that moment, the call to TimeSpan.FromMilliseconds results in an OverflowException.

More specifically:
**System.OverflowException:** 'TimeSpan overflowed because the duration is too long.'

This can be prevented by checking the duration beforehand:

`mediaElement.Duration = TimeSpan.FromMilliseconds(player.Duration == C.TimeUnset ? 0 : player.Duration);`