### PR TITLE
Add `MemoryAnalyzer` roslyn analyzer

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,8 +27,11 @@
      CS1592: Badly formed XML in included comments file 
      CS1598: XML parser could not be loaded. The XML documentation file will not be generated. 
      CS1658: Identifier expected; 'true' is a keyword 
-     CS1734: XML comment has a paramref tag, but there is no parameter by that name -->
-     <WarningsAsErrors>nullable,CS0419,CS1570,CS1571,CS1572,CS1573,CS1574,CS1580,CS1581,CS1584,CS1589,CS1590,CS1592,CS1598,CS1658,CS1734</WarningsAsErrors>
+     CS1734: XML comment has a paramref tag, but there is no parameter by that name 
+     MA0001: Don't define public events in NSObject subclasses
+     MA0002: Don't declare members in NSObject subclasses unless they are WeakReference, WeakReference<T>, or Value types
+     MA0003: Don't subscribe to events inside NSObject subclasses unless it's your event (via this.MyEvent) or inherited from a base type, or the method is static -->
+     <WarningsAsErrors>nullable,CS0419,CS1570,CS1571,CS1572,CS1573,CS1574,CS1580,CS1581,CS1584,CS1589,CS1590,CS1592,CS1598,CS1658,CS1734,MA0001,MA0002,MA0003</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CommunityToolkit.Maui.Core/CommunityToolkit.Maui.Core.csproj
+++ b/src/CommunityToolkit.Maui.Core/CommunityToolkit.Maui.Core.csproj
@@ -56,6 +56,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
+    <PackageReference Include="MemoryAnalyzers" Version="0.1.0-beta.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    
     <PackageReference Include="System.Speech" Version="7.0.0" Condition="'$(TargetFramework)' == '$(NetVersion)-windows10.0.19041.0'" />
   </ItemGroup>
 

--- a/src/CommunityToolkit.Maui.Core/Views/Alert/AlertView.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Alert/AlertView.macios.cs
@@ -39,7 +39,7 @@ public class AlertView : UIView
 				return anchorView;
 			}
 
-			throw new ObjectDisposedException(nameof(AnchorView));
+			return null;
 		}
 		set => anchorViewReference.SetTarget(value);
 	}
@@ -56,7 +56,7 @@ public class AlertView : UIView
 				return container;
 			}
 
-			throw new ObjectDisposedException(nameof(Container));
+			return null;
 		}
 		set => containerReference.SetTarget(value);
 	}

