### PR TITLE
Promote `MediaManager.PlatformSeek()` from `void` to `ValueTask`

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.android.cs
@@ -19,7 +19,10 @@ public partial class MediaElementHandler : ViewHandler<MediaElement, MauiMediaEl
 
 	protected override MauiMediaElement CreatePlatformView()
 	{
-		mediaManager ??= new(MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} cannot be null"), VirtualView);
+		mediaManager ??= new(MauiContext ?? throw new InvalidOperationException($"{nameof(MauiContext)} cannot be null"), 
+								VirtualView,
+								Dispatcher.GetForCurrentThread() ?? throw new InvalidOperationException($"{nameof(IDispatcher)} cannot be null"));
+
 		var (_, playerView) = mediaManager.CreatePlatformView();
 		return new(Context, playerView);
 	}

--- a/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.macios.cs
@@ -16,7 +16,9 @@ public partial class MediaElementHandler : ViewHandler<MediaElement, MauiMediaEl
 			throw new InvalidOperationException($"{nameof(MauiContext)} cannot be null");
 		}
 
-		mediaManager ??= new(MauiContext, VirtualView);
+		mediaManager ??= new(MauiContext,
+								VirtualView,
+								Dispatcher.GetForCurrentThread() ?? throw new InvalidOperationException($"{nameof(IDispatcher)} cannot be null"));
 
 		// Retrieve the parenting page so we can provide that to the platform control
 		var parent = VirtualView.Parent;

--- a/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.tizen.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.tizen.cs
@@ -10,7 +10,10 @@ public partial class MediaElementHandler : ViewHandler<MediaElement, MauiMediaEl
 	/// <exception cref="NullReferenceException">Thrown if <see cref="MauiContext"/> is <see langword="null"/>.</exception>
 	protected override MauiMediaElement CreatePlatformView()
 	{
-		mediaManager ??= new(MauiContext ?? throw new NullReferenceException(), VirtualView);
+		mediaManager ??= new(MauiContext ?? throw new NullReferenceException(), 
+								VirtualView,
+								Dispatcher.GetForCurrentThread() ?? throw new InvalidOperationException($"{nameof(IDispatcher)} cannot be null"));
+
 		var playerView = mediaManager.CreatePlatformView();
 		return new (playerView);
 	}

--- a/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.windows.cs
@@ -20,7 +20,10 @@ public partial class MediaElementHandler : ViewHandler<MediaElement, MauiMediaEl
 	/// <inheritdoc/>
 	protected override MauiMediaElement CreatePlatformView()
 	{
-		mediaManager ??= new(MauiContext ?? throw new NullReferenceException(), VirtualView);
+		mediaManager ??= new(MauiContext ?? throw new NullReferenceException(), 
+								VirtualView,
+								Dispatcher.GetForCurrentThread() ?? throw new InvalidOperationException($"{nameof(IDispatcher)} cannot be null"));
+
 		var mediaPlatform = mediaManager.CreatePlatformView();
 		return new(mediaPlatform);
 	}

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.android.cs
@@ -243,9 +243,11 @@ public partial class MediaManager : Java.Lang.Object, IPlayer.IListener
 		Player.Pause();
 	}
 
-	protected virtual partial void PlatformSeek(TimeSpan position)
+	protected virtual partial ValueTask PlatformSeek(TimeSpan position)
 	{
 		Player?.SeekTo((long)position.TotalMilliseconds);
+
+		return ValueTask.CompletedTask;
 	}
 
 	protected virtual partial void PlatformStop()

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
@@ -124,12 +124,12 @@ public partial class MediaManager : IDisposable
 		Player?.Pause();
 	}
 
-	protected virtual partial void PlatformSeek(TimeSpan position)
+	protected virtual partial ValueTask PlatformSeek(TimeSpan position)
 	{
 		if (PlayerItem is null || Player?.CurrentItem is null
 			|| Player?.Status != AVPlayerStatus.ReadyToPlay)
 		{
-			return;
+			return ValueTask.CompletedTask;
 		}
 
 		var ranges = Player.CurrentItem.SeekableTimeRanges;
@@ -149,6 +149,8 @@ public partial class MediaManager : IDisposable
 				break;
 			}
 		}
