### PR TITLE
Relax ViewController detection for iOS MediaElement to enable non-Shell usage

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.macios.cs
@@ -20,23 +20,22 @@ public class MauiMediaElement : UIView
 		playerViewController.View.Frame = Bounds;
 
 #if IOS16_0_OR_GREATER || MACCATALYST16_1_OR_GREATER
-		// On iOS 16+ and macOS 13+ the AVPlayerViewController has to be added to the parent ViewController, otherwise the transport controls won't be displayed.
-		var viewController = WindowStateManager.Default.GetCurrentUIViewController() ?? throw new InvalidOperationException("ViewController can't be null.");
+		// On iOS 16+ and macOS 13+, in combination with Shell the AVPlayerViewController has to be added to the parent ViewController, otherwise the transport controls won't be displayed.
+		var viewController = WindowStateManager.Default.GetCurrentUIViewController();
 
-		if (viewController.View is null)
+		// If we don't find the viewController, assume it's not Shell and still continue, the transport controls will still be displayed
+		if (viewController?.View is not null)
 		{
-			throw new NullReferenceException($"{nameof(viewController.View)} cannot be null");
+			// Zero out the safe area insets of the AVPlayerViewController
+			UIEdgeInsets insets = viewController.View.SafeAreaInsets;
+			playerViewController.AdditionalSafeAreaInsets =
+				new UIEdgeInsets(insets.Top * -1, insets.Left, insets.Bottom * -1, insets.Right);
+
+
+			// Add the View from the AVPlayerViewController to the parent ViewController
+			viewController.AddChildViewController(playerViewController);
+			viewController.View.AddSubview(playerViewController.View);
 		}
-
-		// Zero out the safe area insets of the AVPlayerViewController
-		UIEdgeInsets insets = viewController.View.SafeAreaInsets;
-		playerViewController.AdditionalSafeAreaInsets =
-			new UIEdgeInsets(insets.Top * -1, insets.Left, insets.Bottom * -1, insets.Right);
-
-
-		// Add the View from the AVPlayerViewController to the parent ViewController
-		viewController.AddChildViewController(playerViewController);
-		viewController.View.AddSubview(playerViewController.View);
 #endif
 
 		AddSubview(playerViewController.View);


### PR DESCRIPTION
 ### Description of Change ###

For iOS 16 and macOS 13 and up we have to do a little trickery to make the platform transport controls show up. It seems that this trickery only works, but also only is necessary, when you use .NET MAUI Shell.

This PR relaxes the code a little bit so that it doesn't start throwing exceptions but just skips over this part. From testing this seems to work in both Shell and non-Shell scenarios now.

 ### Linked Issues ###

 - Fixes #985

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description), not testable besides manually
 - [ ] Has samples (if omitted, state reason in description), the sample app uses Shell, you can add this but not really include it in the sample app
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: NA
