### PR TITLE
[MediaElement] Pre-initialize the Player Volume and Muted Properties

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
@@ -93,6 +93,14 @@ public partial class MediaManager : IDisposable
 			Player = Player
 		};
 
+		// Pre-initialize Volume and Muted properties to the player object
+		Player.Muted = MediaElement.ShouldMute;
+		var volumeDiff = Math.Abs(Player.Volume - MediaElement.Volume);
+		if (volumeDiff > 0.01)
+		{
+			Player.Volume = (float)MediaElement.Volume;
+		}
+
 		AddStatusObservers();
 		AddPlayedToEndObserver();
 		AddErrorObservers();


### PR DESCRIPTION
 ### Description of Change ###

Pre-initialized the Volume and Muted properties of the AVPlayer object so the video can set to start muted or under a specific volume. This issue occurs only when initializing the Media Element on the page.

**How to test this patch**

1. Open the `samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml` file, and add `ShouldMute="True"` property on the following XAML element:

```xml
<toolkit:MediaElement
                x:Name="mediaElement"
                ShouldAutoPlay="True"
                Source="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
                MediaEnded="OnMediaEnded"
                MediaFailed="OnMediaFailed"
                MediaOpened="OnMediaOpened"
                PositionChanged="OnPositionChanged"
                StateChanged="OnStateChanged"
                SeekCompleted="OnSeekCompleted"/>
```
2. Run the sample app and go to Media Element under Views
3. The video must start muted

_The sample steps apply for Volume when it is set to 0._

 ### Linked Issues ###

 - Fixes [#1372](https://github.com/CommunityToolkit/Maui/issues/1372)

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated.


 ### Additional information ###

There is no need to update documentation since this is a bug on the iOS Player reported by our friend Varmod. This has been tested on iOS and MacOS.
 
