### PR TITLE
Revert `MemoryAnalyzer` PR Until Device Unit Testing is Available

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,11 +27,8 @@
      CS1592: Badly formed XML in included comments file 
      CS1598: XML parser could not be loaded. The XML documentation file will not be generated. 
      CS1658: Identifier expected; 'true' is a keyword 
-     CS1734: XML comment has a paramref tag, but there is no parameter by that name 
-     MA0001: Don't define public events in NSObject subclasses
-     MA0002: Don't declare members in NSObject subclasses unless they are WeakReference, WeakReference<T>, or Value types
-     MA0003: Don't subscribe to events inside NSObject subclasses unless it's your event (via this.MyEvent) or inherited from a base type, or the method is static -->
-     <WarningsAsErrors>nullable,CS0419,CS1570,CS1571,CS1572,CS1573,CS1574,CS1580,CS1581,CS1584,CS1589,CS1590,CS1592,CS1598,CS1658,CS1734,MA0001,MA0002,MA0003</WarningsAsErrors>
+     CS1734: XML comment has a paramref tag, but there is no parameter by that name -->
+     <WarningsAsErrors>nullable,CS0419,CS1570,CS1571,CS1572,CS1573,CS1574,CS1580,CS1581,CS1584,CS1589,CS1590,CS1592,CS1598,CS1658,CS1734</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CommunityToolkit.Maui.Core/CommunityToolkit.Maui.Core.csproj
+++ b/src/CommunityToolkit.Maui.Core/CommunityToolkit.Maui.Core.csproj
@@ -56,11 +56,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
-    <PackageReference Include="MemoryAnalyzers" Version="0.1.0-beta.3">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    
     <PackageReference Include="System.Speech" Version="7.0.0" Condition="'$(TargetFramework)' == '$(NetVersion)-windows10.0.19041.0'" />
   </ItemGroup>
 

