### PR TITLE
StatusBar. Check for Android Activity for null.

### DIFF
--- a/src/CommunityToolkit.Maui.UnitTests/Behaviors/StatusBarBehaviorTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Behaviors/StatusBarBehaviorTests.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.Maui.Behaviors;
 using CommunityToolkit.Maui.Core;
+using FluentAssertions;
 using Xunit;
 
 namespace CommunityToolkit.Maui.UnitTests.Behaviors;
@@ -12,11 +13,11 @@ public class StatusBarBehaviorTests : BaseTest
 		var statusBarBehavior = new StatusBarBehavior();
 
 		Assert.Equal(Colors.Transparent, statusBarBehavior.StatusBarColor);
-		Assert.Equal(Core.StatusBarStyle.Default, statusBarBehavior.StatusBarStyle);
+		Assert.Equal(StatusBarStyle.Default, statusBarBehavior.StatusBarStyle);
 	}
 
 	[Fact]
-	public void VerifyAttachToPageSuceedes()
+	public void VerifyAttachToPageSucceeds()
 	{
 		var statusBarBehavior = new StatusBarBehavior();
 
@@ -36,5 +37,21 @@ public class StatusBarBehaviorTests : BaseTest
 		var view = new View();
 
 		Assert.Throws<InvalidOperationException>(() => view.Behaviors.Add(statusBarBehavior));
+	}
+
+	[Fact]
+	public void VerifyStatusBarColorCallsOnPropertyChangedThrowsExceptionOnUnsupportedPlatform()
+	{
+		var statusBarBehavior = new StatusBarBehavior();
+		var exception = Assert.Throws<NotSupportedException>(() => statusBarBehavior.StatusBarColor = Colors.Red);
+		exception.Message.Should().Be("PlatformSetColor is only supported on net6.0-ios and net6.0-android and later");
+	}
+
+	[Fact]
+	public void VerifyStatusBarStyleCallsOnPropertyChangedThrowsExceptionOnUnsupportedPlatform()
+	{
+		var statusBarBehavior = new StatusBarBehavior();
+		var exception = Assert.Throws<NotSupportedException>(() => statusBarBehavior.StatusBarStyle = StatusBarStyle.DarkContent);
+		exception.Message.Should().Be("PlatformSetStyle is only supported on net6.0-ios and net6.0-android and later");
 	}
 }

--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/StatusBar/StatusBarBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/StatusBar/StatusBarBehavior.shared.cs
@@ -63,14 +63,21 @@ public class StatusBarBehavior : PlatformBehavior<Page>
 	/// <inheritdoc /> 
 	protected override void OnPropertyChanged([CallerMemberName] string? propertyName = null)
 	{
+		base.OnPropertyChanged(propertyName);
+		
 		if (string.IsNullOrWhiteSpace(propertyName))
 		{
 			return;
 		}
 
-		base.OnPropertyChanged(propertyName);
+#if ANDROID
+		if (Platform.CurrentActivity is null)
+		{
+			return;
+		}
+#endif
 
-		if (propertyName.IsOneOf(StatusBarColorProperty, Page.WidthProperty, Page.HeightProperty))
+		if (propertyName.IsOneOf(StatusBarColorProperty, VisualElement.WidthProperty, VisualElement.HeightProperty))
 		{
 			StatusBar.SetColor(StatusBarColor);
 		}


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

Check Activity for null on PropertyChanged.

OnPropertyChanged is called before OnAttachedTo. However, OnAttachedTo called later and set the StatusBar color. Then if any of the properties are changed OnPropertyChanged is called and updates the value.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #685, #880

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
