### PR TITLE
Make `TextColorTo` Generated Classes for .NET MAUI Controls Internal

### DIFF
--- a/src/CommunityToolkit.Maui.SourceGenerators/Generators/TextColorToGenerator.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Generators/TextColorToGenerator.cs
@@ -57,7 +57,7 @@ class TextColorToGenerator : IIncrementalGenerator
 
 		foreach (var namedTypeSymbol in mauiTextStyleImplementors)
 		{
-			textStyleClassList.Add((namedTypeSymbol.Name, "public", namedTypeSymbol.ContainingNamespace.ToDisplayString(), namedTypeSymbol.TypeArguments.GetGenericTypeArgumentsString(), namedTypeSymbol.GetGenericTypeConstraintsAsString()));
+			textStyleClassList.Add((namedTypeSymbol.Name, "internal", namedTypeSymbol.ContainingNamespace.ToDisplayString(), namedTypeSymbol.TypeArguments.GetGenericTypeArgumentsString(), namedTypeSymbol.GetGenericTypeConstraintsAsString()));
 		}
 
 		// Collect All Classes in User Library that Implement ITextStyle
@@ -120,7 +120,7 @@ using Microsoft.Maui.Graphics;
 
 namespace " + textStyleClass.Namespace + @";
 
-static partial class ColorAnimationExtensions_" + textStyleClass.ClassName + @"
+"+ textStyleClass.ClassAcessModifier + @" static partial class ColorAnimationExtensions_" + textStyleClass.ClassName + @"
 {
 	/// <summary>
 	/// Animates the TextColor of an <see cref=""Microsoft.Maui.ITextStyle""/> to the given color

--- a/src/CommunityToolkit.Maui.SourceGenerators/Generators/TextColorToGenerator.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Generators/TextColorToGenerator.cs
@@ -120,7 +120,7 @@ using Microsoft.Maui.Graphics;
 
 namespace " + textStyleClass.Namespace + @";
 
-"+ textStyleClass.ClassAcessModifier + @" static partial class ColorAnimationExtensions_" + textStyleClass.ClassName + @"
+" + textStyleClass.ClassAcessModifier + @" static partial class ColorAnimationExtensions_" + textStyleClass.ClassName + @"
 {
 	/// <summary>
 	/// Animates the TextColor of an <see cref=""Microsoft.Maui.ITextStyle""/> to the given color

--- a/src/CommunityToolkit.Maui.SourceGenerators/Generators/TextColorToGenerator.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Generators/TextColorToGenerator.cs
@@ -120,7 +120,7 @@ using Microsoft.Maui.Graphics;
 
 namespace " + textStyleClass.Namespace + @";
 
-" + textStyleClass.ClassAcessModifier + @" static partial class ColorAnimationExtensions_" + textStyleClass.ClassName + @"
+static partial class ColorAnimationExtensions_" + textStyleClass.ClassName + @"
 {
 	/// <summary>
 	/// Animates the TextColor of an <see cref=""Microsoft.Maui.ITextStyle""/> to the given color


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Markup Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Markup Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI Markup core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui.markup/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

This PR changes generated classes for .NET MAUI controls, i.e.  code generated for `Microsoft.Maui.Controls.*` by `TextColorTo`, from `public` to `internal`.

The bug in https://github.com/CommunityToolkit/Maui.Markup/issues/158 is caused by two matching public classes being generated in both the .NET MAUI library (eg `net7.0-ios`) and the referenced class library (e.g. `net7.0`).

```
📦MyMauiSolution
 ┣ 📂MyMauiApp
    - <TargetFrameworks>net7.0-android;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
 ┗ 📂MyLibrary
    - <TargetFramework>net7.0</TargetFramework>
```

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes https://github.com/CommunityToolkit/Maui/discussions/756#discussioncomment-4125731

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui.Markup/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 