--- a/src/CommunityToolkit.Maui.Core/Views/Alert/AlertView.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Alert/AlertView.macios.cs
@@ -9,8 +9,6 @@ namespace CommunityToolkit.Maui.Core.Views;
 public class AlertView : UIView
 {
 	readonly List<UIView> children = Enumerable.Empty<UIView>().ToList();
-	readonly WeakReference<UIView?> anchorViewReference = new(null);
-	readonly WeakReference<UIStackView?> containerReference = new(null);
 
 	/// <summary>
 	/// Parent UIView
@@ -23,27 +21,19 @@ public class AlertView : UIView
 	public IReadOnlyList<UIView> Children => children;
 
 	/// <summary>
+	/// <see cref="UIView"/> on which Alert will appear. When null, <see cref="AlertView"/> will appear at bottom of screen.
+	/// </summary>
+	public UIView? AnchorView { get; set; }
+
+	/// <summary>
 	/// <see cref="AlertViewVisualOptions"/>
 	/// </summary>
 	public AlertViewVisualOptions VisualOptions { get; } = new();
 
 	/// <summary>
-	/// <see cref="UIView"/> on which Alert will appear. When null, <see cref="AlertView"/> will appear at bottom of screen.
-	/// </summary>
-	public UIView? AnchorView
-	{
-		get => anchorViewReference.TryGetTarget(out var anchorView) ? anchorView : null;
-		set => anchorViewReference.SetTarget(value);
-	}
-
-	/// <summary>
 	/// Container of <see cref="AlertView"/>
 	/// </summary>
-	protected UIStackView? Container
-	{
-		get => containerReference.TryGetTarget(out var container) ? container : null;
-		set => containerReference.SetTarget(value);
-	}
+	protected UIStackView? Container { get; set; }
 
 	/// <summary>
 	/// Dismisses the Popup from the screen

--- a/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.android.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.android.cs
@@ -3,6 +3,10 @@ using Android.Content;
 using Android.Views;
 using CommunityToolkit.Maui.Core.Extensions;
 using Microsoft.Maui.Platform;
+using AColor = Android.Graphics.Color;
+using APaint = Android.Graphics.Paint;
+using APath = Android.Graphics.Path;
+using AView = Android.Views.View;
 
 namespace CommunityToolkit.Maui.Core.Views;
 
@@ -22,7 +26,6 @@ public partial class MauiDrawingView : PlatformTouchGraphicsView
 		if (disposing)
 		{
 			currentPath.Dispose();
-			proxy?.Dispose();
 		}
 
 		base.Dispose(disposing);
@@ -77,7 +80,7 @@ public partial class MauiDrawingView : PlatformTouchGraphicsView
 	public void Initialize()
 	{
 		Drawable = new DrawingViewDrawable(this);
-		proxy = new(this);
+		Lines.CollectionChanged += OnLinesCollectionChanged;
 	}
 
 	void Redraw()

--- a/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.macios.cs
@@ -49,7 +49,7 @@ public partial class MauiDrawingView : PlatformTouchGraphicsView
 	public void Initialize()
 	{
 		Drawable = new DrawingViewDrawable(this);
-		proxy = new(this);
+		Lines.CollectionChanged += OnLinesCollectionChanged;
 	}
 
 	/// <inheritdoc/>
@@ -58,7 +58,6 @@ public partial class MauiDrawingView : PlatformTouchGraphicsView
 		if (disposing)
 		{
 			currentPath.Dispose();
-			proxy?.Dispose();
 		}
 
 		base.Dispose(disposing);

--- a/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.shared.cs
@@ -9,13 +9,11 @@ namespace CommunityToolkit.Maui.Core.Views;
 public partial class MauiDrawingView
 {
 	readonly WeakEventManager weakEventManager = new();
-	readonly WeakReference<Action<ICanvas, RectF>?> drawActionReference = new(null);
 
 	bool isDrawing;
 	PointF previousPoint;
 	PathF currentPath = new();
 	MauiDrawingLine? currentLine;
-	MauiDrawingViewProxy? proxy;
 	Paint paint = new SolidPaint(DrawingViewDefaults.BackgroundColor);
 
 	/// <summary>
@@ -55,11 +53,7 @@ public partial class MauiDrawingView
 	/// <summary>
 	/// Used to draw any shape on the canvas
 	/// </summary>
-	public Action<ICanvas, RectF>? DrawAction
-	{
-		get => drawActionReference.TryGetTarget(out var drawAction) ? drawAction : null;
-		set => drawActionReference.SetTarget(value);
-	}
+	public Action<ICanvas, RectF>? DrawAction { get; set; }
 
 	/// <summary>
 	/// Drawable background
@@ -109,7 +103,7 @@ public partial class MauiDrawingView
 
 		Redraw();
 
-		proxy?.SubscribeCollectionChanged();
+		Lines.CollectionChanged += OnLinesCollectionChanged;
 	}
 
 	void OnMoving(PointF currentPoint)
@@ -171,7 +165,7 @@ public partial class MauiDrawingView
 		currentPath = new PathF();
 	}
 
-	sealed class DrawingViewDrawable : IDrawable
+	class DrawingViewDrawable : IDrawable
 	{
 		readonly MauiDrawingView drawingView;
 
@@ -226,33 +220,6 @@ public partial class MauiDrawingView
 					canvas.DrawPath(path);
 				}
 			}
-		}
-	}
-
-	// Proxy class required to avoid memory leaks on iOS, resolving MA0003
-	// Inspired by SearchbarHandler.MauiSearchBarProxy https://github.com/dotnet/maui/blob/911ea757e996d1213711f786f81e05461df6fc2f/src/Core/src/Handlers/SearchBar/SearchBarHandler.iOS.cs#L155-L251
-	sealed partial class MauiDrawingViewProxy : IDisposable
-	{
-		readonly WeakReference<MauiDrawingView> platformView;
-
-		public MauiDrawingViewProxy(MauiDrawingView view)
-		{
-			platformView = new(view);
-			SubscribeCollectionChanged();
-		}
-
-		MauiDrawingView PlatformView => platformView.TryGetTarget(out var drawingView)
-											? drawingView
-											: throw new ObjectDisposedException(nameof(PlatformView));
-
-		public void Dispose()
-		{
-			PlatformView.Lines.CollectionChanged -= PlatformView.OnLinesCollectionChanged;
-		}
-
-		public void SubscribeCollectionChanged()
-		{
-			PlatformView.Lines.CollectionChanged += PlatformView.OnLinesCollectionChanged;
 		}
 	}
 }

