### PR TITLE
Fix FolderPicker Error when trying to open a second time on MacCatalyst

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Essentials/FileSaverPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Essentials/FileSaverPage.xaml
@@ -16,7 +16,17 @@
                HorizontalTextAlignment="Center"/>
         
         <Button Command="{Binding SaveFileCommand}"
-                Text="Save"
+                Text="Save using FileSaver from DI Container"
+                HorizontalOptions="Center"/>
+
+        
+        <Button Command="{Binding SaveFileStaticCommand}"
+                Text="Save using static FileSaver"
+                HorizontalOptions="Center"/>
+
+        
+        <Button Command="{Binding SaveFileInstanceCommand}"
+                Text="Save using new instance of FileSaver"
                 HorizontalOptions="Center"/>
 
     </VerticalStackLayout>

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Essentials/FolderPickerPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Essentials/FolderPickerPage.xaml
@@ -16,9 +16,18 @@
                HorizontalTextAlignment="Center"/>
         
         <Button Command="{Binding PickFolderCommand}"
-                Text="Pick Folder"
+                Text="Pick Folder using FolderPicker from DI Container"
                 HorizontalOptions="Center"/>
 
+        
+        <Button Command="{Binding PickFolderStaticCommand}"
+                Text="Pick Folder using static FolderPicker"
+                HorizontalOptions="Center"/>
+
+        
+        <Button Command="{Binding PickFolderInstanceCommand}"
+                Text="Pick Folder using new instance of FolderPicker"
+                HorizontalOptions="Center"/>
     </VerticalStackLayout>
     
 </pages:BasePage>

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Essentials/FileSaverViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Essentials/FileSaverViewModel.cs
@@ -28,4 +28,38 @@ public partial class FileSaverViewModel : BaseViewModel
 			await Toast.Make($"File is not saved, {ex.Message}").Show(cancellationToken);
 		}
 	}
+
+	[RelayCommand]
+	async Task SaveFileStatic(CancellationToken cancellationToken)
+	{
+		using var stream = new MemoryStream(Encoding.Default.GetBytes("Hello from the Community Toolkit!"));
+		try
+		{
+			var fileLocation = await FileSaver.SaveAsync("test.txt", stream, cancellationToken);
+			await Toast.Make($"File is saved: {fileLocation}").Show(cancellationToken);
+		}
+		catch (Exception ex)
+		{
+			await Toast.Make($"File is not saved, {ex.Message}").Show(cancellationToken);
+		}
+	}
+
+	[RelayCommand]
+	async Task SaveFileInstance(CancellationToken cancellationToken)
+	{
+		using var stream = new MemoryStream(Encoding.Default.GetBytes("Hello from the Community Toolkit!"));
+		try
+		{
+			var fileSaverInstance = new FileSaverImplementation();
+			var fileLocation = await fileSaverInstance.SaveAsync("test.txt", stream, cancellationToken);
+			await Toast.Make($"File is saved: {fileLocation}").Show(cancellationToken);
+#if IOS || MACCATALYST
+			fileSaverInstance.Dispose();
+#endif
+		}
+		catch (Exception ex)
+		{
+			await Toast.Make($"File is not saved, {ex.Message}").Show(cancellationToken);
+		}
+	}
 }

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Essentials/FolderPickerViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Essentials/FolderPickerViewModel.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using CommunityToolkit.Maui.Alerts;
 using CommunityToolkit.Maui.Core;
 using CommunityToolkit.Maui.Storage;
@@ -21,6 +22,39 @@ public partial class FolderPickerViewModel : BaseViewModel
 		{
 			var folder = await folderPicker.PickAsync(cancellationToken);
 			await Toast.Make($"Folder picked: Name - {folder.Name}, Path - {folder.Path}", ToastDuration.Long).Show(cancellationToken);
+		}
+		catch (Exception ex)
+		{
+			await Toast.Make($"Folder is not picked, {ex.Message}").Show(cancellationToken);
+		}
+	}
+
+	[RelayCommand]
+	async Task PickFolderStatic(CancellationToken cancellationToken)
+	{
+		try
+		{
+			var folder = await FolderPicker.PickAsync(cancellationToken);
+			await Toast.Make($"Folder picked: Name - {folder.Name}, Path - {folder.Path}", ToastDuration.Long).Show(cancellationToken);
+		}
+		catch (Exception ex)
+		{
+			await Toast.Make($"Folder is not picked, {ex.Message}").Show(cancellationToken);
+		}
+	}
+
+	[RelayCommand]
+	async Task PickFolderInstance(CancellationToken cancellationToken)
+	{
+		using var stream = new MemoryStream(Encoding.Default.GetBytes("Hello from the Community Toolkit!"));
+		try
+		{
+			var folderPickerInstance = new FolderPickerImplementation();
+			var folder = await folderPickerInstance.PickAsync(cancellationToken);
+			await Toast.Make($"Folder picked: Name - {folder.Name}, Path - {folder.Path}", ToastDuration.Long).Show(cancellationToken);
+#if IOS || MACCATALYST
+			folderPickerInstance.Dispose();
+#endif
 		}
 		catch (Exception ex)
 		{

--- a/src/CommunityToolkit.Maui.Core/Essentials/FileSaver/FileSaverImplementation.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Essentials/FileSaver/FileSaverImplementation.macios.cs
@@ -1,6 +1,10 @@
+using System.Runtime.Versioning;
+
 namespace CommunityToolkit.Maui.Storage;
 
 /// <inheritdoc cref="IFileSaver" />
+[SupportedOSPlatform("iOS14.0")]
+[SupportedOSPlatform("MacCatalyst14.0")]
 public sealed partial class FileSaverImplementation : IFileSaver, IDisposable
 {
 	UIDocumentPickerViewController? documentPickerViewController;


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #949 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
