### PR TITLE
Do not use shared default value for LinesProperty

### DIFF
--- a/src/CommunityToolkit.Maui.UnitTests/Views/DrawingView/DrawingViewTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/DrawingView/DrawingViewTests.cs
@@ -38,6 +38,12 @@ public class DrawingViewTests : BaseHandlerTest
 	}
 
 	[Fact]
+	public void DefaultLinesShouldNotBeShared()
+	{
+		new Maui.Views.DrawingView().Lines.Should().NotBeSameAs(new Maui.Views.DrawingView().Lines);
+	}
+
+	[Fact]
 	public void OnLinesCollectionChangedHandlerIsCalled()
 	{
 		var drawingViewHandler = CreateViewHandler<MockDrawingViewHandler>(drawingView);

--- a/src/CommunityToolkit.Maui/Views/DrawingView/DrawingView.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/DrawingView/DrawingView.shared.cs
@@ -42,7 +42,7 @@ public class DrawingView : View, IDrawingView
 	/// Backing BindableProperty for the <see cref="Lines"/> property.
 	/// </summary>
 	public static readonly BindableProperty LinesProperty = BindableProperty.Create(
-		nameof(Lines), typeof(ObservableCollection<IDrawingLine>), typeof(DrawingView), new ObservableCollection<IDrawingLine>(), BindingMode.TwoWay);
+		nameof(Lines), typeof(ObservableCollection<IDrawingLine>), typeof(DrawingView), defaultValueCreator: (_) => new ObservableCollection<IDrawingLine>(), defaultBindingMode: BindingMode.TwoWay);
 
 	/// <summary>
 	/// Backing BindableProperty for the <see cref="DrawingLineCompletedCommand"/> property.


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

I've change the `LinesProperty` of the `DrawingView` to use a `defaultValueCreator` delegate instead of a `defaultValue`. The default value is a reference `new ObservableCollection<IDrawingLine>()` in a static create function. Hence it was a collection shared over all `DrawingView`s in a MAUI app.

These kind of situations are AFAIK _exactly_ why the `defaultValueCreator` delegate exists.

I haven't provided samples, but I did add a unittest to verify that `new DrawingView().Lines` no longer share a reference.

I haven't changed any documentation, as it doesn't conflict. The documented use coincidentally worked, because it uses either a `Lines = { Binding MyLines }` in XAML and initialises with a `Lines = new ObservableCollection<IDrawingLine>()` in C#. I think the approach where by default a new collection is initialised with every instance of the component, is the desirable outcome.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #794 , #871

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - ~Has samples (if omitted, state reason in description)~
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - ~Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ~ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
