### PR TITLE
Remove `[UnsupportedOSPlatform("Tizen")]`

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Platform/StatusBar/StatusBar.tizen.cs
+++ b/src/CommunityToolkit.Maui.Core/Platform/StatusBar/StatusBar.tizen.cs
@@ -3,7 +3,6 @@ using Microsoft.Maui.Platform;
 
 namespace CommunityToolkit.Maui.Core.Platform;
 
-[UnsupportedOSPlatform("Tizen")]
 static partial class StatusBar
 {
 	static void PlatformSetColor(Color color)

--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/StatusBar/StatusBarBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/StatusBar/StatusBarBehavior.shared.cs
@@ -10,7 +10,7 @@ namespace CommunityToolkit.Maui.Behaviors;
 /// <summary>
 /// <see cref="PlatformBehavior{TView,TPlatformView}"/> that controls the Status bar color
 /// </summary>
-[UnsupportedOSPlatform("Windows"), UnsupportedOSPlatform("MacCatalyst"), UnsupportedOSPlatform("MacOS"), UnsupportedOSPlatform("Tizen")]
+[UnsupportedOSPlatform("Windows"), UnsupportedOSPlatform("MacCatalyst"), UnsupportedOSPlatform("MacOS")]
 public class StatusBarBehavior : PlatformBehavior<Page>
 {
 	/// <summary>


### PR DESCRIPTION
 ### Description of Change ###

This PR removes `[UnsupportedOSPlatform("Tizen")]`.

In previous versions of .NET this was a Warning, but has been promoted to a Compiler Error in .NET v7.0.3.

([Discovered in CI Pipeline](https://dev.azure.com/dotnet/CommunityToolkit/_build/results?buildId=87518&view=logs&j=67da6a11-18ef-5f70-9b43-fae7e6c83e18&t=49ed9970-d038-52c3-9405-25559677b293&l=21))
 
