### PR TITLE
Provide parent view controller to MediaElement iOS

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.macios.cs
@@ -1,6 +1,7 @@
 ﻿using CommunityToolkit.Maui.Core.Views;
 using CommunityToolkit.Maui.Views;
 using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
 
 namespace CommunityToolkit.Maui.Core.Handlers;
 
@@ -10,9 +11,29 @@ public partial class MediaElementHandler : ViewHandler<MediaElement, MauiMediaEl
 	/// <exception cref="NullReferenceException">Thrown if <see cref="MauiContext"/> is <see langword="null"/>.</exception>
 	protected override MauiMediaElement CreatePlatformView()
 	{
-		mediaManager ??= new(MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} cannot be null"), VirtualView);
+		if (MauiContext is null)
+		{
+			throw new InvalidOperationException($"{nameof(MauiContext)} cannot be null");
+		}
+
+		mediaManager ??= new(MauiContext, VirtualView);
+
+		// Retrieve the parenting page so we can provide that to the platform control
+		var parent = VirtualView.Parent;
+		while (parent != null)
+		{
+			if (parent is Page)
+			{
+				break;
+			}
+
+			parent = parent.Parent;
+		}
+
+		var parentPage = (parent as Page)?.ToHandler(MauiContext);		
+
 		var (_, playerViewController) = mediaManager.CreatePlatformView();
-		return new(playerViewController);
+		return new(playerViewController, parentPage?.ViewController);
 	}
 
 	/// <inheritdoc/>

--- a/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.macios.cs
@@ -20,7 +20,7 @@ public partial class MediaElementHandler : ViewHandler<MediaElement, MauiMediaEl
 
 		// Retrieve the parenting page so we can provide that to the platform control
 		var parent = VirtualView.Parent;
-		while (parent != null)
+		while (parent is not null)
 		{
 			if (parent is Page)
 			{

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.macios.cs
@@ -13,15 +13,16 @@ public class MauiMediaElement : UIView
 	/// Initializes a new instance of the <see cref="MauiMediaElement"/> class.
 	/// </summary>
 	/// <param name="playerViewController">The <see cref="AVPlayerViewController"/> that acts as the platform media player.</param>
+	/// <param name="parentViewController">The <see cref="UIViewController"/> that acts as the parent for <paramref name="playerViewController"/>.</param>
 	/// <exception cref="NullReferenceException">Thrown when <paramref name="playerViewController"/><c>.View</c> is <see langword="null"/>.</exception>
-	public MauiMediaElement(AVPlayerViewController playerViewController)
+	public MauiMediaElement(AVPlayerViewController playerViewController, UIViewController? parentViewController)
 	{
 		ArgumentNullException.ThrowIfNull(playerViewController.View);
 		playerViewController.View.Frame = Bounds;
 
 #if IOS16_0_OR_GREATER || MACCATALYST16_1_OR_GREATER
-		// On iOS 16+ and macOS 13+, in combination with Shell the AVPlayerViewController has to be added to the parent ViewController, otherwise the transport controls won't be displayed.
-		var viewController = WindowStateManager.Default.GetCurrentUIViewController();
+		// On iOS 16+ and macOS 13+ the AVPlayerViewController has to be added to a parent ViewController, otherwise the transport controls won't be displayed.
+		var viewController = parentViewController ?? WindowStateManager.Default.GetCurrentUIViewController();
 
 		// If we don't find the viewController, assume it's not Shell and still continue, the transport controls will still be displayed
 		if (viewController?.View is not null)
@@ -36,6 +37,7 @@ public class MauiMediaElement : UIView
 			viewController.AddChildViewController(playerViewController);
 			viewController.View.AddSubview(playerViewController.View);
 		}
+
 #endif
 
 		AddSubview(playerViewController.View);


### PR DESCRIPTION
### Description of Change ###

When a `MediaElement` is created on iOS, find the parenting `UIViewController` and pass that down. This is needed on iOS to prevent issues with `AVPlayerViewController`

 ### Linked Issues ###

 - Fixes #985

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: NA
