### PR TITLE
FileSaver does not truncate existing files

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Essentials/FileSaver/FileSaverImplementation.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Essentials/FileSaver/FileSaverImplementation.shared.cs
@@ -35,6 +35,7 @@ public sealed partial class FileSaverImplementation
 	static async Task WriteStream(Stream stream, string filePath, CancellationToken cancellationToken)
 	{
 		await using var fileStream = new FileStream(filePath, FileMode.OpenOrCreate);
+		fileStream.SetLength(0);
 		stream.Seek(0, SeekOrigin.Begin);
 		await stream.CopyToAsync(fileStream, cancellationToken).ConfigureAwait(false);
 	}


### PR DESCRIPTION
 ### Description of Change ###

FileMode.OpenOrCreate does not automatically truncate files.

This fix truncates files to ensure that junk data does not appear at the end of a newly saved file if the data being written is shorter than data present in a previously existing file.

 ### Linked Issues ###
 - Fixes #1049