### PR TITLE
Fix Memory leak on Popup

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Handlers/Popup/PopUpHandler.windows.cs
+++ b/src/CommunityToolkit.Maui.Core/Handlers/Popup/PopUpHandler.windows.cs
@@ -95,7 +95,11 @@ public partial class PopupHandler : ElementHandler<IPopup, Popup>
 	/// <inheritdoc/>
 	protected override void DisconnectHandler(Popup platformView)
 	{
-		ArgumentNullException.ThrowIfNull(VirtualView.Parent);
+		if (VirtualView.Parent is null)
+		{
+			return;
+		}
+
 		ArgumentNullException.ThrowIfNull(VirtualView.Handler?.MauiContext);
 		var parent = VirtualView.Parent.ToPlatform(VirtualView.Handler.MauiContext);
 		parent.IsHitTestVisible = true;

--- a/src/CommunityToolkit.Maui/Views/Popup/Popup.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/Popup.shared.cs
@@ -248,10 +248,10 @@ public partial class Popup : Element, IPopup, IWindowController, IPropertyPropag
 	protected virtual async Task OnClosed(object? result, bool wasDismissedByTappingOutsideOfPopup)
 	{
 		((IPopup)this).OnClosed(result);
-		
+
 		await popupDismissedTaskCompletionSource.Task;
 		Parent = null;
-		
+
 		dismissWeakEventManager.HandleEvent(this, new PopupClosedEventArgs(result, wasDismissedByTappingOutsideOfPopup), nameof(Closed));
 	}
 

--- a/src/CommunityToolkit.Maui/Views/Popup/Popup.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/Popup.shared.cs
@@ -228,7 +228,6 @@ public partial class Popup : Element, IPopup, IWindowController, IPropertyPropag
 	{
 		await OnClosed(result, false);
 		resultTaskCompletionSource.TrySetResult(result);
-		CleanUp();
 	}
 
 	/// <summary>
@@ -249,9 +248,11 @@ public partial class Popup : Element, IPopup, IWindowController, IPropertyPropag
 	protected virtual async Task OnClosed(object? result, bool wasDismissedByTappingOutsideOfPopup)
 	{
 		((IPopup)this).OnClosed(result);
+		
 		await popupDismissedTaskCompletionSource.Task;
+		Parent = null;
+		
 		dismissWeakEventManager.HandleEvent(this, new PopupClosedEventArgs(result, wasDismissedByTappingOutsideOfPopup), nameof(Closed));
-		CleanUp();
 	}
 
 	/// <summary>
@@ -261,7 +262,6 @@ public partial class Popup : Element, IPopup, IWindowController, IPropertyPropag
 	{
 		await OnClosed(ResultWhenUserTapsOutsideOfPopup, true);
 		resultTaskCompletionSource.TrySetResult(ResultWhenUserTapsOutsideOfPopup);
-		CleanUp();
 	}
 
 	/// <summary>
@@ -287,19 +287,6 @@ public partial class Popup : Element, IPopup, IWindowController, IPropertyPropag
 	static void OnColorChanged(BindableObject bindable, object oldValue, object newValue)
 	{
 		ArgumentNullException.ThrowIfNull(newValue);
-	}
-
-	bool didCleanUp;
-
-	void CleanUp()
-	{
-		if (didCleanUp)
-		{
-			return;
-		}
-
-		this.Parent = null;
-		didCleanUp = true;
 	}
 
 	void IPopup.OnClosed(object? result) => Handler.Invoke(nameof(IPopup.OnClosed), result);

--- a/src/CommunityToolkit.Maui/Views/Popup/Popup.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/Popup.shared.cs
@@ -228,6 +228,7 @@ public partial class Popup : Element, IPopup, IWindowController, IPropertyPropag
 	{
 		await OnClosed(result, false);
 		resultTaskCompletionSource.TrySetResult(result);
+		CleanUp();
 	}
 
 	/// <summary>
@@ -248,10 +249,9 @@ public partial class Popup : Element, IPopup, IWindowController, IPropertyPropag
 	protected virtual async Task OnClosed(object? result, bool wasDismissedByTappingOutsideOfPopup)
 	{
 		((IPopup)this).OnClosed(result);
-
 		await popupDismissedTaskCompletionSource.Task;
-
 		dismissWeakEventManager.HandleEvent(this, new PopupClosedEventArgs(result, wasDismissedByTappingOutsideOfPopup), nameof(Closed));
+		CleanUp();
 	}
 
 	/// <summary>
@@ -261,6 +261,7 @@ public partial class Popup : Element, IPopup, IWindowController, IPropertyPropag
 	{
 		await OnClosed(ResultWhenUserTapsOutsideOfPopup, true);
 		resultTaskCompletionSource.TrySetResult(ResultWhenUserTapsOutsideOfPopup);
+		CleanUp();
 	}
 
 	/// <summary>
@@ -286,6 +287,19 @@ public partial class Popup : Element, IPopup, IWindowController, IPropertyPropag
 	static void OnColorChanged(BindableObject bindable, object oldValue, object newValue)
 	{
 		ArgumentNullException.ThrowIfNull(newValue);
+	}
+
+	bool didCleanUp;
+
+	void CleanUp()
+	{
+		if (didCleanUp)
+		{
+			return;
+		}
+
+		this.Parent = null;
+		didCleanUp = true;
 	}
 
 	void IPopup.OnClosed(object? result) => Handler.Invoke(nameof(IPopup.OnClosed), result);


### PR DESCRIPTION
 ### Description of Change ###

This PR null the `Popup.Parent`  to prevent memory leaks, it will mostly occur when the parent is a `MainPage` (root page) or `Shell`.

Probably, you may think "Wait, but .NET MAUI doesn't handle that internally?", yeah it does but for `VisualElement` , ` Popup` is an `Element` and doesn't get all this love, so we need to do that by ourselves. :/

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #721

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [ ] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###

Before:
You see the CustomPopup holding on memory.
![image](https://github.com/CommunityToolkit/Maui/assets/20712372/4312fc9f-be08-460b-b7ad-06e765c51001)


After:
No more references to it, YaY:
![image](https://github.com/CommunityToolkit/Maui/assets/20712372/d10e2d74-c910-4c2b-9589-e1664f838ad1)




