### PR TITLE
[BUG] DrawingView GetImageStream cuts off lines on edge of image #773

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Views/DrawingView/Service/DrawingViewService.android.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/DrawingView/Service/DrawingViewService.android.cs
@@ -75,7 +75,7 @@ public static class DrawingViewService
 		Color strokeColor,
 		Paint? background)
 	{
-		var (image, offset) = GetBitmap(points);
+		var (image, offset) = GetBitmap(points, lineWidth);
 		if (image is null)
 		{
 			return null;
@@ -90,7 +90,8 @@ public static class DrawingViewService
 	static Bitmap? GetBitmapForLines(IList<IDrawingLine> lines, Paint? background)
 	{
 		var points = lines.SelectMany(x => x.Points).ToList();
-		var (image, offset) = GetBitmap(points);
+		var maxLineWidth = lines.Select(x => x.LineWidth).Max();
+		var (image, offset) = GetBitmap(points, maxLineWidth);
 		if (image is null)
 		{
 			return null;
@@ -106,17 +107,17 @@ public static class DrawingViewService
 		return image;
 	}
 
-	static (Bitmap?, SizeF offset) GetBitmap(ICollection<PointF> points)
+	static (Bitmap?, SizeF offset) GetBitmap(ICollection<PointF> points, float maxLineWidth)
 	{
 		if (points.Count is 0)
 		{
 			return (null, SizeF.Zero);
 		}
 
-		var minPointX = points.Min(p => p.X);
-		var minPointY = points.Min(p => p.Y);
-		var drawingWidth = points.Max(p => p.X) - minPointX;
-		var drawingHeight = points.Max(p => p.Y) - minPointY;
+		var minPointX = points.Min(p => p.X) - maxLineWidth;
+		var minPointY = points.Min(p => p.Y) - maxLineWidth;
+		var drawingWidth = points.Max(p => p.X) - minPointX + maxLineWidth;
+		var drawingHeight = points.Max(p => p.Y) - minPointY + maxLineWidth;
 		const int minSize = 1;
 		if (drawingWidth < minSize || drawingHeight < minSize)
 		{

--- a/src/CommunityToolkit.Maui.Core/Views/DrawingView/Service/DrawingViewService.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/DrawingView/Service/DrawingViewService.macios.cs
@@ -59,28 +59,29 @@ public static class DrawingViewService
 		return GetUIImage(points, (context, offset) =>
 		{
 			DrawStrokes(context, points.ToList(), lineWidth, strokeColor, offset);
-		}, background);
+		}, background, lineWidth);
 	}
 
 	static UIImage? GetUIImageForLines(IList<IDrawingLine> lines, in Paint? background)
 	{
 		var points = lines.SelectMany(x => x.Points).ToList();
+		var maxLineWidth = lines.Select(x => x.LineWidth).Max();
 		return GetUIImage(points, (context, offset) =>
 		{
 			foreach (var line in lines)
 			{
 				DrawStrokes(context, line.Points, line.LineWidth, line.LineColor, offset);
 			}
-		}, background);
+		}, background, maxLineWidth);
 	}
 
-	static UIImage? GetUIImage(ICollection<PointF> points, Action<CGContext, Size> drawStrokes, Paint? background)
+	static UIImage? GetUIImage(ICollection<PointF> points, Action<CGContext, Size> drawStrokes, Paint? background, NFloat maxLineWidth)
 	{
 		const int minSize = 1;
-		var minPointX = points.Min(p => p.X);
-		var minPointY = points.Min(p => p.Y);
-		var drawingWidth = points.Max(p => p.X) - minPointX;
-		var drawingHeight = points.Max(p => p.Y) - minPointY;
+		var minPointX = points.Min(p => p.X) - maxLineWidth;
+		var minPointY = points.Min(p => p.Y) - maxLineWidth;
+		var drawingWidth = points.Max(p => p.X) - minPointX + maxLineWidth;
+		var drawingHeight = points.Max(p => p.Y) - minPointY + maxLineWidth;
 
 		if (drawingWidth < minSize || drawingHeight < minSize)
 		{

--- a/src/CommunityToolkit.Maui.Core/Views/DrawingView/Service/DrawingViewService.tizen.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/DrawingView/Service/DrawingViewService.tizen.cs
@@ -70,7 +70,7 @@ public static class DrawingViewService
 		}));
 	}
 
