### PR TITLE
Fix for the navigation to the SelectAllText page on macOS

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/SelectAllTextBehaviorPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/SelectAllTextBehaviorPage.xaml
@@ -26,20 +26,20 @@
 
 
             <Label FontAttributes="Italic" Text="Entry without the effect, when focused no text will be selected" />
-            <Border BackgroundColor="{StaticResource SoftBorderBackgroundColor}" >
+            <Border BackgroundColor="{StaticResource SoftFrameBackgroundColor}" >
                 <Entry
 					BackgroundColor="{StaticResource PrimaryColor}"
 					PlaceholderColor="{StaticResource DarkLabelPlaceholderColor}"
-					Text="https://github.com/xamarin/XamarinCommunityToolkit"
+					Text="https://github.com/CommunityToolkit/Maui/"
 					TextColor="{StaticResource DarkLabelTextColor}" />
             </Border>
 
             <Label FontAttributes="Italic" Text="Entry with the effect, when focused all text will be selected" />
-            <Border BackgroundColor="{StaticResource SoftBorderBackgroundColor}" >
+            <Border BackgroundColor="{StaticResource SoftFrameBackgroundColor}" >
                 <Entry
 					BackgroundColor="{StaticResource PrimaryColor}"
 					PlaceholderColor="{StaticResource DarkLabelPlaceholderColor}"
-					Text="https://github.com/xamarin/XamarinCommunityToolkit"
+					Text="https://github.com/CommunityToolkit/Maui/"
 					TextColor="{StaticResource DarkLabelTextColor}">
                     <Entry.Behaviors>
                         <mct:SelectAllTextBehavior />
@@ -52,23 +52,20 @@
 				Text="Editor"
 				TextColor="{StaticResource DarkLabelTextColor}" />
 
-
             <Label FontAttributes="Italic" Text="Editor without the effect, when focused no text will be selected" />
-            <Border BackgroundColor="{StaticResource SoftBorderBackgroundColor}" >
+            <Border BackgroundColor="{StaticResource SoftFrameBackgroundColor}" >
                 <Editor PlaceholderColor="{StaticResource DarkLabelPlaceholderColor}"
 						TextColor="{StaticResource DarkLabelTextColor}"
 						BackgroundColor="{StaticResource PrimaryColor}">
                     <Editor.Text>
-                        Yeah, but your scientists were so preoccupied with whether or not they could, they didn't stop to think if they should. Must go faster... go, go, go, go, go! You know what? It is beets. I've crashed into a beet truck. Is this my espresso machine? Wh-what is-h-how did you get my espresso machine?
-						Just my luck, no ice. I gave it a cold? I gave it a virus. A computer virus. Must go faster... go, go, go, go, go! God creates dinosaurs. God destroys dinosaurs. God creates Man. Man destroys God. Man creates Dinosaurs. Yeah, but your scientists were so preoccupied with whether or not they could, they didn't stop to think if they should.
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                        Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
                     </Editor.Text>
                 </Editor>
             </Border>
 
-
-
             <Label FontAttributes="Italic" Text="Editor with the effect, when focused all text will be selected" />
-            <Border BackgroundColor="{StaticResource SoftBorderBackgroundColor}" >
+            <Border BackgroundColor="{StaticResource SoftFrameBackgroundColor}" >
                 <Editor PlaceholderColor="{StaticResource DarkLabelPlaceholderColor}"
 						TextColor="{StaticResource DarkLabelTextColor}"
 						BackgroundColor="{StaticResource PrimaryColor}">
@@ -76,8 +73,8 @@
                         <mct:SelectAllTextBehavior />
                     </Editor.Behaviors>
                     <Editor.Text>
