### PR TITLE
Use fully qualified namespace for Color reference in TextToColorGenerator

### DIFF
--- a/src/CommunityToolkit.Maui.SourceGenerators/Generators/TextColorToGenerator.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Generators/TextColorToGenerator.cs
@@ -24,6 +24,7 @@ class TextColorToGenerator : IIncrementalGenerator
 	const string iTextStyleInterface = "Microsoft.Maui.ITextStyle";
 	const string iAnimatableInterface = "Microsoft.Maui.Controls.IAnimatable";
 	const string mauiControlsAssembly = "Microsoft.Maui.Controls";
+	const string mauiColorFullName = "global::Microsoft.Maui.Graphics.Color";
 
 	public void Initialize(IncrementalGeneratorInitializationContext context)
 	{
@@ -115,7 +116,7 @@ namespace {{textStyleClassMetadata.Namespace}};
 	/// <param name="length">The duration, in milliseconds, of the animation</param>
 	/// <param name="easing">The easing function to be used in the animation</param>
 	/// <returns>Value indicating if the animation completed successfully or not</returns>
-	public static Task<bool> TextColorTo{{textStyleClassMetadata.GenericArguments}}(this {{textStyleClassMetadata.Namespace}}.{{textStyleClassMetadata.ClassName}}{{textStyleClassMetadata.GenericArguments}} element, Microsoft.Maui.Graphics.Color color, uint rate = 16u, uint length = 250u, Easing? easing = null)
+	public static Task<bool> TextColorTo{{textStyleClassMetadata.GenericArguments}}(this global::{{textStyleClassMetadata.Namespace}}.{{textStyleClassMetadata.ClassName}}{{textStyleClassMetadata.GenericArguments}} element, {{mauiColorFullName}} color, uint rate = 16u, uint length = 250u, Easing? easing = null)
 {{textStyleClassMetadata.GenericConstraints}}
 	{
 		ArgumentNullException.ThrowIfNull(element);

--- a/src/CommunityToolkit.Maui.SourceGenerators/Generators/TextColorToGenerator.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Generators/TextColorToGenerator.cs
@@ -115,7 +115,7 @@ namespace {{textStyleClassMetadata.Namespace}};
 	/// <param name="length">The duration, in milliseconds, of the animation</param>
 	/// <param name="easing">The easing function to be used in the animation</param>
 	/// <returns>Value indicating if the animation completed successfully or not</returns>
-	public static Task<bool> TextColorTo{{textStyleClassMetadata.GenericArguments}}(this {{textStyleClassMetadata.Namespace}}.{{textStyleClassMetadata.ClassName}}{{textStyleClassMetadata.GenericArguments}} element, Color color, uint rate = 16u, uint length = 250u, Easing? easing = null)
+	public static Task<bool> TextColorTo{{textStyleClassMetadata.GenericArguments}}(this {{textStyleClassMetadata.Namespace}}.{{textStyleClassMetadata.ClassName}}{{textStyleClassMetadata.GenericArguments}} element, Microsoft.Maui.Graphics.Color color, uint rate = 16u, uint length = 250u, Easing? easing = null)
 {{textStyleClassMetadata.GenericConstraints}}
 	{
 		ArgumentNullException.ThrowIfNull(element);


### PR DESCRIPTION
This change should prevent "ambiguous reference" error to occur when other packages are included in a MAUI project that provide their own Color objects.

Examples of such libraries are SixLabors.ImageSharp.

<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->

In the source code generator use a fully qualified namespace to the Color object, so `Color` is changed into `Microsoft.Maui.Graphics.Color`.

No tests added, as I don't think we can test for such a change. No documentation change required either. No samples for the fix here (not sure how to test).

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #1331

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [x] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
