### PR TITLE
Fix dispose on MediaElement on Windows

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.windows.cs
@@ -32,7 +32,27 @@ public partial class MediaElementHandler : ViewHandler<MediaElement, MauiMediaEl
 	protected override void DisconnectHandler(MauiMediaElement platformView)
 	{
 		Dispose();
-		platformView.Dispose();
+		UnloadPlatformView(platformView);
 		base.DisconnectHandler(platformView);
+	}
+
+	static void UnloadPlatformView(MauiMediaElement platformView)
+	{
+		if (platformView.IsLoaded)
+		{
+			platformView.Unloaded += OnPlatformViewUnloaded;
+		}
+		else
+		{
+			platformView.Dispose();
+		}
+
+		static void OnPlatformViewUnloaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+		{
+			var mediaElement = (MauiMediaElement)sender;
+
+			mediaElement.Unloaded -= OnPlatformViewUnloaded;
+			mediaElement.Dispose();
+		}
 	}
 }


### PR DESCRIPTION

 ### Description of Change ###

Added a handler to dispose of the `PlatformView` at the right moment.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #1245 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [x] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
