### PR TITLE
Updated the validation to allow the image button to apply the tint co…

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/IconTintColorBehaviorPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/IconTintColorBehaviorPage.xaml
@@ -13,73 +13,100 @@
 	<ScrollView>
 		<Grid
 			Padding="20" 
-			ColumnDefinitions="*,*"
-			RowDefinitions="Auto, Auto, 60, 60, 60, Auto"
+			ColumnDefinitions="*, *, *"
+			RowDefinitions="Auto, Auto, 60, Auto, 60, Auto"
 			RowSpacing="20">
 
 			<Label
 				Margin="0,0,0,20"
 				Text="With the IconTintColorBehavior you set the tint color of an image. This behavior works on the Image and ImageButton controls and is implemented for the Android, iOS, maccatalyst and Windows platforms."
+				LineBreakMode="WordWrap"
 				HorizontalTextAlignment="Center"
-				Grid.ColumnSpan="2"/>
+				Grid.ColumnSpan="3"
+				Grid.Column="0"
+				Grid.Row="0"/>
 
-				<Label
-					Grid.Row="1"
-					FontAttributes="Bold"
-					FontSize="18"
-					HorizontalTextAlignment="Center"
-					Text="Image control" />
+			<Label
+				Grid.Row="1"
+				Grid.ColumnSpan="3"
+				FontAttributes="Bold"
+				FontSize="18"
+				HorizontalTextAlignment="Center"
+				Text="Image control" />
 
-				<Image Grid.Row="2" Source="shield.png" />
+			<Image
+				Grid.Row="2"
+				Grid.Column="0"
+				Source="shield.png" />
 
-				<Image Grid.Row="3" Source="shield.png">
-					<Image.Behaviors>
-						<mct:IconTintColorBehavior TintColor="Red" />
-					</Image.Behaviors>
-				</Image>
+			<Image
+				Grid.Row="2"
+				Grid.Column="1"
+				Source="shield.png">
+				<Image.Behaviors>
+					<mct:IconTintColorBehavior TintColor="Red" />
+				</Image.Behaviors>
+			</Image>
 
-				<Image Grid.Row="4" Source="shield.png">
-					<Image.Behaviors>
-						<mct:IconTintColorBehavior TintColor="Green" />
-					</Image.Behaviors>
-				</Image>
+			<Image
+				Grid.Row="2"
+				Grid.Column="2"
+				Source="shield.png">
+				<Image.Behaviors>
+					<mct:IconTintColorBehavior TintColor="Green" />
+				</Image.Behaviors>
+			</Image>
 
-				<Label
-					Grid.Column="1"
-					Grid.Row="1"
-					FontAttributes="Bold"
-					FontSize="18"
-					HorizontalTextAlignment="Center"
-					Text="ImageButton control" />
+			<Label
+				Grid.Column="0"
+				Grid.ColumnSpan="3"
+				Grid.Row="3"
+				Padding="0,20,0,0"
+				FontAttributes="Bold"
+				FontSize="18"
+				HorizontalTextAlignment="Center"
+				Text="ImageButton control" />
 
-				<ImageButton
-					Grid.Row="2"
-					Grid.Column="1"
-					Source="shield.png" />
+			<ImageButton
+				Grid.Row="4"
+				Grid.Column="0"
+				Source="shield.png" />
 
-				<ImageButton
-					Grid.Row="3"
-					Grid.Column="1"
-					Source="shield.png">
-					<ImageButton.Behaviors>
-						<mct:IconTintColorBehavior TintColor="Red" />
-					</ImageButton.Behaviors>
-				</ImageButton>
+			<ImageButton
+				x:Name="UpdateImage"
+				Grid.Row="4"
+				Grid.Column="1"
+				Clicked="ChangeSource_Clicked"
+				Source="shield.png">
+				<ImageButton.Behaviors>
+					<mct:IconTintColorBehavior TintColor="Red" />
+				</ImageButton.Behaviors>
+			</ImageButton>
 
