### PR TITLE
Fix disposal of MediaElement for Windows

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.windows.cs
@@ -28,8 +28,8 @@ public partial class MediaElementHandler : ViewHandler<MediaElement, MauiMediaEl
 	/// <inheritdoc/>
 	protected override void DisconnectHandler(MauiMediaElement platformView)
 	{
-		platformView.Dispose();
 		Dispose();
+		platformView.Dispose();
 		base.DisconnectHandler(platformView);
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Changes the order of the dispose calls for Windows to see if that fixes issues when cleaning up resources 

 ### Linked Issues ###

 - Fixes #962

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: NA
 
