### PR TITLE
Allow AVPlayer to play even when user has device in silent mode

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Interfaces/IMediaElement.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Interfaces/IMediaElement.cs
@@ -64,6 +64,11 @@ public interface IMediaElement : IView
 	bool ShouldMute { get; set; }
 
 	/// <summary>
+	/// Gets or sets if the audio should bypass silent mode if a user has it enabled.
+	/// </summary>
+	bool ShouldBypassSilentMode { get; set; }
+
+	/// <summary>
 	/// Gets or sets whether the player should show the platform playback controls.
 	/// </summary>
 	bool ShouldShowPlaybackControls { get; set; }

--- a/src/CommunityToolkit.Maui.MediaElement/MediaElement.shared.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/MediaElement.shared.cs
@@ -58,6 +58,12 @@ public class MediaElement : View, IMediaElement
 		  BindableProperty.Create(nameof(ShouldMute), typeof(bool), typeof(MediaElement), false);
 
 	/// <summary>
+	/// Backing store for the <see cref="ShouldBypassSilentMode"/> property.
+	/// </summary>
+	public static readonly BindableProperty ShouldBypassSilentModeProperty =
+		  BindableProperty.Create(nameof(ShouldBypassSilentMode), typeof(bool), typeof(MediaElement), false);
+
+	/// <summary>
 	/// Backing store for the <see cref="Position"/> property.
 	/// </summary>
 	public static readonly BindableProperty PositionProperty =
@@ -235,6 +241,18 @@ public class MediaElement : View, IMediaElement
 	{
 		get => (bool)GetValue(ShouldMuteProperty);
 		set => SetValue(ShouldMuteProperty, value);
+	}
+
+	/// <summary>
+	/// Gets or sets if the audio should bypass silent mode if a user has it enabled.
+	/// </summary>
+	/// <remarks>
+	/// This only affects iOS, other devices will automatically bypass silent mode.
+	/// </remarks>
+	public bool ShouldBypassSilentMode
+	{
+		get => (bool)GetValue(ShouldBypassSilentModeProperty);
+		set => SetValue(ShouldBypassSilentModeProperty, value);
 	}
 
 	/// <summary>

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
@@ -97,9 +97,12 @@ public partial class MediaManager : IDisposable
 		AddPlayedToEndObserver();
 		AddErrorObservers();
 
-		//Set a SharedInstance to active, and set the category to 'Playback' so we can play on devices that have silent mode turned on.
-		AVAudioSession.SharedInstance().SetActive(true);
-		AVAudioSession.SharedInstance().SetCategory(AVAudioSessionCategory.Playback);
+		if (MediaElement.ShouldBypassSilentMode)
+		{
+			// Set a SharedInstance to active, and set the category to 'Playback' so we can play on devices that have silent mode turned on.
+			AVAudioSession.SharedInstance().SetActive(true);
+			AVAudioSession.SharedInstance().SetCategory(AVAudioSessionCategory.Playback);
+		}
 
 		return (Player, PlayerViewController);
 	}

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
@@ -97,6 +97,10 @@ public partial class MediaManager : IDisposable
 		AddPlayedToEndObserver();
 		AddErrorObservers();
 
+		//Set a SharedInstance to active, and set the category to 'Playback' so we can play on devices that have silent mode turned on.
+		AVAudioSession.SharedInstance().SetActive(true);
+		AVAudioSession.SharedInstance().SetCategory(AVAudioSessionCategory.Playback);
+
 		return (Player, PlayerViewController);
 	}
 
@@ -375,6 +379,8 @@ public partial class MediaManager : IDisposable
 				Player.Pause();
 				DestroyErrorObservers();
 				DestroyPlayedToEndObserver();
+
+				AVAudioSession.SharedInstance().SetActive(false);
 
 				RateObserver?.Dispose();
 				CurrentItemErrorObserver?.Dispose();


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

Modifies MediaElement's MediaManager on iOS to allow iOS devices to play audio in 'Silent Mode'.

 ### Linked Issues ###

 - Fixes #1358

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [x] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###

This implementation was tested on a physical iOS device and works fine.
