### PR TITLE
1207 UniformItemsLayout NoItems crash

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Layouts/UniformItemsLayoutPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Layouts/UniformItemsLayoutPage.xaml
@@ -114,6 +114,15 @@
                     </StackLayout>
                 </StackLayout>
             </mct:UniformItemsLayout>
+
+            <Button Text="Add Random item" Command="{Binding AddItemCommand}" HorizontalOptions="Center" VerticalOptions="Center" Padding="8"/>
+            <mct:UniformItemsLayout BindableLayout.ItemsSource="{Binding Items}">
+                <BindableLayout.ItemTemplate>
+                    <DataTemplate>
+                        <Label Text="{Binding}" />
+                    </DataTemplate>
+                </BindableLayout.ItemTemplate>
+            </mct:UniformItemsLayout>
         </VerticalStackLayout>
     </ScrollView>
 </pages:BasePage>

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Layouts/UniformItemsLayoutViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Layouts/UniformItemsLayoutViewModel.cs
@@ -1,6 +1,16 @@
-﻿namespace CommunityToolkit.Maui.Sample.ViewModels.Layouts;
+﻿using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 
-public class UniformItemsLayoutViewModel : BaseViewModel
+namespace CommunityToolkit.Maui.Sample.ViewModels.Layouts;
+
+public partial class UniformItemsLayoutViewModel : BaseViewModel
 {
+	[RelayCommand]
+	void AddItem()
+	{
+		Items.Add(Path.GetRandomFileName());
+	}
 
+	public ObservableCollection<string> Items { get; } = new();
 }

--- a/src/CommunityToolkit.Maui.Core/Layouts/UniformItemsLayoutManager.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Layouts/UniformItemsLayoutManager.shared.cs
@@ -65,7 +65,7 @@ public class UniformItemsLayoutManager : LayoutManager
 
 		if (childWidth == 0)
 		{
-			var sizeRequest = visibleChildren[0].Measure(double.PositiveInfinity, double.PositiveInfinity);
+			var sizeRequest = visibleChildren.Length == 0 ? Size.Zero : visibleChildren[0].Measure(double.PositiveInfinity, double.PositiveInfinity);
 
 			childWidth = sizeRequest.Width;
 			childHeight = sizeRequest.Height;

--- a/src/CommunityToolkit.Maui.UnitTests/Layouts/UniformItemsLayoutTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Layouts/UniformItemsLayoutTests.cs
@@ -60,6 +60,17 @@ public class UniformItemsLayoutTests : BaseTest
 	}
 
 	[Fact]
+	public void MeasureUniformItemsLayout_NoItems_ZeroSize()
+	{
+		var expectedSize = Size.Zero;
+		var emptyUniformItemsLayout = new UniformItemsLayout();
+
+		var actualSize = emptyUniformItemsLayout.CrossPlatformMeasure(double.PositiveInfinity, double.PositiveInfinity);
+
+		Assert.Equal(expectedSize, actualSize);
+	}
+
+	[Fact]
 	public void MeasureUniformItemsLayout_WrapOnNextRow()
 	{
 		var expectedSize = new Size(childWidth, childHeight * childCount);


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #1207 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [ ] Rebased on top of `main` at time of PR
 - [ ] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
