### PR TITLE
Add redrawing of Snackbar and Toast when the screen is rotated

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Views/RoundedView.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/RoundedView.macios.cs
@@ -55,6 +55,13 @@ public class RoundedView : UIView
 		Layer.MasksToBounds = true;
 	}
 
+	/// <inheritdoc />
+	public override void LayoutSubviews()
+	{
+		base.LayoutSubviews();
+		Draw(Frame);
+	}
+
 	static CGPath? GetRoundedPath(CGRect rect, NFloat left, NFloat top, NFloat right, NFloat bottom)
 	{
 		var path = new UIBezierPath();


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

This PR resolves the issue where when a long message that does not include a line feed code is specified for Snackbar and Toast, it is not drawn correctly after the screen is rotated.

 ### Description of Change ###

Override the LayoutSubviews method of the RoundedView class that draws the Snackbar and Toast background and call the Draw method so that the Snackbar and Toast are redrawn after the screen is rotated.

[src\CommunityToolkit.Maui.Core\Views\RoundedView.macios.cs]

    /// <inheritdoc />
    public override void LayoutSubviews()
    {
        base.LayoutSubviews();
        Draw(Frame);
    }

This will cause Snackbar and Toast to be redrawn after the screen is rotated, so they will be drawn at the intended size.
This also resolves the issue where the corner shapes of Snackbar and Toast appear to have changed without being redrawn.

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #1404

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###

Below are the verification results after fix.

[Snackbar]

<table>
  <tr>
    <td>[Before Rotation]</td>
    <td>[After Rotation]</td>
  </tr>
  <tr>
    <td><img width="250" src="https://github.com/CommunityToolkit/Maui/assets/125236133/6633618c-f949-4fd0-97e1-7b775c9fefe4" /></td>
    <td><img width="250" src="https://github.com/CommunityToolkit/Maui/assets/125236133/06078e0e-6738-44b1-9800-1191ada53434" /></td>
  </tr>
</table>

[Toast]

<table>
  <tr>
    <td>[Before Rotation]</td>
    <td>[After Rotation]</td>
  </tr>
  <tr>
    <td><img width="250" src="https://github.com/CommunityToolkit/Maui/assets/125236133/236267a2-a9da-49aa-b566-86986e10b3d1" /></td>
    <td><img width="250" src="https://github.com/CommunityToolkit/Maui/assets/125236133/fe501229-6505-44e1-b1ad-758b33adcfa7" /></td>
  </tr>
</table>

In both execution results, you can see that the Snackbar and Toast are drawn at the intended size after the screen is rotated.

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
