### PR TITLE
Sample icon tint color behavior inside a popup

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Views/Popups/SimplePopup.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Views/Popups/SimplePopup.xaml
@@ -25,7 +25,7 @@
 					<Setter Property="HorizontalTextAlignment" Value="Start" />
 					<Setter Property="VerticalTextAlignment" Value="Center" />
 				</Style>
-				<Style x:Key="PopupLayout" TargetType="StackLayout">
+				<Style x:Key="PopupLayout" TargetType="VerticalStackLayout">
 					<Setter Property="Padding" Value="{OnPlatform Android=20, WinUI=20, iOS=5, MacCatalyst=5, Tizen=20}" />
 				</Style>
 			</ResourceDictionary>
@@ -33,6 +33,18 @@
 
 		<Label Style="{StaticResource Title}" Text="Simple Popup" />
 		<BoxView Style="{StaticResource Divider}" />
-		<Label Style="{StaticResource Content}" Text="This is a platform specific popup with a .NET MAUI View being rendered. The behaviors of the popup will confirm to 100% this platform look and feel, but still allows you to use your .NET MAUI controls." />
+		<Label Style="{StaticResource Content}" Text="This is a platform specific popup with a .NET MAUI View being rendered. " />
+		<Image Source="shield.png"
+				Margin="0,10,0,10"
+               WidthRequest="30"
+               HeightRequest="30">
+        </Image>
+		<Image Source="shield.png"
+               WidthRequest="30"
+               HeightRequest="30">
+            <Image.Behaviors>
+                <mct:IconTintColorBehavior TintColor="Red" />
+            </Image.Behaviors>
+        </Image>
 	</VerticalStackLayout>
 </mct:Popup>

--- a/samples/CommunityToolkit.Maui.Sample/Views/Popups/SimplePopup.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Views/Popups/SimplePopup.xaml
@@ -5,46 +5,46 @@
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	xmlns:mct="http://schemas.microsoft.com/dotnet/2022/maui/toolkit">
 
-	<VerticalStackLayout Style="{StaticResource PopupLayout}">
+    <VerticalStackLayout Style="{StaticResource PopupLayout}">
 
-		<VerticalStackLayout.Resources>
-			<ResourceDictionary>
-				<Style x:Key="Title" TargetType="Label">
-					<Setter Property="FontSize" Value="26" />
-					<Setter Property="FontAttributes" Value="Bold" />
-					<Setter Property="TextColor" Value="#000" />
-					<Setter Property="VerticalTextAlignment" Value="Center" />
-					<Setter Property="HorizontalTextAlignment" Value="Center" />
-				</Style>
-				<Style x:Key="Divider" TargetType="BoxView">
-					<Setter Property="HeightRequest" Value="1" />
-					<Setter Property="Margin" Value="50, 25" />
-					<Setter Property="Color" Value="#c3c3c3" />
-				</Style>
-				<Style x:Key="Content" TargetType="Label">
-					<Setter Property="HorizontalTextAlignment" Value="Start" />
-					<Setter Property="VerticalTextAlignment" Value="Center" />
-				</Style>
-				<Style x:Key="PopupLayout" TargetType="VerticalStackLayout">
-					<Setter Property="Padding" Value="{OnPlatform Android=20, WinUI=20, iOS=5, MacCatalyst=5, Tizen=20}" />
-				</Style>
-			</ResourceDictionary>
-		</VerticalStackLayout.Resources>
+        <VerticalStackLayout.Resources>
+            <ResourceDictionary>
+                <Style x:Key="Title" TargetType="Label">
+                    <Setter Property="FontSize" Value="26" />
+                    <Setter Property="FontAttributes" Value="Bold" />
+                    <Setter Property="TextColor" Value="#000" />
+                    <Setter Property="VerticalTextAlignment" Value="Center" />
+                    <Setter Property="HorizontalTextAlignment" Value="Center" />
+                </Style>
+                <Style x:Key="Divider" TargetType="BoxView">
+                    <Setter Property="HeightRequest" Value="1" />
+                    <Setter Property="Margin" Value="50, 25" />
+                    <Setter Property="Color" Value="#c3c3c3" />
+                </Style>
+                <Style x:Key="Content" TargetType="Label">
+                    <Setter Property="HorizontalTextAlignment" Value="Start" />
+                    <Setter Property="VerticalTextAlignment" Value="Center" />
+                </Style>
+                <Style x:Key="PopupLayout" TargetType="VerticalStackLayout">
+                    <Setter Property="Padding" Value="{OnPlatform Android=20, WinUI=20, iOS=5, MacCatalyst=5, Tizen=20}" />
+                </Style>
+            </ResourceDictionary>
+        </VerticalStackLayout.Resources>
 
-		<Label Style="{StaticResource Title}" Text="Simple Popup" />
-		<BoxView Style="{StaticResource Divider}" />
-		<Label Style="{StaticResource Content}" Text="This is a platform specific popup with a .NET MAUI View being rendered. " />
-		<Image Source="shield.png"
-				Margin="0,10,0,10"
-               WidthRequest="30"
+        <Label Style="{StaticResource Title}" Text="Simple Popup" />
+        <BoxView Style="{StaticResource Divider}" />
+        <Label Style="{StaticResource Content}" Text="This is a platform specific popup with a .NET MAUI View being rendered. " />
+        <Image Source="shield.png"
+			   Margin="0,10,0,10"
+			   WidthRequest="30"
                HeightRequest="30">
         </Image>
-		<Image Source="shield.png"
+        <Image Source="shield.png"
                WidthRequest="30"
                HeightRequest="30">
             <Image.Behaviors>
                 <mct:IconTintColorBehavior TintColor="Red" />
             </Image.Behaviors>
         </Image>
-	</VerticalStackLayout>
+    </VerticalStackLayout>
 </mct:Popup>


### PR DESCRIPTION
### Description of Change ###

Updates the sample of the simple popup by including a couple of images and one of them using the Icon Tint Color Behavior.

 ### Linked Issues ###

 - Fixes [#663](https://github.com/CommunityToolkit/Maui/issues/663)

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [ ] Rebased on top of `main` at time of PR
 - [ ] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ 


 ### Additional information ###

@brminnick please find on this PR the popup sample updated with the icon tint color samples. 
