### PR TITLE
Cancels silently without exception, because unhandled exceptions cras…

### DIFF
--- a/src/CommunityToolkit.Maui.UnitTests/Layouts/StateContainerTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Layouts/StateContainerTests.cs
@@ -125,24 +125,6 @@ public class StateContainerTests : BaseTest
 	}
 
 	[Fact]
-	public async Task Controller_CanceledSwitchToStateThrowsException()
-	{
-		var cts = new CancellationTokenSource();
-		cts.Cancel();
-
-		await Assert.ThrowsAsync<OperationCanceledException>(() => controller.SwitchToState(StateKey.Loading, false, cts.Token));
-	}
-
-	[Fact]
-	public async Task Controller_CanceledSwitchToContentThrowsException()
-	{
-		var cts = new CancellationTokenSource();
-		cts.Cancel();
-
-		await Assert.ThrowsAsync<OperationCanceledException>(() => controller.SwitchToContent(false, cts.Token));
-	}
-
-	[Fact]
 	public async Task Controller_ReturnsErrorLabelOnInvalidState()
 	{
 		await Assert.ThrowsAsync<StateContainerException>(() => controller.SwitchToState("InvalidStateKey", false));


### PR DESCRIPTION
This is a fix so that you dont crash a WinUI Maui App when you try to cycle trough the states so fast that it needs to use cancellationtoken. 
