### PR TITLE
Add `IAsynchronousHandler`

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Handlers/Popup/PopUpHandler.android.cs
+++ b/src/CommunityToolkit.Maui.Core/Handlers/Popup/PopUpHandler.android.cs
@@ -23,7 +23,7 @@ public partial class PopupHandler : ElementHandler<IPopup, MauiPopup>
 			popup.Dismiss();
 		}
 
-		view.PopupDismissedTaskCompletionSource.TrySetResult();
+		view.HandlerCompleteTCS.TrySetResult();
 
 		handler.DisconnectHandler(popup);
 	}

--- a/src/CommunityToolkit.Maui.Core/Handlers/Popup/PopupHandler.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Handlers/Popup/PopupHandler.macios.cs
@@ -19,7 +19,7 @@ public partial class PopupHandler : ElementHandler<IPopup, MauiPopup>
 			await vc.DismissViewControllerAsync(true);
 		}
 
-		view.PopupDismissedTaskCompletionSource.TrySetResult();
+		view.HandlerCompleteTCS.TrySetResult();
 
 		handler.DisconnectHandler(handler.PlatformView);
 	}

--- a/src/CommunityToolkit.Maui.Core/Handlers/Popup/PopupHandler.net.cs
+++ b/src/CommunityToolkit.Maui.Core/Handlers/Popup/PopupHandler.net.cs
@@ -13,7 +13,7 @@ public partial class PopupHandler : Microsoft.Maui.Handlers.ElementHandler<IPopu
 	/// <param name="result">The result that should return from this Popup.</param>
 	public static void MapOnClosed(PopupHandler handler, IPopup view, object? result)
 	{
-		view.PopupDismissedTaskCompletionSource.TrySetResult();
+		view.HandlerCompleteTCS.TrySetResult();
 	}
 
 	/// <summary>

--- a/src/CommunityToolkit.Maui.Core/Interfaces/IAsynchronousHandler.cs
+++ b/src/CommunityToolkit.Maui.Core/Interfaces/IAsynchronousHandler.cs
@@ -1,0 +1,13 @@
+﻿namespace CommunityToolkit.Maui.Core;
+
+/// <summary>
+/// Interface that allows asynchronous completion of .NET MAUI Handlers
+/// </summary>
+public interface IAsynchronousHandler
+{
+	/// <summary>
+	/// A <see cref="TaskCompletionSource"/> to provide Handlers an asynchronous way to complete
+	/// </summary>
+	TaskCompletionSource HandlerCompleteTCS { get; }
+}
+

--- a/src/CommunityToolkit.Maui.Core/Interfaces/IPopup.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Interfaces/IPopup.shared.cs
@@ -6,7 +6,7 @@ namespace CommunityToolkit.Maui.Core;
 /// <summary>
 /// Represents a small View that pops up at front the Page.
 /// </summary>
-public interface IPopup : IElement, IVisualTreeElement
+public interface IPopup : IElement, IVisualTreeElement, IAsynchronousHandler
 {
 	/// <summary>
 	/// Gets the View that Popup will be anchored.
@@ -42,11 +42,6 @@ public interface IPopup : IElement, IVisualTreeElement
 	/// Gets the vertical aspect of this element's arrangement in a container.
 	/// </summary>
 	LayoutAlignment VerticalOptions { get; }
-
-	/// <summary>
-	/// <see cref="TaskCompletionSource"/> that completes when the operating system has dismissed <see cref="IPopup"/> from the screen
-	/// </summary>
-	TaskCompletionSource PopupDismissedTaskCompletionSource { get; }
 
 	/// <summary>
 	/// Occurs when the Popup is closed.

--- a/src/CommunityToolkit.Maui.UnitTests/Views/Popup/PopupTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/Popup/PopupTests.cs
@@ -209,7 +209,7 @@ public class PopupTests : BaseHandlerTest
 
 		protected override Task OnClosed(object? result, bool wasDismissedByTappingOutsideOfPopup)
 		{
-			((IPopup)this).PopupDismissedTaskCompletionSource.TrySetResult();
+			((IPopup)this).HandlerCompleteTCS.TrySetResult();
 			return base.OnClosed(result, wasDismissedByTappingOutsideOfPopup);
 		}
 	}

--- a/src/CommunityToolkit.Maui/Views/Popup/Popup.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/Popup.shared.cs
@@ -194,7 +194,7 @@ public partial class Popup : Element, IPopup, IWindowController, IPropertyPropag
 	IView? IPopup.Content => Content;
 
 	/// <inheritdoc/>
-	TaskCompletionSource IPopup.PopupDismissedTaskCompletionSource => popupDismissedTaskCompletionSource;
+	TaskCompletionSource IAsynchronousHandler.HandlerCompleteTCS => popupDismissedTaskCompletionSource;
 
 	/// <summary>
 	/// Resets the Popup.


### PR DESCRIPTION
 ### Description of Change ###

> Note: This PR targets https://github.com/CommunityToolkit/Maui/pull/1223, not **main**

This PR adds `IAsynchronousHandler`, an interface that can be applied to .NET MAUI Controls where we need to asynchronously wait for a `Task` to complete, like `Popup.CloseAsync()`