### PR TITLE
Update ToastDuration options documentation with actual duration

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Interfaces/IToast.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Interfaces/IToast.shared.cs
@@ -22,12 +22,12 @@ public interface IToast : IAlert
 public enum ToastDuration
 {
 	/// <summary>
-	/// Displays Toast for a short time
+	/// Displays Toast for a short time (~2 seconds).
 	/// </summary>
 	Short,
 
 	/// <summary>
-	/// Displays Toast for a long time
+	/// Displays Toast for a long time (~3.5 seconds).
 	/// </summary>
 	Long
 }


### PR DESCRIPTION
While creating a video for Toast I noticed that this enum only specified "short" and "long" which isn't very meaningful to the user. Added the actual length to the description for this.