### PR TITLE
Remove `VerticalStackLayout` from `StateContainerController`

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Layouts/StateContainerViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Layouts/StateContainerViewModel.cs
@@ -8,8 +8,17 @@ public partial class StateContainerViewModel : BaseViewModel
 	[ObservableProperty]
 	string? currentState, gridState, noAnimateState, notFoundState, fullPageState;
 
+	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ToggleGridStateCommand))]
+	bool canGridStateChange = true;
+
+	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(CycleStatesCommand))]
+	bool canCycleStateChange = true;
+
+	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ToggleFullPageStateCommand))]
+	bool canFullPageStateChange = true;
+
 	[ObservableProperty]
-	bool canGridStateChange = true, canCycleStateChange = true, canAnimationStateChange = true, canFullPageStateChange = true;
+	bool canAnimationStateChange = true;
 
 	[RelayCommand(CanExecute = nameof(CanCycleStateChange))]
 	async Task CycleStates()
@@ -48,19 +57,20 @@ public partial class StateContainerViewModel : BaseViewModel
 		_ => StateKey.Loading
 	};
 
-	partial void OnCanGridStateChangeChanged(bool value)
-	{
-		ToggleGridStateCommand.NotifyCanExecuteChanged();
-	}
+	[ObservableProperty]
+	private string? state;
 
-	partial void OnCanCycleStateChangeChanged(bool value)
+	[RelayCommand]
+	private void ToggleState()
 	{
-		CycleStatesCommand.NotifyCanExecuteChanged();
-	}
-
-	partial void OnCanFullPageStateChangeChanged(bool value)
-	{
-		ToggleFullPageStateCommand.NotifyCanExecuteChanged();
+		State = State switch
+		{
+			"1" => "2",
+			"2" => "3",
+			"3" => "4",
+			"4" => "5",
+			_ => "1"
+		};
 	}
 
 	static class StateKey

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Layouts/StateContainerViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Layouts/StateContainerViewModel.cs
@@ -57,22 +57,6 @@ public partial class StateContainerViewModel : BaseViewModel
 		_ => StateKey.Loading
 	};
 
-	[ObservableProperty]
-	private string? state;
-
-	[RelayCommand]
-	private void ToggleState()
-	{
-		State = State switch
-		{
-			"1" => "2",
-			"2" => "3",
-			"3" => "4",
-			"4" => "5",
-			_ => "1"
-		};
-	}
-
 	static class StateKey
 	{
 		public const string Loading = nameof(Loading);

--- a/src/CommunityToolkit.Maui.UnitTests/Layouts/StateContainerTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Layouts/StateContainerTests.cs
@@ -539,29 +539,13 @@ public class StateContainerTests : BaseTest
 	}
 
 	[Fact]
-	public void Controller_GridStateInnerLayoutSpansParent()
+	public void Controller_GridStateViewSpansParent()
 	{
 		gridController.SwitchToState(StateKey.Loading);
-		var innerLayout = gridController.GetLayout().Children.First();
+		var view = (View)gridController.GetLayout().Children.First();
 
-		Assert.IsType<VerticalStackLayout>(innerLayout);
-		Assert.Equal(Grid.GetColumnSpan((VerticalStackLayout)innerLayout), grid.ColumnDefinitions.Count);
-		Assert.Equal(Grid.GetRowSpan((VerticalStackLayout)innerLayout), grid.RowDefinitions.Count);
-	}
-
-	[Fact]
-	public void Controller_GridStateInnerLayoutRespectsViewOptions()
-	{
-		gridController.SwitchToState(StateKey.Anything);
-		var innerLayout = gridController.GetLayout().Children.First();
-
-		Assert.IsType<VerticalStackLayout>(innerLayout);
-
-		var label = ((VerticalStackLayout)innerLayout).Children.First();
-
-		Assert.IsType<Label>(label);
-		Assert.Equal(((VerticalStackLayout)innerLayout).VerticalOptions, ((Label)label).VerticalOptions);
-		Assert.Equal(((VerticalStackLayout)innerLayout).HorizontalOptions, ((Label)label).HorizontalOptions);
+		Assert.Equal(Grid.GetColumnSpan(view), grid.ColumnDefinitions.Count);
+		Assert.Equal(Grid.GetRowSpan(view), grid.RowDefinitions.Count);
 	}
 
 	class ViewModel : INotifyPropertyChanged

--- a/src/CommunityToolkit.Maui/Layouts/StateContainer/StateContainerController.shared.cs
+++ b/src/CommunityToolkit.Maui/Layouts/StateContainer/StateContainerController.shared.cs
@@ -8,7 +8,7 @@ sealed class StateContainerController
 	readonly WeakReference<Layout> layoutWeakReference;
 
 	string? previousState;
-	IList<IView> originalContent = Enumerable.Empty<IView>().ToList();
+	List<IView> originalContent = Enumerable.Empty<IView>().ToList();
 
 	/// <summary>
 	/// Initialize <see cref="StateContainerController"/> with a <see cref="Layout"/>

