### PR TITLE
Fix Label background color in CompareConverter Sample #796

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Converters/CompareConverterPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Converters/CompareConverterPage.xaml
@@ -29,7 +29,7 @@
 
         <Label 
             Text="The background of this label will be green if the value of the slider is greater than or equal to 50%, and red otherwise."
-            BackgroundColor="{Binding SliderValue, Mode=OneWay, Converter={mct:CompareConverter ComparingValue={StaticResource ComparingValue}, ComparisonOperator=GreaterOrEqual, TrueObject={StaticResource LightGreen}, FalseObject={ StaticResource PaleVioletRed}}}"
+            BackgroundColor="{Binding SliderValue, Mode=OneWay, Converter={mct:CompareConverter ComparingValue={StaticResource ComparingValue}, ComparisonOperator=GreaterOrEqual, TrueObject={StaticResource LightGreen}, FalseObject={StaticResource PaleVioletRed}}}"
             TextColor="Black"
             Padding="4, 0"/>
 

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Converters/CompareConverterPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Converters/CompareConverterPage.xaml
@@ -10,6 +10,8 @@
     <pages:BasePage.Resources>
         <ResourceDictionary>
             <x:Double x:Key="ComparingValue">0.5</x:Double>
+            <Color x:Key="LightGreen">LightGreen</Color>
+            <Color x:Key="PaleVioletRed">PaleVioletRed</Color>
         </ResourceDictionary>
     </pages:BasePage.Resources>
     
@@ -27,7 +29,7 @@
 
         <Label 
             Text="The background of this label will be green if the value of the slider is greater than or equal to 50%, and red otherwise."
-            BackgroundColor="{Binding SliderValue, Mode=OneWay, Converter={mct:CompareConverter ComparingValue={StaticResource ComparingValue}, ComparisonOperator=GreaterOrEqual, TrueObject=LightGreen, FalseObject=PaleVioletRed}}"
+            BackgroundColor="{Binding SliderValue, Mode=OneWay, Converter={mct:CompareConverter ComparingValue={StaticResource ComparingValue}, ComparisonOperator=GreaterOrEqual, TrueObject={StaticResource LightGreen}, FalseObject={ StaticResource PaleVioletRed}}}"
             TextColor="Black"
             Padding="4, 0"/>
 


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

Set background color

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #796

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [ ] Rebased on top of `main` at time of PR
 - [ ] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