--- a/src/CommunityToolkit.Maui.Core/Views/Alert/AlertView.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Alert/AlertView.macios.cs
@@ -9,6 +9,8 @@ namespace CommunityToolkit.Maui.Core.Views;
 public class AlertView : UIView
 {
 	readonly List<UIView> children = Enumerable.Empty<UIView>().ToList();
+	readonly WeakReference<UIView?> anchorViewReference = new(null);
+	readonly WeakReference<UIStackView?> containerReference = new(null);
 
 	/// <summary>
 	/// Parent UIView
@@ -21,19 +23,43 @@ public class AlertView : UIView
 	public IReadOnlyList<UIView> Children => children;
 
 	/// <summary>
-	/// <see cref="UIView"/> on which Alert will appear. When null, <see cref="AlertView"/> will appear at bottom of screen.
-	/// </summary>
-	public UIView? AnchorView { get; set; }
-
-	/// <summary>
 	/// <see cref="AlertViewVisualOptions"/>
 	/// </summary>
 	public AlertViewVisualOptions VisualOptions { get; } = new();
 
 	/// <summary>
+	/// <see cref="UIView"/> on which Alert will appear. When null, <see cref="AlertView"/> will appear at bottom of screen.
+	/// </summary>
+	public UIView? AnchorView
+	{
+		get
+		{
+			if (anchorViewReference.TryGetTarget(out var anchorView))
+			{
+				return anchorView;
+			}
+
+			throw new ObjectDisposedException(nameof(AnchorView));
+		}
+		set => anchorViewReference.SetTarget(value);
+	}
+
+	/// <summary>
 	/// Container of <see cref="AlertView"/>
 	/// </summary>
-	protected UIStackView? Container { get; set; }
+	protected UIStackView? Container
+	{
+		get
+		{
+			if (containerReference.TryGetTarget(out var container))
+			{
+				return container;
+			}
+
+			throw new ObjectDisposedException(nameof(Container));
+		}
+		set => containerReference.SetTarget(value);
+	}
 
 	/// <summary>
 	/// Dismisses the Popup from the screen

--- a/src/CommunityToolkit.Maui.Core/Views/Alert/AlertView.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Alert/AlertView.macios.cs
@@ -32,15 +32,7 @@ public class AlertView : UIView
 	/// </summary>
 	public UIView? AnchorView
 	{
-		get
-		{
-			if (anchorViewReference.TryGetTarget(out var anchorView))
-			{
-				return anchorView;
-			}
-
-			return null;
-		}
+		get => anchorViewReference.TryGetTarget(out var anchorView) ? anchorView : null;
 		set => anchorViewReference.SetTarget(value);
 	}
 
@@ -49,15 +41,7 @@ public class AlertView : UIView
 	/// </summary>
 	protected UIStackView? Container
 	{
-		get
-		{
-			if (containerReference.TryGetTarget(out var container))
-			{
-				return container;
-			}
-
-			return null;
-		}
+		get => containerReference.TryGetTarget(out var container) ? container : null;
 		set => containerReference.SetTarget(value);
 	}
 

--- a/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.android.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.android.cs
@@ -3,10 +3,6 @@ using Android.Content;
 using Android.Views;
 using CommunityToolkit.Maui.Core.Extensions;
 using Microsoft.Maui.Platform;
-using AColor = Android.Graphics.Color;
-using APaint = Android.Graphics.Paint;
-using APath = Android.Graphics.Path;
-using AView = Android.Views.View;
 
 namespace CommunityToolkit.Maui.Core.Views;
 
@@ -26,6 +22,7 @@ public partial class MauiDrawingView : PlatformTouchGraphicsView
 		if (disposing)
 		{
 			currentPath.Dispose();
+			proxy?.Dispose();
 		}
 
 		base.Dispose(disposing);
@@ -80,7 +77,7 @@ public partial class MauiDrawingView : PlatformTouchGraphicsView
 	public void Initialize()
 	{
 		Drawable = new DrawingViewDrawable(this);
-		Lines.CollectionChanged += OnLinesCollectionChanged;
+		proxy = new(this);
 	}
 
 	void Redraw()

--- a/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.macios.cs
@@ -49,7 +49,7 @@ public partial class MauiDrawingView : PlatformTouchGraphicsView
 	public void Initialize()
 	{
 		Drawable = new DrawingViewDrawable(this);
-		Lines.CollectionChanged += OnLinesCollectionChanged;
+		proxy = new(this);
 	}
 
 	/// <inheritdoc/>
@@ -58,6 +58,7 @@ public partial class MauiDrawingView : PlatformTouchGraphicsView
 		if (disposing)
 		{
 			currentPath.Dispose();
+			proxy?.Dispose();
 		}
 
 		base.Dispose(disposing);

--- a/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.shared.cs
@@ -57,15 +57,7 @@ public partial class MauiDrawingView
 	/// </summary>
 	public Action<ICanvas, RectF>? DrawAction
 	{
-		get
-		{
-			if (drawActionReference.TryGetTarget(out var drawAction))
-			{
-				return drawAction;
-			}
-
-			return null;
-		}
+		get => drawActionReference.TryGetTarget(out var drawAction) ? drawAction : null;
 		set => drawActionReference.SetTarget(value);
 	}
 

--- a/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.shared.cs
@@ -64,7 +64,7 @@ public partial class MauiDrawingView
 				return drawAction;
 			}
 
-			throw new ObjectDisposedException(nameof(DrawAction));
+			return null;
 		}
 		set => drawActionReference.SetTarget(value);
 	}

