### PR TITLE
Update MediaManager.macios.cs

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
@@ -11,6 +11,10 @@ namespace CommunityToolkit.Maui.Core.Views;
 
 public partial class MediaManager : IDisposable
 {
+	// Media would still start playing when Speed was set although ShouldAutoPlay=False
+	// This field was added to overcome that.
+	bool initialSpeedSet;
+
 	/// <summary>
 	/// The default <see cref="NSKeyValueObservingOptions"/> flags used in the iOS and macOS observers.
 	/// </summary>
@@ -253,12 +257,20 @@ public partial class MediaManager : IDisposable
 
 	protected virtual partial void PlatformUpdateSpeed()
 	{
-		if (PlayerViewController?.Player is null)
+		if (PlayerViewController?.Player is null || MediaElement is null)
 		{
 			return;
 		}
 
+		// First time we're getting a playback speed and should NOT auto play, do nothing.
+		if (!initialSpeedSet && !MediaElement.ShouldAutoPlay)
+		{
+			initialSpeedSet = true;
+			return;
+		}
+
 		PlayerViewController.Player.Rate = (float)MediaElement.Speed;
+
 	}
 
 	protected virtual partial void PlatformUpdateShouldShowPlaybackControls()


### PR DESCRIPTION
### Description of Change ###

Adds a bit of logic to detect if `ShouldAutoPlay` is `false` and `Speed` is getting set for the first time. What would happen is: `Source` is getting set which checks if it should start auto playing (which it shouldn't), then we set the `Speed` and whenever `Speed` is more than 0, it would still start playing.

This should overcome that. I checked Windows and it isn't happening there. That's why I didn't make it a more global solution (because Android already has something similar as well).

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #943

 ### PR Checklist ###
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->