+
+		return ValueTask.CompletedTask;
 	}
 
 	protected virtual partial void PlatformStop()

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.shared.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.shared.cs
@@ -24,10 +24,12 @@ public partial class MediaManager
 	/// </summary>
 	/// <param name="context">This application's <see cref="IMauiContext"/>.</param>
 	/// <param name="mediaElement">The <see cref="IMediaElement"/> instance that is managed through this class.</param>
-	public MediaManager(IMauiContext context, IMediaElement mediaElement)
+	/// <param name="dispatcher">The <see cref="IDispatcher"/> instance that allows propagation to the main thread.</param>
+	public MediaManager(IMauiContext context, IMediaElement mediaElement, IDispatcher dispatcher)
 	{
-		this.MediaElement = mediaElement;
 		MauiContext = context;
+		Dispatcher = dispatcher;
+		MediaElement = mediaElement;
 
 		Logger = MauiContext.Services.GetRequiredService<ILoggerFactory>().CreateLogger(nameof(MediaManager));
 	}
@@ -41,6 +43,11 @@ public partial class MediaManager
 	/// The <see cref="IMauiContext"/> used by this class.
 	/// </summary>
 	protected IMauiContext MauiContext { get; }
+
+	/// <summary>
+	/// The <see cref="IDispatcher"/> that allows propagation to the main thread
+	/// </summary>
+	protected IDispatcher Dispatcher { get; }
 
 	/// <summary>
 	/// Gets the <see cref="ILogger"/> instance for logging purposes.
@@ -75,9 +82,9 @@ public partial class MediaManager
 	/// Invokes the seek operation on the platform element.
 	/// </summary>
 	/// <param name="position">The position to seek to.</param>
-	public void Seek(TimeSpan position)
+	public async ValueTask Seek(TimeSpan position)
 	{
-		PlatformSeek(position);
+		await PlatformSeek(position);
 	}
 
 	/// <summary>
@@ -175,7 +182,7 @@ public partial class MediaManager
 	/// Invokes the platform seek functionality and seeks to a specific position.
 	/// </summary>
 	/// <param name="position">The position to seek to.</param>
-	protected virtual partial void PlatformSeek(TimeSpan position);
+	protected virtual partial ValueTask PlatformSeek(TimeSpan position);
 
 	/// <summary>
 	/// Invokes the platform stop functionality and stops media playback.
@@ -232,9 +239,9 @@ public partial class MediaManager
 #if !(WINDOWS || ANDROID || IOS || MACCATALYST || TIZEN)
 partial class MediaManager
 {
+	protected virtual partial ValueTask PlatformSeek(TimeSpan position) => ValueTask.CompletedTask;
 	protected virtual partial void PlatformPlay() { }
 	protected virtual partial void PlatformPause() { }
-	protected virtual partial void PlatformSeek(TimeSpan position) { }
 	protected virtual partial void PlatformStop() { }
 	protected virtual partial void PlatformUpdateAspect() { }
 	protected virtual partial void PlatformUpdateSource() { }

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.windows.cs
@@ -78,17 +78,19 @@ partial class MediaManager : IDisposable
 		}
 	}
 
-	protected virtual partial void PlatformSeek(TimeSpan position)
+	protected virtual async partial ValueTask PlatformSeek(TimeSpan position)
 	{
-		MainThread.BeginInvokeOnMainThread(() =>
+		if (Player?.MediaPlayer.CanSeek ?? false)
 		{
-			if (Player?.MediaPlayer.CanSeek ?? false)
+			if (Dispatcher.IsDispatchRequired)
 			{
-			
-					Player.MediaPlayer.Position = position;
-		
+				await Dispatcher.DispatchAsync(() => Player.MediaPlayer.Position = position);
 			}
-		});
+			else
+			{
+				Player.MediaPlayer.Position = position;
+			}
+		}
 	}
 
 	protected virtual partial void PlatformStop()


### PR DESCRIPTION
 ### Description of Change ###

This PR is a recommendation to update the existing PR #1015.

### Additional Information

This PR also includes formatting fixes to `MediaManager.Tizen.cs`:
- Use `or` to evaluate multiple `enum` states
- Consolidate methods, keeping `public` methods grouped together, `protected` methods grouped together, etc