### PR TITLE
Update build pipeline to enable separate MediaElement release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,7 @@ variables:
   PreviewNumber: $[counter(variables['CurrentSemanticVersionBase'], 1001)]
   CurrentSemanticVersion: '$(CurrentSemanticVersionBase)-preview$(PreviewNumber)'
   NugetPackageVersion: '$(CurrentSemanticVersion)'
+  NugetPackageVersionMediaElement: '$(CurrentSemanticVersion)'
   TOOLKIT_NET_VERSION: '7.0.100'
   LATEST_NET_VERSION: '7.0.x'
   PathToLibrarySolution: 'src/CommunityToolkit.Maui.sln'
@@ -93,14 +94,24 @@ jobs:
     pool:
       vmImage: $(image)
     steps:
-      # if this is a tagged build, then update the version number
+      # if this is a tagged build for CommunityToolkit.Maui, then update the version number
       - powershell: |
           $buildSourceBranch = "$(Build.SourceBranch)"
           $tagVersion = $buildSourceBranch.Substring($buildSourceBranch.LastIndexOf("/") + 1)
           Write-Host("Branch = $buildSourceBranch, Version = $tagVersion");
           Write-Host ("##vso[task.setvariable variable=NugetPackageVersion;]$tagVersion")
         displayName: Set NuGet Version to Tag Number
-        condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/') # Only run this step when a Tag has triggered the CI Pipeline
+        condition: and(startsWith(variables['Build.SourceBranch'], 'refs/tags/'), not(endsWith(variables['Build.SourceBranch'].ToLowerInvariant(), '-mediaelement'))) # Only run this step when a Tag has triggered the CI Pipeline
+
+      # if this is a tagged build for CommunityToolkit.Maui.MediaElement, then update the version number
+      - powershell: |
+          $buildSourceBranch = "$(Build.SourceBranch)"
+          $tagVersion = $buildSourceBranch.Substring($buildSourceBranch.LastIndexOf("/") + 1)
+          $tagVersion = $tagVersion.Substring(0, $buildSourceBranch.LastIndexOf("-"))
+          Write-Host("Branch = $buildSourceBranch, Version = $tagVersion");
+          Write-Host ("##vso[task.setvariable variable=NugetPackageVersionMediaElement;]$tagVersion")
+        displayName: Set NuGet Version to Tag Number
+        condition: and(startsWith(variables['Build.SourceBranch'], 'refs/tags/'), endsWith(variables['Build.SourceBranch'].ToLowerInvariant(), '-mediaelement')) # Only run this step when a Tag has triggered the CI Pipeline        
 
       # if this is a PR build, then update the version number
       - powershell: |
@@ -109,6 +120,7 @@ jobs:
           $fullVersionString = "$(CurrentSemanticVersionBase)-build-$prNumber.$(Build.BuildId)+$commitId"
           Write-Host("GitHub PR = $prNumber, Commit = $commitId");
           Write-Host ("##vso[task.setvariable variable=NugetPackageVersion;]$fullVersionString")
+          Write-Host ("##vso[task.setvariable variable=NugetPackageVersionMediaElement;]$fullVersionString")
           Write-Host "##vso[build.updatebuildnumber]$fullVersionString"
         displayName: Set NuGet Version to PR Version
         condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['build.reason'], 'PullRequest')) # Only run this step on Windows when a Pull Request has triggered the CI Pipeline
@@ -199,7 +211,7 @@ jobs:
       - task: CmdLine@2
         displayName: 'Pack CommunityToolkit.Maui.MediaElement NuGet'
         inputs:
-          script: 'dotnet pack $(PathToCommunityToolkitMediaElementCsproj) -c Release -p:PackageVersion=$(NugetPackageVersion)'
+          script: 'dotnet pack $(PathToCommunityToolkitMediaElementCsproj) -c Release -p:PackageVersion=$(NugetPackageVersionMediaElement)'
 
       # check vulnerabilities
       - powershell: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,7 +101,7 @@ jobs:
           Write-Host("Branch = $buildSourceBranch, Version = $tagVersion");
           Write-Host ("##vso[task.setvariable variable=NugetPackageVersion;]$tagVersion")
         displayName: Set NuGet Version to Tag Number
-        condition: and(startsWith(variables['Build.SourceBranch'], 'refs/tags/'), not(endsWith(variables['Build.SourceBranch'].ToLowerInvariant(), '-mediaelement'))) # Only run this step when a Tag has triggered the CI Pipeline
+        condition: and(startsWith(variables['Build.SourceBranch'], 'refs/tags/'), not(endsWith(variables['Build.SourceBranch'], '-mediaelement'))) # Only run this step when a Tag has triggered the CI Pipeline
 
       # if this is a tagged build for CommunityToolkit.Maui.MediaElement, then update the version number
       - powershell: |
@@ -111,7 +111,7 @@ jobs:
           Write-Host("Branch = $buildSourceBranch, Version = $tagVersion");
           Write-Host ("##vso[task.setvariable variable=NugetPackageVersionMediaElement;]$tagVersion")
         displayName: Set NuGet Version to Tag Number
-        condition: and(startsWith(variables['Build.SourceBranch'], 'refs/tags/'), endsWith(variables['Build.SourceBranch'].ToLowerInvariant(), '-mediaelement')) # Only run this step when a Tag has triggered the CI Pipeline        
+        condition: and(startsWith(variables['Build.SourceBranch'], 'refs/tags/'), endsWith(variables['Build.SourceBranch'], '-mediaelement')) # Only run this step when a Tag has triggered the CI Pipeline        
 
       # if this is a PR build, then update the version number
       - powershell: |


### PR DESCRIPTION
This updates our build pipeline so that we can release `MediaElement` separately from the main package. It adds these things:
* Separate variable for setting the MediaElement version
* Only if the tag does _not_ end with `-mediaelement` (case insensitive), we assume that it's a release for the main package
* Only if the tag _does_ end with `-mediaelement` (case insensitive), we assume that it's a release for `MediaElement`

The rest of the process stays pretty much the same. In Azure DevOps I will create separate releases for each of these packages. The artifacts are still always published because we also use this flow for the pull requests, that will be fixed by a separate pipeline in Azure DevOps to release the right bits.