--- a/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.shared.cs
@@ -235,15 +235,15 @@ public partial class MauiDrawingView
 	{
 		readonly WeakReference<MauiDrawingView> platformView;
 
-		MauiDrawingView PlatformView => platformView.TryGetTarget(out var drawingView)
-											? drawingView
-											: throw new ObjectDisposedException(nameof(PlatformView));
-
 		public MauiDrawingViewProxy(MauiDrawingView view)
 		{
 			platformView = new(view);
 			SubscribeCollectionChanged();
 		}
+
+		MauiDrawingView PlatformView => platformView.TryGetTarget(out var drawingView)
+											? drawingView
+											: throw new ObjectDisposedException(nameof(PlatformView));
 
 		public void Dispose()
 		{

--- a/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.shared.cs
@@ -9,6 +9,7 @@ namespace CommunityToolkit.Maui.Core.Views;
 public partial class MauiDrawingView
 {
 	readonly WeakEventManager weakEventManager = new();
+	readonly WeakReference<Action<ICanvas, RectF>?> drawActionReference = new(null);
 
 	bool isDrawing;
 	PointF previousPoint;
@@ -53,7 +54,19 @@ public partial class MauiDrawingView
 	/// <summary>
 	/// Used to draw any shape on the canvas
 	/// </summary>
-	public Action<ICanvas, RectF>? DrawAction { get; set; }
+	public Action<ICanvas, RectF>? DrawAction
+	{
+		get
+		{
+			if (drawActionReference.TryGetTarget(out var drawAction))
+			{
+				return drawAction;
+			}
+
+			throw new ObjectDisposedException(nameof(DrawAction));
+		}
+		set => drawActionReference.SetTarget(value);
+	}
 
 	/// <summary>
 	/// Drawable background

--- a/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.tizen.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.tizen.cs
@@ -20,7 +20,7 @@ public partial class MauiDrawingView : PlatformTouchGraphicsView
 	public void Initialize()
 	{
 		Drawable = new DrawingViewDrawable(this);
-		Lines.CollectionChanged += OnLinesCollectionChanged;
+		proxy = new(this);
 	}
 
 	/// <inheritdoc />
@@ -29,6 +29,7 @@ public partial class MauiDrawingView : PlatformTouchGraphicsView
 		if (disposing)
 		{
 			currentPath.Dispose();
+			proxy?.Dispose();
 			TouchEvent -= OnTouch;
 		}
 

--- a/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.windows.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.windows.cs
@@ -30,7 +30,7 @@ public partial class MauiDrawingView : PlatformTouchGraphicsView, IDisposable
 			System.Diagnostics.Trace.WriteLine("DrawingView requires Windows 10.0.18362 or higher.");
 		}
 
-		Lines.CollectionChanged += OnLinesCollectionChanged;
+		proxy = new(this);
 	}
 
 	/// <inheritdoc />
@@ -49,6 +49,7 @@ public partial class MauiDrawingView : PlatformTouchGraphicsView, IDisposable
 			if (disposing)
 			{
 				currentPath.Dispose();
+				proxy?.Dispose();
 			}
 
 			isDisposed = true;

--- a/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
@@ -176,8 +176,7 @@ public class MauiPopup : UIViewController
 
 	void SetPresentationController()
 	{
-		var popOverDelegate = new PopoverDelegate();
-		popOverDelegate.PopoverDismissedEvent += HandlePopoverDelegateDismissed;
+		var popOverDelegate = new PopoverDelegate(this);
 
 		UIPopoverPresentationController presentationController = (UIPopoverPresentationController)(PresentationController ?? throw new InvalidOperationException($"{nameof(PresentationController)} cannot be null."));
 		presentationController.SourceView = ViewController?.View ?? throw new InvalidOperationException($"{nameof(ViewController.View)} cannot be null.");
@@ -200,12 +199,23 @@ public class MauiPopup : UIViewController
 	sealed class PopoverDelegate : UIPopoverPresentationControllerDelegate
 	{
 		readonly WeakEventManager popoverDismissedEventmanager = new();
+		readonly WeakReference<MauiPopup> virtualView;
+
+		public PopoverDelegate(MauiPopup virtualView)
+		{
+			this.virtualView = new(virtualView);
+			PopoverDismissedEvent += VirtualView.HandlePopoverDelegateDismissed;
+		}
 
 		public event EventHandler<UIPresentationController> PopoverDismissedEvent
 		{
 			add => popoverDismissedEventmanager.AddEventHandler(value);
 			remove => popoverDismissedEventmanager.RemoveEventHandler(value);
 		}
+
+		MauiPopup VirtualView => this.virtualView.TryGetTarget(out var virtualView)
+										? virtualView
+										: throw new ObjectDisposedException(nameof(VirtualView));
 
 		public override UIModalPresentationStyle GetAdaptivePresentationStyle(UIPresentationController forPresentationController) =>
 			UIModalPresentationStyle.None;

--- a/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
@@ -34,15 +34,7 @@ public class MauiPopup : UIViewController
 
 	internal UIViewController? ViewController
 	{
-		get
-		{
-			if (viewControllerReference.TryGetTarget(out var viewController))
-			{
-				return viewController;
-			}
-
-			return null;
-		}
+		get => viewControllerReference.TryGetTarget(out var viewController) ? viewController : null;
 		set => viewControllerReference.SetTarget(value);
 	}
 

--- a/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
@@ -41,7 +41,7 @@ public class MauiPopup : UIViewController
 				return viewController;
 			}
 
-			throw new ObjectDisposedException(nameof(ViewController));
+			return null;
 		}
 		set => viewControllerReference.SetTarget(value);
 	}