--- a/src/CommunityToolkit.Maui/Layouts/StateContainer/StateContainerController.shared.cs
+++ b/src/CommunityToolkit.Maui/Layouts/StateContainer/StateContainerController.shared.cs
@@ -71,6 +71,7 @@ sealed class StateContainerController
 			{
 				VerticalOptions = view.VerticalOptions,
 				HorizontalOptions = view.HorizontalOptions,
+				InputTransparent = true
 			};
 
 			if (grid.RowDefinitions.Count > 0)

--- a/src/CommunityToolkit.Maui/Layouts/StateContainer/StateContainerController.shared.cs
+++ b/src/CommunityToolkit.Maui/Layouts/StateContainer/StateContainerController.shared.cs
@@ -64,36 +64,21 @@ sealed class StateContainerController
 		// Otherwise it would just end up in row 0 : column 0.
 		if (layout is IGridLayout grid)
 		{
-			// We create a VerticalStackLayout spanning the Grid.
-			// It takes VerticalOptions and HorizontalOptions from the
-			// view to allow for more control over how it layouts.
-			var innerLayout = new VerticalStackLayout
-			{
-				VerticalOptions = view.VerticalOptions,
-				HorizontalOptions = view.HorizontalOptions,
-				InputTransparent = true
-			};
-
 			if (grid.RowDefinitions.Count > 0)
 			{
-				Grid.SetRowSpan(innerLayout, grid.RowDefinitions.Count);
+				Grid.SetRowSpan(view, grid.RowDefinitions.Count);
 			}
 
 			if (grid.ColumnDefinitions.Count > 0)
 			{
-				Grid.SetColumnSpan(innerLayout, grid.ColumnDefinitions.Count);
+				Grid.SetColumnSpan(view, grid.ColumnDefinitions.Count);
 			}
 
 			// We need to delete the view reference from its parent if it was previously added.
 			((Layout?)view.Parent)?.Remove(view);
+		}
 
-			innerLayout.Children.Add(view);
-			layout.Children.Add(innerLayout);
-		}
-		else
-		{
-			layout.Children.Add(view);
-		}
+		layout.Children.Add(view);
 	}
 
 	internal Layout GetLayout()

--- a/src/CommunityToolkit.Maui/Layouts/StateContainer/StateContainerController.shared.cs
+++ b/src/CommunityToolkit.Maui/Layouts/StateContainer/StateContainerController.shared.cs
@@ -8,7 +8,7 @@ sealed class StateContainerController
 	readonly WeakReference<Layout> layoutWeakReference;
 
 	string? previousState;
-	List<View> originalContent = Enumerable.Empty<View>().ToList();
+	IList<IView> originalContent = Enumerable.Empty<IView>().ToList();
 
 	/// <summary>
 	/// Initialize <see cref="StateContainerController"/> with a <see cref="Layout"/>
@@ -48,11 +48,11 @@ sealed class StateContainerController
 		// Put the original content somewhere where we can restore it.
 		if (previousState is null)
 		{
-			originalContent = new List<View>();
+			originalContent = new List<IView>();
 
 			foreach (var item in layout.Children)
 			{
-				originalContent.Add((View)item);
+				originalContent.Add(item);
 			}
 		}
 
@@ -70,7 +70,7 @@ sealed class StateContainerController
 			var innerLayout = new VerticalStackLayout
 			{
 				VerticalOptions = view.VerticalOptions,
-				HorizontalOptions = view.HorizontalOptions
+				HorizontalOptions = view.HorizontalOptions,
 			};
 
 			if (grid.RowDefinitions.Count > 0)


### PR DESCRIPTION
 ### Description of Change ###

This PR removes the `VerticalStackLayout` from the `StateContainer`.

.NET MAUI has [different behavior than Xamarin.Forms](https://github.com/dotnet/maui/issues/8888) for `StackLayout`. In .NET MAUI, `VerticalStackLayout` expands to the size of its children. When the children require more space than is available on the screen, `VerticalStackLayout` will continue to "display" the additional `View` below the visible area on the screen.

The example below uses a `ScrollView` inside of `StateContainer`. When `StateContainerController` places the `ScrollView` inside of a `VerticalStackLayout`, it does not scroll because the size of the `VerticalStackLayout` extends past the bottom of the screen. 

| `StateContainer` with `VerticalStackLayout` | `StateContainer` without `VerticalStackLayout` (Fixed)| 
| -- | -- |
| Cannot scroll the `ScrollView` because `VerticalStackLayout` has laid out its children past the bottom of the screen  (notice how the Yellow color extends past the `Button` with a `BackgroundColor = Colors.Pink`)| Can scroll because the `ScrollView` is properly sized |
| ![Simulator Screen Recording - iPhone 14 Pro - 2023-06-21 at 18 32 41](https://github.com/CommunityToolkit/Maui/assets/13558917/892da004-0426-40ed-8043-52184dd2743a) | ![Simulator Screen Recording - iPhone 14 Pro - 2023-06-21 at 18 31 28](https://github.com/CommunityToolkit/Maui/assets/13558917/ef7062d6-dcaa-490c-99b1-1ff569e511e0) |



 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Partially Fixes #1118

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)


 ### Additional information ###

I've also updated `StateContainerController` to use `IList<IView> originalContent` instead of `List<View> originalContent` to avoid the need to cast `item` when adding it to the list.
 
