### PR TITLE
♻️ [Housekeeping] Fixed  GravatarImageSourceTests.TestDefaultStream

### DIFF
--- a/src/CommunityToolkit.Maui.UnitTests/ImageSources/GravatarImageSource/GravatarImageSourceTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/ImageSources/GravatarImageSource/GravatarImageSourceTests.cs
@@ -348,7 +348,7 @@ public class GravatarImageSourceTests : BaseHandlerTest
 		CancellationTokenSource cts = new();
 		var gravatarImageSource = new GravatarImageSource();
 		Stream? stream = await gravatarImageSource.Stream(cts.Token);
-		stream.Should().BeNull();
+		stream.Should().NotBeNull();
 	}
 
 	[Fact]


### PR DESCRIPTION
By default, we call the `https://www.gravatar.com/avatar/` and now they return a `Stream` instead of null, so I changed the test to match this new behavior.