-                        Yeah, but your scientists were so preoccupied with whether or not they could, they didn't stop to think if they should. Must go faster... go, go, go, go, go! You know what? It is beets. I've crashed into a beet truck. Is this my espresso machine? Wh-what is-h-how did you get my espresso machine?
-						Just my luck, no ice. I gave it a cold? I gave it a virus. A computer virus. Must go faster... go, go, go, go, go! God creates dinosaurs. God destroys dinosaurs. God creates Man. Man destroys God. Man creates Dinosaurs. Yeah, but your scientists were so preoccupied with whether or not they could, they didn't stop to think if they should.
+                       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                       Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
                     </Editor.Text>
                 </Editor>
             </Border>

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/SelectAllTextBehaviorPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/SelectAllTextBehaviorPage.xaml
@@ -26,7 +26,7 @@
 
 
             <Label FontAttributes="Italic" Text="Entry without the effect, when focused no text will be selected" />
-            <Border BackgroundColor="{StaticResource SoftFrameBackgroundColor}" >
+            <Border BackgroundColor="{StaticResource SoftBorderBackgroundColor}" >
                 <Entry
 					BackgroundColor="{StaticResource PrimaryColor}"
 					PlaceholderColor="{StaticResource DarkLabelPlaceholderColor}"
@@ -35,7 +35,7 @@
             </Border>
 
             <Label FontAttributes="Italic" Text="Entry with the effect, when focused all text will be selected" />
-            <Border BackgroundColor="{StaticResource SoftFrameBackgroundColor}" >
+            <Border BackgroundColor="{StaticResource SoftBorderBackgroundColor}" >
                 <Entry
 					BackgroundColor="{StaticResource PrimaryColor}"
 					PlaceholderColor="{StaticResource DarkLabelPlaceholderColor}"
@@ -53,7 +53,7 @@
 				TextColor="{StaticResource DarkLabelTextColor}" />
 
             <Label FontAttributes="Italic" Text="Editor without the effect, when focused no text will be selected" />
-            <Border BackgroundColor="{StaticResource SoftFrameBackgroundColor}" >
+            <Border BackgroundColor="{StaticResource SoftBorderBackgroundColor}" >
                 <Editor PlaceholderColor="{StaticResource DarkLabelPlaceholderColor}"
 						TextColor="{StaticResource DarkLabelTextColor}"
 						BackgroundColor="{StaticResource PrimaryColor}">
@@ -65,7 +65,7 @@
             </Border>
 
             <Label FontAttributes="Italic" Text="Editor with the effect, when focused all text will be selected" />
-            <Border BackgroundColor="{StaticResource SoftFrameBackgroundColor}" >
+            <Border BackgroundColor="{StaticResource SoftBorderBackgroundColor}" >
                 <Editor PlaceholderColor="{StaticResource DarkLabelPlaceholderColor}"
 						TextColor="{StaticResource DarkLabelTextColor}"
 						BackgroundColor="{StaticResource PrimaryColor}">

--- a/samples/CommunityToolkit.Maui.Sample/Resources/Styles/Colors.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Resources/Styles/Colors.xaml
@@ -14,7 +14,7 @@
     <Color x:Key="NormalLabelTextColor">#888888</Color>
     <Color x:Key="DarkLabelTextColor">#000000</Color>
     <Color x:Key="DarkLabelPlaceholderColor">#333d47</Color>
-    <Color x:Key="SoftFrameBackgroundColor">#ecf0f9</Color>
+    <Color x:Key="SoftBorderBackgroundColor">#ecf0f9</Color>
     <Color x:Key="StatusbarColor">#1976D2</Color>
     <Color x:Key="NavBarColor">#1976D2</Color>
 


### PR DESCRIPTION
### Description of Change ###

Updated the StaticResource set for the border, since it was preventing to navigate to the **SelectAllText** page on macOS only. It works on iOS, Android, and Windows as well.

The documentation has been created on the following PR: https://github.com/MicrosoftDocs/CommunityToolkit/pull/316

 ### Linked Issues ###

 - Fixes [#432](https://github.com/CommunityToolkit/Maui/issues/432) 

 ### PR Checklist ###
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [x] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/316 


 cc: @pictos @brminnick 
