### PR TITLE
Call InvalidateMeasure on DockLayout when properties change affecting layout

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Essentials/SpeechToText/SpeechToTextImplementation.windows.cs
+++ b/src/CommunityToolkit.Maui.Core/Essentials/SpeechToText/SpeechToTextImplementation.windows.cs
@@ -30,7 +30,7 @@ public sealed partial class SpeechToTextImplementation
 		speechRecognitionEngine = null;
 		speechRecognizer = null;
 	}
-	
+
 	async Task<string> InternalListenAsync(CultureInfo culture,
 		IProgress<string>? recognitionResult,
 		CancellationToken cancellationToken)

--- a/src/CommunityToolkit.Maui.Core/Essentials/SpeechToText/SpeechToTextImplementation.windows.cs
+++ b/src/CommunityToolkit.Maui.Core/Essentials/SpeechToText/SpeechToTextImplementation.windows.cs
@@ -30,7 +30,7 @@ public sealed partial class SpeechToTextImplementation
 		speechRecognitionEngine = null;
 		speechRecognizer = null;
 	}
-
+	
 	async Task<string> InternalListenAsync(CultureInfo culture,
 		IProgress<string>? recognitionResult,
 		CancellationToken cancellationToken)

--- a/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
@@ -62,9 +62,11 @@ public class MauiPopup : UIViewController
 	/// <inheritdoc/>
 	public override void ViewWillTransitionToSize(CGSize toSize, IUIViewControllerTransitionCoordinator coordinator)
 	{
-		coordinator.AnimateAlongsideTransition((IUIViewControllerTransitionCoordinatorContext obj) => {
+		coordinator.AnimateAlongsideTransition((IUIViewControllerTransitionCoordinatorContext obj) =>
+		{
 			// Before screen rotate
-		}, (IUIViewControllerTransitionCoordinatorContext obj) => {
+		}, (IUIViewControllerTransitionCoordinatorContext obj) =>
+		{
 			// After screen rotate
 			if (VirtualView is not null)
 			{

--- a/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
@@ -62,11 +62,9 @@ public class MauiPopup : UIViewController
 	/// <inheritdoc/>
 	public override void ViewWillTransitionToSize(CGSize toSize, IUIViewControllerTransitionCoordinator coordinator)
 	{
-		coordinator.AnimateAlongsideTransition((IUIViewControllerTransitionCoordinatorContext obj) =>
-		{
+		coordinator.AnimateAlongsideTransition((IUIViewControllerTransitionCoordinatorContext obj) => {
 			// Before screen rotate
-		}, (IUIViewControllerTransitionCoordinatorContext obj) =>
-		{
+		}, (IUIViewControllerTransitionCoordinatorContext obj) => {
 			// After screen rotate
 			if (VirtualView is not null)
 			{

--- a/src/CommunityToolkit.Maui.Maps/Handler/Map/MapHandler.Windows.cs
+++ b/src/CommunityToolkit.Maui.Maps/Handler/Map/MapHandler.Windows.cs
@@ -1,12 +1,12 @@
-﻿using Microsoft.Maui.Maps.Handlers;
-using Microsoft.Maui.Maps;
-using Microsoft.Maui.Platform;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml;
-using IMap = Microsoft.Maui.Maps.IMap;
-using Windows.Devices.Geolocation;
-using System.Text.Json;
+﻿using System.Text.Json;
 using Microsoft.Maui.Controls.Maps;
+using Microsoft.Maui.Maps;
+using Microsoft.Maui.Maps.Handlers;
+using Microsoft.Maui.Platform;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Windows.Devices.Geolocation;
+using IMap = Microsoft.Maui.Maps.IMap;
 
 namespace CommunityToolkit.Maui.Maps.Handlers;
 
@@ -144,7 +144,7 @@ public partial class MapHandlerWindows : MapHandler
 		}
 		CallJSMethod(handler.PlatformView, $"setRegion({newRegion.Center.Latitude},{newRegion.Center.Longitude});");
 	}
-	
+
 	static void CallJSMethod(FrameworkElement platformWebView, string script)
 	{
 		if (platformWebView is WebView2 webView2 && webView2.CoreWebView2 != null)
@@ -312,7 +312,7 @@ public partial class MapHandlerWindows : MapHandler
 	{
 		// Update initial properties when our page is loaded
 		Mapper.UpdateProperties(this, VirtualView);
-		
+
 		if (regionToGo != null)
 		{
 			MapMoveToRegion(this, VirtualView, regionToGo);

--- a/src/CommunityToolkit.Maui.Maps/Handler/Map/MapHandler.Windows.cs
+++ b/src/CommunityToolkit.Maui.Maps/Handler/Map/MapHandler.Windows.cs
@@ -1,12 +1,12 @@
-﻿using System.Text.Json;
-using Microsoft.Maui.Controls.Maps;
+﻿using Microsoft.Maui.Maps.Handlers;
 using Microsoft.Maui.Maps;
-using Microsoft.Maui.Maps.Handlers;
 using Microsoft.Maui.Platform;
-using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Windows.Devices.Geolocation;
+using Microsoft.UI.Xaml;
 using IMap = Microsoft.Maui.Maps.IMap;
+using Windows.Devices.Geolocation;
+using System.Text.Json;
+using Microsoft.Maui.Controls.Maps;
 
 namespace CommunityToolkit.Maui.Maps.Handlers;
 
@@ -144,7 +144,7 @@ public partial class MapHandlerWindows : MapHandler
 		}
 		CallJSMethod(handler.PlatformView, $"setRegion({newRegion.Center.Latitude},{newRegion.Center.Longitude});");
 	}
-
+	
 	static void CallJSMethod(FrameworkElement platformWebView, string script)
 	{
 		if (platformWebView is WebView2 webView2 && webView2.CoreWebView2 != null)
@@ -312,7 +312,7 @@ public partial class MapHandlerWindows : MapHandler
 	{
 		// Update initial properties when our page is loaded
 		Mapper.UpdateProperties(this, VirtualView);
-
+		
 		if (regionToGo != null)
 		{
 			MapMoveToRegion(this, VirtualView, regionToGo);

--- a/src/CommunityToolkit.Maui.Maps/Handler/Map/MapHandler.Windows.cs
+++ b/src/CommunityToolkit.Maui.Maps/Handler/Map/MapHandler.Windows.cs
@@ -1,14 +1,14 @@
-﻿using Microsoft.Maui.Maps.Handlers;
-using Microsoft.Maui.Maps;
-using Microsoft.Maui.Platform;
-using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml;
-using IMap = Microsoft.Maui.Maps.IMap;
-using Windows.Devices.Geolocation;
+﻿using System.Globalization;
 using System.Text.Json;
 using Microsoft.Maui.Controls.Maps;
-using System.Globalization;
+using Microsoft.Maui.Maps;
+using Microsoft.Maui.Maps.Handlers;
+using Microsoft.Maui.Platform;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using Microsoft.Web.WebView2.Core;
+using Windows.Devices.Geolocation;
+using IMap = Microsoft.Maui.Maps.IMap;
 
 namespace CommunityToolkit.Maui.Maps.Handlers;
 
@@ -124,7 +124,7 @@ public partial class MapHandlerWindows : MapHandler
 	public static new void MapPins(IMapHandler handler, IMap map)
 	{
 		CallJSMethod(handler.PlatformView, "removeAllPins();");
-		
+
 		foreach (var pin in map.Pins)
 		{
 			CallJSMethod(handler.PlatformView, $"addPin({pin.Location.Latitude.ToString(CultureInfo.InvariantCulture)}," +
@@ -155,7 +155,7 @@ public partial class MapHandlerWindows : MapHandler
 
 		CallJSMethod(handler.PlatformView, $"setRegion({newRegion.Center.Latitude.ToString(CultureInfo.InvariantCulture)},{newRegion.Center.Longitude.ToString(CultureInfo.InvariantCulture)});");
 	}
-	
+
 	static void CallJSMethod(FrameworkElement platformWebView, string script)
 	{
 		if (platformWebView is WebView2 webView2 && webView2.CoreWebView2 != null)
@@ -357,7 +357,7 @@ public partial class MapHandlerWindows : MapHandler
 	{
 		// Update initial properties when our page is loaded
 		Mapper.UpdateProperties(this, VirtualView);
-		
+
 		if (regionToGo != null)
 		{
 			MapMoveToRegion(this, VirtualView, regionToGo);
@@ -380,7 +380,7 @@ public partial class MapHandlerWindows : MapHandler
 
 		var clickedInfoWindowWebView = JsonSerializer.Deserialize<InfoWindow>(args.WebMessageAsJson, jsonSerializerOptions);
 		var clickedInfoWindowWebViewId = clickedInfoWindowWebView?.InfoWindowMarkerId;
-		
+
 		if (!string.IsNullOrEmpty(clickedInfoWindowWebViewId))
 		{
 			var clickedPin = VirtualView.Pins.SingleOrDefault(p => (p as Pin)?.Id.ToString().Equals(clickedInfoWindowWebViewId) ?? false);

--- a/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.windows.cs
@@ -20,7 +20,7 @@ public partial class MediaElementHandler : ViewHandler<MediaElement, MauiMediaEl
 	/// <inheritdoc/>
 	protected override MauiMediaElement CreatePlatformView()
 	{
-		mediaManager ??= new(MauiContext ?? throw new NullReferenceException(), 
+		mediaManager ??= new(MauiContext ?? throw new NullReferenceException(),
 								VirtualView,
 								Dispatcher.GetForCurrentThread() ?? throw new InvalidOperationException($"{nameof(IDispatcher)} cannot be null"));
 

--- a/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.windows.cs
@@ -20,7 +20,7 @@ public partial class MediaElementHandler : ViewHandler<MediaElement, MauiMediaEl
 	/// <inheritdoc/>
 	protected override MauiMediaElement CreatePlatformView()
 	{
-		mediaManager ??= new(MauiContext ?? throw new NullReferenceException(),
+		mediaManager ??= new(MauiContext ?? throw new NullReferenceException(), 
 								VirtualView,
 								Dispatcher.GetForCurrentThread() ?? throw new InvalidOperationException($"{nameof(IDispatcher)} cannot be null"));
 

--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.windows.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.windows.cs
@@ -31,7 +31,7 @@ public partial class IconTintColorBehavior
 				if (currentColorBrush is not null && TintColor is not null)
 				{
 					currentColorBrush.Color = TintColor.ToWindowsColor();
-				} 
+				}
 				else
 				{
 					ApplyTintColor(platformView, bindable, TintColor);
@@ -95,7 +95,7 @@ public partial class IconTintColorBehavior
 		{
 			return;
 		}
-		
+
 		switch (platformView)
 		{
 			case WImage wImage:
@@ -113,7 +113,7 @@ public partial class IconTintColorBehavior
 
 			default:
 				throw new NotSupportedException($"{nameof(IconTintColorBehavior)} only currently supports {typeof(WImage)} and {typeof(WButton)}.");
-		}		
+		}
 	}
 
 	void LoadAndApplyImageTintColor(View element, WImage image, Color color)
@@ -141,7 +141,7 @@ public partial class IconTintColorBehavior
 			}
 		}
 	}
-	
+
 	void ApplyImageTintColor(View element, WImage image, Color color)
 	{
 		if (!TryGetSourceImageUri(image, (IImageElement)element, out var uri))

--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.windows.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.windows.cs
@@ -31,7 +31,7 @@ public partial class IconTintColorBehavior
 				if (currentColorBrush is not null && TintColor is not null)
 				{
 					currentColorBrush.Color = TintColor.ToWindowsColor();
-				}
+				} 
 				else
 				{
 					ApplyTintColor(platformView, bindable, TintColor);
@@ -95,7 +95,7 @@ public partial class IconTintColorBehavior
 		{
 			return;
 		}
-
+		
 		switch (platformView)
 		{
 			case WImage wImage:
@@ -113,7 +113,7 @@ public partial class IconTintColorBehavior
 
 			default:
 				throw new NotSupportedException($"{nameof(IconTintColorBehavior)} only currently supports {typeof(WImage)} and {typeof(WButton)}.");
-		}
+		}		
 	}
 
 	void LoadAndApplyImageTintColor(View element, WImage image, Color color)
@@ -141,7 +141,7 @@ public partial class IconTintColorBehavior
 			}
 		}
 	}
-
+	
 	void ApplyImageTintColor(View element, WImage image, Color color)
 	{
 		if (!TryGetSourceImageUri(image, (IImageElement)element, out var uri))

--- a/src/CommunityToolkit.Maui/Layouts/DockLayout.shared.cs
+++ b/src/CommunityToolkit.Maui/Layouts/DockLayout.shared.cs
@@ -12,26 +12,38 @@ public class DockLayout : Layout, IDockLayout
 	/// <summary>
 	/// Docking position for a view.
 	/// </summary>
-	public static readonly BindableProperty DockPositionProperty = BindableProperty.CreateAttached(nameof(DockPosition), typeof(DockPosition), typeof(DockLayout), DockPosition.None,
-		propertyChanged: OnDockPositionPropertyChanged);
+	public static readonly BindableProperty DockPositionProperty = BindableProperty.CreateAttached(nameof(DockPosition), 
+																									typeof(DockPosition), 
+																									typeof(DockLayout), 
+																									DockPosition.None,
+																									propertyChanged: OnDockPositionPropertyChanged);
 
 	/// <summary>
 	/// If true, the last child is expanded to fill the remaining space (default: true).
 	/// </summary>
-	public static readonly BindableProperty ShouldExpandLastChildProperty = BindableProperty.Create(nameof(ShouldExpandLastChild), typeof(bool), typeof(DockLayout), true,
-		propertyChanged: OnShouldExpandLastChildPropertyChanged);
+	public static readonly BindableProperty ShouldExpandLastChildProperty = BindableProperty.Create(nameof(ShouldExpandLastChild), 
+																										typeof(bool), 
+																										typeof(DockLayout), 
+																										true,
+																										propertyChanged: OnShouldExpandLastChildPropertyChanged);
 
 	/// <summary>
 	/// Horizontal spacing between docked views.
 	/// </summary>
-	public static readonly BindableProperty HorizontalSpacingProperty = BindableProperty.Create(nameof(HorizontalSpacing), typeof(double), typeof(DockLayout), 0.0d,
-		propertyChanged: OnHorizontalSpacingPropertyChanged);
+	public static readonly BindableProperty HorizontalSpacingProperty = BindableProperty.Create(nameof(HorizontalSpacing), 
+																									typeof(double), 
+																									typeof(DockLayout), 
+																									0.0d,
+																									propertyChanged: OnHorizontalSpacingPropertyChanged);
 
 	/// <summary>
 	/// Vertical spacing between docked views.
 	/// </summary>
-	public static readonly BindableProperty VerticalSpacingProperty = BindableProperty.Create(nameof(VerticalSpacing), typeof(double), typeof(DockLayout), 0.0d,
-		propertyChanged: OnVerticalSpacingPropertyChanged);
+	public static readonly BindableProperty VerticalSpacingProperty = BindableProperty.Create(nameof(VerticalSpacing), 
+																								typeof(double), 
+																								typeof(DockLayout), 
+																								0.0d,
+																								propertyChanged: OnVerticalSpacingPropertyChanged);
 
 	/// <inheritdoc/>
 	public bool ShouldExpandLastChild

--- a/src/CommunityToolkit.Maui/Layouts/DockLayout.shared.cs
+++ b/src/CommunityToolkit.Maui/Layouts/DockLayout.shared.cs
@@ -12,22 +12,38 @@ public class DockLayout : Layout, IDockLayout
 	/// <summary>
 	/// Docking position for a view.
 	/// </summary>
-	public static readonly BindableProperty DockPositionProperty = BindableProperty.Create(nameof(DockPosition), typeof(DockPosition), typeof(DockLayout), DockPosition.None);
+	public static readonly BindableProperty DockPositionProperty = BindableProperty.CreateAttached(nameof(DockPosition), typeof(DockPosition), typeof(DockLayout), DockPosition.None,
+		propertyChanged: InvalidateMeasure);
 
 	/// <summary>
 	/// If true, the last child is expanded to fill the remaining space (default: true).
 	/// </summary>
-	public static readonly BindableProperty ShouldExpandLastChildProperty = BindableProperty.Create(nameof(ShouldExpandLastChild), typeof(bool), typeof(DockLayout), true);
+	public static readonly BindableProperty ShouldExpandLastChildProperty = BindableProperty.Create(nameof(ShouldExpandLastChild), typeof(bool), typeof(DockLayout), true,
+		propertyChanged: InvalidateMeasure);
 
 	/// <summary>
 	/// Horizontal spacing between docked views.
 	/// </summary>
-	public static readonly BindableProperty HorizontalSpacingProperty = BindableProperty.Create(nameof(HorizontalSpacing), typeof(double), typeof(DockLayout), 0.0d);
+	public static readonly BindableProperty HorizontalSpacingProperty = BindableProperty.Create(nameof(HorizontalSpacing), typeof(double), typeof(DockLayout), 0.0d,
+		propertyChanged: InvalidateMeasure);
 
 	/// <summary>
 	/// Vertical spacing between docked views.
 	/// </summary>
-	public static readonly BindableProperty VerticalSpacingProperty = BindableProperty.Create(nameof(VerticalSpacing), typeof(double), typeof(DockLayout), 0.0d);
+	public static readonly BindableProperty VerticalSpacingProperty = BindableProperty.Create(nameof(VerticalSpacing), typeof(double), typeof(DockLayout), 0.0d,
+		propertyChanged: InvalidateMeasure);
+
+	static void InvalidateMeasure(BindableObject bindable, object oldValue, object newValue)
+	{
+		if (bindable is DockLayout dockLayout)
+		{
+			dockLayout.InvalidateMeasure();
+		}
+		else if (bindable is Element element && element.Parent is DockLayout parentDockLayout)
+		{
+			parentDockLayout.InvalidateMeasure();
+		}
+	}
 
 	/// <inheritdoc/>
 	public bool ShouldExpandLastChild

--- a/src/CommunityToolkit.Maui/Layouts/DockLayout.shared.cs
+++ b/src/CommunityToolkit.Maui/Layouts/DockLayout.shared.cs
@@ -13,37 +13,25 @@ public class DockLayout : Layout, IDockLayout
 	/// Docking position for a view.
 	/// </summary>
 	public static readonly BindableProperty DockPositionProperty = BindableProperty.CreateAttached(nameof(DockPosition), typeof(DockPosition), typeof(DockLayout), DockPosition.None,
-		propertyChanged: InvalidateMeasure);
+		propertyChanged: OnDockPositionPropertyChanged);
 
 	/// <summary>
 	/// If true, the last child is expanded to fill the remaining space (default: true).
 	/// </summary>
 	public static readonly BindableProperty ShouldExpandLastChildProperty = BindableProperty.Create(nameof(ShouldExpandLastChild), typeof(bool), typeof(DockLayout), true,
-		propertyChanged: InvalidateMeasure);
+		propertyChanged: OnShouldExpandLastChildPropertyChanged);
 
 	/// <summary>
 	/// Horizontal spacing between docked views.
 	/// </summary>
 	public static readonly BindableProperty HorizontalSpacingProperty = BindableProperty.Create(nameof(HorizontalSpacing), typeof(double), typeof(DockLayout), 0.0d,
-		propertyChanged: InvalidateMeasure);
+		propertyChanged: OnHorizontalSpacingPropertyChanged);
 
 	/// <summary>
 	/// Vertical spacing between docked views.
 	/// </summary>
 	public static readonly BindableProperty VerticalSpacingProperty = BindableProperty.Create(nameof(VerticalSpacing), typeof(double), typeof(DockLayout), 0.0d,
-		propertyChanged: InvalidateMeasure);
-
-	static void InvalidateMeasure(BindableObject bindable, object oldValue, object newValue)
-	{
-		if (bindable is DockLayout dockLayout)
-		{
-			dockLayout.InvalidateMeasure();
-		}
-		else if (bindable is Element element && element.Parent is DockLayout parentDockLayout)
-		{
-			parentDockLayout.InvalidateMeasure();
-		}
-	}
+		propertyChanged: OnVerticalSpacingPropertyChanged);
 
 	/// <inheritdoc/>
 	public bool ShouldExpandLastChild
@@ -98,4 +86,54 @@ public class DockLayout : Layout, IDockLayout
 
 	/// <inheritdoc/>
 	protected override ILayoutManager CreateLayoutManager() => new DockLayoutManager(this);
+
+	static void OnDockPositionPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+	{
+		if (bindable is Element element)
+		{
+			InvalidateDockLayoutMeasure(element);
+		}
+	}
+
+	static void OnShouldExpandLastChildPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+	{
+		if (bindable is Element element)
+		{
+			InvalidateDockLayoutMeasure(element);
+		}
+	}
+
+	static void OnHorizontalSpacingPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+	{
+		if (bindable is Element element)
+		{
+			InvalidateDockLayoutMeasure(element);
+		}
+	}
+
+	static void OnVerticalSpacingPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+	{
+		if (bindable is Element element)
+		{
+			InvalidateDockLayoutMeasure(element);
+		}
+	}
+
+	static void InvalidateDockLayoutMeasure(Element element)
+	{
+		if (element is DockLayout dockLayout)
+		{
+			dockLayout.InvalidateMeasure();
+		}
+
+		while (element.Parent is not null)
+		{
+			if (element.Parent is DockLayout dockLayoutParent)
+			{
+				dockLayoutParent.InvalidateMeasure();
+			}
+
+			element = element.Parent;
+		}
+	}
 }


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

When properties are updated affecting layout, `InvalidateMeasure` should be called to trigger the layout to happen, normally called via a propertyChanged notification. This PR adds that for `DockLayout`. The `InvalidateMeasure` method added here is similar to what's called for Grid properties in the MAUI repo.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #1250

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [ ] Rebased on top of `main` at time of PR
 - [ ] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->

 ### Additional information ###
 
Note that I attempted adding unit tests, but none of my attempts were able to catch the behavior difference when `InvalidateMeasure` is called. This may be something normally done by "device tests" in the MAUI repo. So I ended up just testing manually against my test repo, which all looked good.

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