-	static (SKBitmap?, SizeF offset) GetBitmap(in ICollection<PointF> points)
+	static (SKBitmap?, SizeF offset) GetBitmap(in ICollection<PointF> points, float maxLineWidth)
 	{
 		if (points.Count is 0)
 		{
@@ -78,10 +78,10 @@ public static class DrawingViewService
 		}
 
 		const int minSize = 1;
-		var minPointX = points.Min(static p => p.X);
-		var minPointY = points.Min(static p => p.Y);
-		var drawingWidth = points.Max(static p => p.X) - minPointX;
-		var drawingHeight = points.Max(static p => p.Y) - minPointY;
+		var minPointX = points.Min(p => p.X) - maxLineWidth;
+		var minPointY = points.Min(p => p.Y) - maxLineWidth;
+		var drawingWidth = points.Max(p => p.X) - minPointX + maxLineWidth;
+		var drawingHeight = points.Max(p => p.Y) - minPointY + maxLineWidth;
 
 		if (drawingWidth < minSize || drawingHeight < minSize)
 		{
@@ -96,7 +96,8 @@ public static class DrawingViewService
 	static SKBitmap? GetBitmapForLines(in IList<IDrawingLine> lines, in Paint? background)
 	{
 		var points = lines.SelectMany(static x => x.Points).ToList();
-		var (image, offset) = GetBitmap(points);
+		var maxLineWidth = lines.Select(x => x.LineWidth).Max();
+		var (image, offset) = GetBitmap(points, maxLineWidth);
 
 		if (image is null)
 		{
@@ -117,7 +118,7 @@ public static class DrawingViewService
 
 	static SKBitmap? GetBitmapForPoints(in ICollection<PointF> points, in float lineWidth, in Color strokeColor, in Paint? background)
 	{
-		var (image, offset) = GetBitmap(points);
+		var (image, offset) = GetBitmap(points, lineWidth);
 		if (image is null)
 		{
 			return null;

--- a/src/CommunityToolkit.Maui.Core/Views/DrawingView/Service/DrawingViewService.windows.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/DrawingView/Service/DrawingViewService.windows.cs
@@ -74,7 +74,7 @@ public static class DrawingViewService
 		Paint? background,
 		bool scale = false)
 	{
-		var (offscreen, offset) = GetCanvasRenderTarget(points, size, scale);
+		var (offscreen, offset) = GetCanvasRenderTarget(points, size, scale, lineWidth);
 		if (offscreen is null)
 		{
 			return null;
@@ -109,7 +109,7 @@ public static class DrawingViewService
 		session.DrawInk(strokes);
 	}
 
-	static (CanvasRenderTarget? offscreen, Size offset) GetCanvasRenderTarget(ICollection<PointF> points, SizeF size, bool scale)
+	static (CanvasRenderTarget? offscreen, Size offset) GetCanvasRenderTarget(ICollection<PointF> points, SizeF size, bool scale, float maxLineWidth)
 	{
 		const int minSize = 1;
 
@@ -118,10 +118,10 @@ public static class DrawingViewService
 			return (null, Size.Zero);
 		}
 
-		var minPointX = points.Min(p => p.X);
-		var minPointY = points.Min(p => p.Y);
-		var drawingWidth = points.Max(p => p.X) - minPointX;
-		var drawingHeight = points.Max(p => p.Y) - minPointY;
+		var minPointX = points.Min(p => p.X) - maxLineWidth;
+		var minPointY = points.Min(p => p.Y) - maxLineWidth;
+		var drawingWidth = points.Max(p => p.X) - minPointX + maxLineWidth;
+		var drawingHeight = points.Max(p => p.Y) - minPointY + maxLineWidth;
 		if (drawingWidth < minSize || drawingHeight < minSize)
 		{
 			return (null, new Size(minPointX, minPointY));
@@ -134,7 +134,8 @@ public static class DrawingViewService
 	static CanvasRenderTarget? GetImageInternal(IList<IDrawingLine> lines, Size size, Paint? background, bool scale = false)
 	{
 		var points = lines.SelectMany(x => x.Points).ToList();
-		var (offscreen, offset) = GetCanvasRenderTarget(points, size, scale);
+		var maxLineWidth = lines.Select(x => x.LineWidth).Max();
+		var (offscreen, offset) = GetCanvasRenderTarget(points, size, scale, maxLineWidth);
 		if (offscreen is null)
 		{
 			return null;


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

Add offset to image by max line width

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #773 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [ ] Rebased on top of `main` at time of PR
 - [ ] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
