### PR TITLE
fix  IconTintColorBehavior  for Windows

### DIFF
--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.windows.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.windows.cs
@@ -118,14 +118,7 @@ public partial class IconTintColorBehavior
 
 	void LoadAndApplyImageTintColor(View element, WImage image, Color color)
 	{
-		if (image.IsLoaded)
-		{
-			ApplyTintColor();
-		}
-		else
-		{
-			image.ImageOpened += OnImageOpened;
-		}
+		image.ImageOpened += OnImageOpened;
 
 		void OnImageOpened(object sender, RoutedEventArgs e)
 		{


### PR DESCRIPTION
 ### Description of Change ###

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->

 ### Linked Issues ###
Fixes #1333 IconTintColorBehavior causes image not to load on Windows 

 ### PR Checklist ###
Fixed issue with OnImageOpened