--- a/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.tizen.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.tizen.cs
@@ -20,7 +20,7 @@ public partial class MauiDrawingView : PlatformTouchGraphicsView
 	public void Initialize()
 	{
 		Drawable = new DrawingViewDrawable(this);
-		proxy = new(this);
+		Lines.CollectionChanged += OnLinesCollectionChanged;
 	}
 
 	/// <inheritdoc />
@@ -29,7 +29,6 @@ public partial class MauiDrawingView : PlatformTouchGraphicsView
 		if (disposing)
 		{
 			currentPath.Dispose();
-			proxy?.Dispose();
 			TouchEvent -= OnTouch;
 		}
 

--- a/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.windows.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/DrawingView/PlatformView/MauiDrawingView.windows.cs
@@ -30,7 +30,7 @@ public partial class MauiDrawingView : PlatformTouchGraphicsView, IDisposable
 			System.Diagnostics.Trace.WriteLine("DrawingView requires Windows 10.0.18362 or higher.");
 		}
 
-		proxy = new(this);
+		Lines.CollectionChanged += OnLinesCollectionChanged;
 	}
 
 	/// <inheritdoc />
@@ -49,7 +49,6 @@ public partial class MauiDrawingView : PlatformTouchGraphicsView, IDisposable
 			if (disposing)
 			{
 				currentPath.Dispose();
-				proxy?.Dispose();
 			}
 
 			isDisposed = true;

--- a/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
@@ -10,7 +10,6 @@ namespace CommunityToolkit.Maui.Core.Views;
 public class MauiPopup : UIViewController
 {
 	readonly IMauiContext mauiContext;
-	readonly WeakReference<UIViewController?> viewControllerReference = new(null);
 
 	/// <summary>
 	/// Constructor of <see cref="MauiPopup"/>.
@@ -32,11 +31,7 @@ public class MauiPopup : UIViewController
 	/// </summary>
 	public IPopup? VirtualView { get; private set; }
 
-	internal UIViewController? ViewController
-	{
-		get => viewControllerReference.TryGetTarget(out var viewController) ? viewController : null;
-		set => viewControllerReference.SetTarget(value);
-	}
+	internal UIViewController? ViewController { get; private set; }
 
 	/// <summary>
 	/// Method to update the Popup's size.
@@ -168,12 +163,20 @@ public class MauiPopup : UIViewController
 
 	void SetPresentationController()
 	{
-		var popOverDelegate = new PopoverDelegate(this);
+		var popOverDelegate = new PopoverDelegate();
+		popOverDelegate.PopoverDismissedEvent += HandlePopoverDelegateDismissed;
 
 		UIPopoverPresentationController presentationController = (UIPopoverPresentationController)(PresentationController ?? throw new InvalidOperationException($"{nameof(PresentationController)} cannot be null."));
 		presentationController.SourceView = ViewController?.View ?? throw new InvalidOperationException($"{nameof(ViewController.View)} cannot be null.");
 
 		presentationController.Delegate = popOverDelegate;
+	}
+
+	[MemberNotNull(nameof(VirtualView))]
+	void HandlePopoverDelegateDismissed(object? sender, UIPresentationController e)
+	{
+		_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} cannot be null.");
+		VirtualView.Handler?.Invoke(nameof(IPopup.OnDismissedByTappingOutsideOfPopup));
 	}
 
 	void AddToCurrentPageViewController(UIViewController viewController)