-				<ImageButton
-					Grid.Row="4"
-					Grid.Column="1"
-					Command="{Binding ChangeCommand}"
-					Source="shield.png">
-					<ImageButton.Behaviors>
-						<mct:IconTintColorBehavior TintColor="{Binding Source={x:Reference this}, Path=BindingContext.ChangedColor}" />
-					</ImageButton.Behaviors>
-				</ImageButton>
+			<ImageButton
+				Grid.Row="4"
+				Grid.Column="2"
+				Command="{Binding ChangeCommand}"
+				Source="shield.png">
+				<ImageButton.Behaviors>
+					<mct:IconTintColorBehavior TintColor="{Binding Source={x:Reference this}, Path=BindingContext.ChangedColor}" />
+				</ImageButton.Behaviors>
+			</ImageButton>
 
 			<Label
 				Grid.Row="5"
-				Grid.Column="1"
+				Grid.Column="2"
+				FontSize="Micro"
+				FontAttributes="Italic"
 				Text="The ImageButton above uses Binding in order to change the TintColor. Click it!"/>
-			</Grid>
+			<Label
+				Grid.Row="5"
+				Grid.Column="1"
+				FontSize="Micro"
+				FontAttributes="Italic"
+				Text="The ImageButton above updates the image source. Click it!"/>
+		
+		</Grid>
+		
 	</ScrollView>
 </pages:BasePage>

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/IconTintColorBehaviorPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/IconTintColorBehaviorPage.xaml.cs
@@ -1,5 +1,4 @@
 using CommunityToolkit.Maui.Sample.ViewModels.Behaviors;
-using Microsoft.Maui.Controls;
 
 namespace CommunityToolkit.Maui.Sample.Pages.Behaviors;
 

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/IconTintColorBehaviorPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/IconTintColorBehaviorPage.xaml.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.Maui.Sample.ViewModels.Behaviors;
+using Microsoft.Maui.Controls;
 
 namespace CommunityToolkit.Maui.Sample.Pages.Behaviors;
 
@@ -8,5 +9,23 @@ public partial class IconTintColorBehaviorPage : BasePage<IconTintColorBehaviorV
 		: base(iconTintColorBehaviorViewModel)
 	{
 		InitializeComponent();
+	}
+
+	void ChangeSource_Clicked(System.Object sender, System.EventArgs e)
+	{
+		var imageSource = (ImageButton)sender;
+		var selectedImage = imageSource.Source as FileImageSource;
+
+		if (selectedImage is not null)
+		{
+			if (selectedImage.File == "dotnet_bot.png")
+			{
+				UpdateImage.Source = "shield.png";
+			}
+			else
+			{
+				UpdateImage.Source = "dotnet_bot.png";
+			}
+		}
 	}
 }

--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.macios.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.macios.cs
@@ -23,9 +23,9 @@ public partial class IconTintColorBehavior
 
 	void OnElementPropertyChanged(object? sender, PropertyChangedEventArgs e)
 	{
-		if (e.PropertyName != ImageButton.IsLoadingProperty.PropertyName
-			|| e.PropertyName != Image.SourceProperty.PropertyName
-			|| e.PropertyName != ImageButton.SourceProperty.PropertyName
+		if ((e.PropertyName != ImageButton.IsLoadingProperty.PropertyName
+			&& e.PropertyName != Image.SourceProperty.PropertyName
+			&& e.PropertyName != ImageButton.SourceProperty.PropertyName)
 			|| sender is not IImageElement element
 			|| (sender as VisualElement)?.Handler?.PlatformView is not UIView platformView)
 		{


### PR DESCRIPTION
 ### Description of Change ###

Updated the iOS validations to allow the Image button and image to re-apply the tint color when the source is updated via a page element event. Special thanks to [v0idzz](https://github.com/v0idzz) for providing a proposal solution.

 ### Linked Issues ###

 - Fixes [#1196](https://github.com/CommunityToolkit/Maui/issues/1196) 

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ 


 ### Additional information ###

Additionally, I went head and updated a little the UI of the sample app for the Image Tint Color to reflect make it a little more clear and also added the sample of a change source image button, so it can be applied. 

No documentation is required to be updated, since this was an iOS bug only. It has been tested on iOS.

![Simulator Screenshot - iPhone 11 Pro Max - 2023-09-05 at 08 43 37](https://github.com/CommunityToolkit/Maui/assets/1047398/c669654c-5c33-4623-8a2c-6c32ed7bfbff)

