### PR TITLE
Added Generic EventArgs Converter

### DIFF
--- a/src/CommunityToolkit.Maui/Converters/EventArgsConverter.cs
+++ b/src/CommunityToolkit.Maui/Converters/EventArgsConverter.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
+namespace CommunityToolkit.Maui.Converters;
+
+/// <summary>
+/// Converts/Extracts the incoming value from <see cref="EventArgs"/> object and returns the entire EventArgs of <see cref="EventArgs"/> property from it.
+/// </summary>
+public class EventArgsConverter : BaseConverterOneWay<EventArgs?, object?>
+{
+	/// <inheritdoc/>
+	public override object? DefaultConvertReturnValue { get; set; } = null;
+
+	/// <summary>
+	/// Converts/Extracts the incoming value from <see cref="EventArgs"/> object and returns the value of <see cref="EventArgs"/> property from it.
+	/// </summary>
+	/// <param name="value">The entire EventArgs.</param>
+	/// <param name="culture">(Not Used)</param>
+	/// <returns>A <see cref="EventArgs"/> object from object of type <see cref="EventArgs"/>.</returns>
+	[return: NotNullIfNotNull(nameof(value))]
+	public override object? ConvertFrom(EventArgs? value, CultureInfo? culture = null) => value switch
+	{
+		null => null,
+		_ => value
+	};
+}


### PR DESCRIPTION
Enable users to use EventToCommandBehaviours using a generic EventArgs which casts any EventArgs inherited class. EventArgsConverter="{StaticResource Key=EventArgsConverter}"

<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - New Feature: https://github.com/CommunityToolkit/Maui/issues/1134

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [ ] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
