### PR TITLE
[Housekeeping] Increase Toolkit .NET Version to v7.0.200

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ variables:
   CurrentSemanticVersion: '$(CurrentSemanticVersionBase)-preview$(PreviewNumber)'
   NugetPackageVersion: '$(CurrentSemanticVersion)'
   NugetPackageVersionMediaElement: '$(CurrentSemanticVersion)'
-  TOOLKIT_NET_VERSION: '7.0.100'
+  TOOLKIT_NET_VERSION: '7.0.200'
   LATEST_NET_VERSION: '7.0.x'
   PathToLibrarySolution: 'src/CommunityToolkit.Maui.sln'
   PathToSamplesSolution: 'samples/CommunityToolkit.Maui.Sample.sln'

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.100",
+    "version": "7.0.200",
     "rollForward": "latestMajor"
   }
 }


### PR DESCRIPTION
 ### Description of Change ###

This PR increases the minimum .NET Dependency listed in `global.json` + `azure-pipelines.yml` to .NET v7.0.200.

This fixes an oversight after we [increased the .NET MAUI version to v7.0.59 to support `CollectionView` in `Expander`](https://github.com/CommunityToolkit/Maui/commit/4adb6c94d1f78bb56f5bb6fc09d864f64f1dc31d#diff-7915b9b726a397ae7ba6af7b9703633d21c031ebf21682f3ee7e6a4ec52837a5).

The Issue linked below demonstrates that .NET MAUI Community Toolkit no longer supports .NET v7.0.100 (we should've updated these values in `global.json` and `azure-pipelines.yml` in that PR).

We've also noted the Breaking Change in our [Release Notes for v5.0.0](https://github.com/CommunityToolkit/Maui/releases/tag/5.0.0) that .NET MAUI 7.0.59 is required which is included in .NET 7.0.200.

 ### Linked Issues ###

 - Fixes https://github.com/CommunityToolkit/Maui/issues/1068

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to coding standard
 
