### PR TITLE
Various MediaElement fixes

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/CommunityToolkit.Maui.Sample.csproj
+++ b/samples/CommunityToolkit.Maui.Sample/CommunityToolkit.Maui.Sample.csproj
@@ -76,10 +76,6 @@
     <RuntimeIdentifiers>maccatalyst-arm64;maccatalyst-x64</RuntimeIdentifiers>
   </PropertyGroup>
   
-  <ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221209.1" />
-  </ItemGroup>
-  
   <ItemGroup>
     <Compile Update="Pages\Views\MediaElement\MediaElementPage.xaml.cs">
       <DependentUpon>MediaElementPage.xaml</DependentUpon>

--- a/src/CommunityToolkit.Maui.MediaElement/CommunityToolkit.Maui.MediaElement.csproj
+++ b/src/CommunityToolkit.Maui.MediaElement/CommunityToolkit.Maui.MediaElement.csproj
@@ -62,8 +62,4 @@
     <PackageReference Include="Xam.Plugins.Android.ExoPlayer" Version="2.18.8" />
     <PackageReference Include="Xam.Plugins.Android.ExoPlayer.Transformer" Version="2.18.8" />
   </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework.Contains('-windows'))">
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221209.1" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
-  </ItemGroup>
 </Project>

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.android.cs
@@ -15,6 +15,8 @@ namespace CommunityToolkit.Maui.Core.Views;
 
 public partial class MediaManager : Java.Lang.Object, IPlayer.IListener
 {
+	double previousSpeed = -1;
+
 	/// <summary>
 	/// The platform native counterpart of <see cref="MediaElement"/>.
 	/// </summary>
@@ -342,13 +344,26 @@ public partial class MediaManager : Java.Lang.Object, IPlayer.IListener
 			return;
 		}
 
+		// First time we're getting a playback speed, set initial value
+		if (previousSpeed == -1)
+		{
+			previousSpeed = MediaElement.Speed;
+		}
+
 		if (MediaElement.Speed > 0)
 		{
 			Player.SetPlaybackSpeed((float)MediaElement.Speed);
-			Player.Play();
+
+			if (previousSpeed == 0)
+			{
+				Player.Play();
+			}
+
+			previousSpeed = MediaElement.Speed;
 		}
 		else
 		{
+			previousSpeed = 0;
 			Player.Pause();
 		}
 	}

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.windows.cs
@@ -127,6 +127,15 @@ partial class MediaManager : IDisposable
 		}
 
 		Player.MediaPlayer.PlaybackRate = MediaElement.Speed;
+
+		if (MediaElement.Speed == 0)
+		{
+			MediaElement.Pause();
+		}
+		else
+		{
+			MediaElement.Play();
+		}
 	}
 
 	protected virtual partial void PlatformUpdateShouldShowPlaybackControls()

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.windows.cs
@@ -126,13 +126,16 @@ partial class MediaManager : IDisposable
 			return;
 		}
 
+		var previousSpeed = Player.MediaPlayer.PlaybackRate;
 		Player.MediaPlayer.PlaybackRate = MediaElement.Speed;
 
-		if (MediaElement.Speed == 0)
+		// Only trigger once when going to the paused state
+		if (MediaElement.Speed == 0 && previousSpeed > 0)
 		{
 			MediaElement.Pause();
 		}
-		else
+		// Only trigger once when we move from the paused state
+		else if (MediaElement.Speed > 0 && previousSpeed == 0)
 		{
 			MediaElement.Play();
 		}


### PR DESCRIPTION
## Description
A couple of small fixes for MediaElement.
* Removes higher WindowsAppSDK version dependency fixing a build error in your .NET MAUI app when consuming
* Fix `ShouldAutoPlay` on Android
* Proper `CurrentState` reporting on Windows when the `Speed` property is used to play and pause

## Related issues/PRs
* Fixes #927 
* Fixes #926 
* Fixes #921 
* Closes #925 