### PR TITLE
[MAPS] Fix location coordinates and Pin/InfoWindow click

### DIFF
--- a/src/CommunityToolkit.Maui.Maps/Handler/Map/MapHandler.Windows.cs
+++ b/src/CommunityToolkit.Maui.Maps/Handler/Map/MapHandler.Windows.cs
@@ -337,18 +337,15 @@ public partial class MapHandlerWindows : MapHandler
 
 	void WebViewWebMessageReceived(WebView2 sender, Microsoft.Web.WebView2.Core.CoreWebView2WebMessageReceivedEventArgs args)
 	{
-		var clickedPin = JsonSerializer.Deserialize<Pin>(args.WebMessageAsJson, jsonSerializerOptions);
-		if (clickedPin?.Location != null)
+		var clickedPinWebView = JsonSerializer.Deserialize<Pin>(args.WebMessageAsJson, jsonSerializerOptions);
+		var clickedPinWebViewId = clickedPinWebView?.MarkerId?.ToString();
+
+		if (clickedPinWebView?.Location != null && string.IsNullOrEmpty(clickedPinWebViewId))
 		{
-			var clickedPinId = clickedPin.MarkerId?.ToString();
+			var clickedPin = VirtualView.Pins.SingleOrDefault(p => (p as Pin)?.Id.ToString().Equals(clickedPinWebViewId) ?? false);
 
-			if (string.IsNullOrEmpty(clickedPinId))
-			{
-				return;
-			}
-
-			VirtualView.Pins.SingleOrDefault(p => (p as Pin)?.Id.ToString().Equals(clickedPinId) ?? false)?.SendMarkerClick();
-			clickedPin.SendInfoWindowClick();
+			clickedPin?.SendMarkerClick();
+			clickedPin?.SendInfoWindowClick();
 			return;
 		}
 

--- a/src/CommunityToolkit.Maui.Maps/Handler/Map/MapHandler.Windows.cs
+++ b/src/CommunityToolkit.Maui.Maps/Handler/Map/MapHandler.Windows.cs
@@ -388,9 +388,9 @@ public partial class MapHandlerWindows : MapHandler
 		}
 
 		var mapRect = JsonSerializer.Deserialize<Bounds>(args.WebMessageAsJson, jsonSerializerOptions);
-		if (mapRect?.Center != null)
+		if (mapRect?.Center is not null)
 		{
-			VirtualView.VisibleRegion = new MapSpan(new Location(mapRect.Center?.Latitude ?? 0, mapRect.Center?.Longitude ?? 0),
+			VirtualView.VisibleRegion = new MapSpan(new Location(mapRect.Center.Latitude, mapRect.Center.Longitude),
 				mapRect.Height, mapRect.Width);
 		}
 	}

--- a/src/CommunityToolkit.Maui.Maps/Handler/Map/MapHandler.Windows.cs
+++ b/src/CommunityToolkit.Maui.Maps/Handler/Map/MapHandler.Windows.cs
@@ -340,7 +340,7 @@ public partial class MapHandlerWindows : MapHandler
 		var clickedPinWebView = JsonSerializer.Deserialize<Pin>(args.WebMessageAsJson, jsonSerializerOptions);
 		var clickedPinWebViewId = clickedPinWebView?.MarkerId?.ToString();
 
-		if (clickedPinWebView?.Location != null && string.IsNullOrEmpty(clickedPinWebViewId))
+		if (!string.IsNullOrEmpty(clickedPinWebViewId))
 		{
 			var clickedPin = VirtualView.Pins.SingleOrDefault(p => (p as Pin)?.Id.ToString().Equals(clickedPinWebViewId) ?? false);
 


### PR DESCRIPTION
Because the coordinates were provided without quotes, comma characters would end up in the coordinates and mess up the JavaScript syntax causing weird locations to be used.

In addition, the clicking of a Pin would not work. Also added  the InfoWindow and the click of said window.

With this PR, all of these are fixed.

Fixes #1255 