--- a/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
@@ -10,6 +10,7 @@ namespace CommunityToolkit.Maui.Core.Views;
 public class MauiPopup : UIViewController
 {
 	readonly IMauiContext mauiContext;
+	readonly WeakReference<UIViewController?> viewControllerReference = new(null);
 
 	/// <summary>
 	/// Constructor of <see cref="MauiPopup"/>.
@@ -31,7 +32,19 @@ public class MauiPopup : UIViewController
 	/// </summary>
 	public IPopup? VirtualView { get; private set; }
 
-	internal UIViewController? ViewController { get; private set; }
+	internal UIViewController? ViewController
+	{
+		get
+		{
+			if (viewControllerReference.TryGetTarget(out var viewController))
+			{
+				return viewController;
+			}
+
+			throw new ObjectDisposedException(nameof(viewController));
+		}
+		set => viewControllerReference.SetTarget(value);
+	}
 
 	/// <summary>
 	/// Method to update the Popup's size.

--- a/src/CommunityToolkit.Maui.Maps/CommunityToolkit.Maui.Maps.csproj
+++ b/src/CommunityToolkit.Maui.Maps/CommunityToolkit.Maui.Maps.csproj
@@ -51,6 +51,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Maui.Controls.Maps" Version="7.0.86" />
+    
+    <PackageReference Include="MemoryAnalyzers" Version="0.1.0-beta.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/CommunityToolkit.Maui.MediaElement/CommunityToolkit.Maui.MediaElement.csproj
+++ b/src/CommunityToolkit.Maui.MediaElement/CommunityToolkit.Maui.MediaElement.csproj
@@ -53,9 +53,16 @@
     <None Include="ReadMe.txt" pack="true" PackagePath="." />
   </ItemGroup>
 
-    <ItemGroup>
+  <ItemGroup>
     <None Include="..\CommunityToolkit.Maui.MediaElement.Analyzers\bin\$(Configuration)\netstandard2.0\CommunityToolkit.Maui.MediaElement.Analyzers.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="..\CommunityToolkit.Maui.MediaElement.Analyzers.CodeFixes\bin\$(Configuration)\netstandard2.0\CommunityToolkit.Maui.MediaElement.Analyzers.CodeFixes.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MemoryAnalyzers" Version="0.1.0-beta.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.Contains('-android'))">

--- a/src/CommunityToolkit.Maui/CommunityToolkit.Maui.csproj
+++ b/src/CommunityToolkit.Maui/CommunityToolkit.Maui.csproj
@@ -67,6 +67,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+
+    <PackageReference Include="MemoryAnalyzers" Version="0.1.0-beta.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

This PR adds a new Roslyn Analyzer:  [MemoryAnalyzers](https://github.com/jonathanpeppers/memory-analyzers), a set of Roslyn C# code analyzers for finding memory leaks in iOS and MacCatalyst applications, created by @jonathanpeppers on Microsoft's .NET MAUI team.

The .NET MAUI team adopted `MemoryAnalyzers`, adding it to their code base in this PR last week: https://github.com/dotnet/maui/pull/16346/files

This PR also implements updates to our code base where `MemoryAnalyzers` found potential memory leaks.

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 I've also added `WarningsAsErrors` for the current 3 warnings surfaced by `MemoryAnalyzer` to ensure future PRs don't accidentally introduce new memory leaks: `MA0001`, `MA0002` and `MA0003`