@@ -184,13 +187,6 @@ public class MauiPopup : UIViewController
 	sealed class PopoverDelegate : UIPopoverPresentationControllerDelegate
 	{
 		readonly WeakEventManager popoverDismissedEventmanager = new();
-		readonly WeakReference<MauiPopup> mauiPopup;
-
-		public PopoverDelegate(MauiPopup mauiPopup)
-		{
-			this.mauiPopup = new(mauiPopup);
-			PopoverDismissedEvent += HandlePopoverDelegateDismissed;
-		}
 
 		public event EventHandler<UIPresentationController> PopoverDismissedEvent
 		{
@@ -198,19 +194,10 @@ public class MauiPopup : UIViewController
 			remove => popoverDismissedEventmanager.RemoveEventHandler(value);
 		}
 
-		MauiPopup MauiPopup => mauiPopup.TryGetTarget(out var virtualView)
-										? virtualView
-										: throw new ObjectDisposedException(nameof(MauiPopup));
-
 		public override UIModalPresentationStyle GetAdaptivePresentationStyle(UIPresentationController forPresentationController) =>
 			UIModalPresentationStyle.None;
 
 		public override void DidDismiss(UIPresentationController presentationController) =>
 			popoverDismissedEventmanager.HandleEvent(this, presentationController, nameof(PopoverDismissedEvent));
-
-		void HandlePopoverDelegateDismissed(object? sender, UIPresentationController e)
-		{
-			MauiPopup.VirtualView?.Handler?.Invoke(nameof(IPopup.OnDismissedByTappingOutsideOfPopup));
-		}
 	}
 }

--- a/src/CommunityToolkit.Maui.Maps/CommunityToolkit.Maui.Maps.csproj
+++ b/src/CommunityToolkit.Maui.Maps/CommunityToolkit.Maui.Maps.csproj
@@ -51,11 +51,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Maui.Controls.Maps" Version="7.0.86" />
-    
-    <PackageReference Include="MemoryAnalyzers" Version="0.1.0-beta.3">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/CommunityToolkit.Maui.MediaElement/CommunityToolkit.Maui.MediaElement.csproj
+++ b/src/CommunityToolkit.Maui.MediaElement/CommunityToolkit.Maui.MediaElement.csproj
@@ -53,16 +53,9 @@
     <None Include="ReadMe.txt" pack="true" PackagePath="." />
   </ItemGroup>
 
-  <ItemGroup>
+    <ItemGroup>
     <None Include="..\CommunityToolkit.Maui.MediaElement.Analyzers\bin\$(Configuration)\netstandard2.0\CommunityToolkit.Maui.MediaElement.Analyzers.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="..\CommunityToolkit.Maui.MediaElement.Analyzers.CodeFixes\bin\$(Configuration)\netstandard2.0\CommunityToolkit.Maui.MediaElement.Analyzers.CodeFixes.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="MemoryAnalyzers" Version="0.1.0-beta.3">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.Contains('-android'))">

--- a/src/CommunityToolkit.Maui/CommunityToolkit.Maui.csproj
+++ b/src/CommunityToolkit.Maui/CommunityToolkit.Maui.csproj
@@ -67,11 +67,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-
-    <PackageReference Include="MemoryAnalyzers" Version="0.1.0-beta.3">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION



 ### Description of Change ###

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->

This reverts PR #1371.

After review from [Jonathan Peppers raised concerns around missing unit tests on PR #1371](https://github.com/CommunityToolkit/Maui/pull/1371/files/75386fb41d957a739419704caea417e538e98a96#diff-ce1cac33c2cb0a6f0ffc172a4aef7135ec91135c1387186d2b816f8801529919), it's best that we revert this PR until we have implemented Device Unit Testing (ie unit testing on `net7.0-ios`).

 ### Additional information ###

I will create a Proposal for re-implementing `MemoryAnalysis` that will include the unit tests for `.net7.0-ios`. I will add the `blocked` label to the Proposal until device unit testing is available.
