### PR TITLE
[MacCatalyst] Get correct window associated with the Popup

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
@@ -116,7 +116,7 @@ public class MauiPopup : UIViewController
 	/// <returns>The UIViewController that is hosting the <i>element.Parent</i> view or <i>null</i> if UIViewController cannot be located.</returns>
 	UIViewController? GetUIViewControllerHostingPopupParentElement(IPopup element)
 	{
-		var scenes = UIApplication.SharedApplication.ConnectedScenes.OfType<UIWindowScene>().ToList();
+		var scenes = UIApplication.SharedApplication.ConnectedScenes.OfType<UIWindowScene>();
 
 		foreach (var scene in scenes)
 		{

--- a/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
@@ -97,48 +97,11 @@ public class MauiPopup : UIViewController
 
 		UIViewController? rootViewController;
 
-#if MACCATALYST
-		var popupParentElementUIViewController = GetUIViewControllerHostingPopupParentElement(element);
-		rootViewController = popupParentElementUIViewController ?? WindowStateManager.Default.GetCurrentUIViewController() ?? throw new InvalidOperationException($"{nameof(PageHandler.ViewController)} cannot be null.");
-#else
-		rootViewController = WindowStateManager.Default.GetCurrentUIViewController() ?? throw new InvalidOperationException($"{nameof(PageHandler.ViewController)} cannot be null.");
-#endif
-
+		var pagehandler = VirtualView.Parent.Handler as PageHandler;
+		rootViewController = pagehandler?.ViewController ?? WindowStateManager.Default.GetCurrentUIViewController() ?? throw new InvalidOperationException($"{nameof(PageHandler.ViewController)} cannot be null.");
 		ViewController ??= rootViewController;
 		SetDimmingBackgroundEffect();
 	}
-
-#if MACCATALYST
-	/// <summary>
-	/// The <see cref="IPopup"/> is associated to a view (e.g. ContentPage). Use this method to locate the UIViewController in the native application that is hosting that view.
-	/// </summary>
-	/// <param name="element">An instance of <see cref="IPopup"/>.</param>
-	/// <returns>The UIViewController that is hosting the <i>element.Parent</i> view or <i>null</i> if UIViewController cannot be located.</returns>
-	UIViewController? GetUIViewControllerHostingPopupParentElement(IPopup element)
-	{
-		var scenes = UIApplication.SharedApplication.ConnectedScenes.OfType<UIWindowScene>();
-
-		foreach (var scene in scenes)
-		{
-			foreach (var window in scene.Windows)
-			{
-				if (window.RootViewController is not Microsoft.Maui.Platform.ContainerViewController rootViewController)
-				{
-					continue;
-				}
-
-				var isViewMatching = rootViewController?.CurrentView == element.Parent;
-
-				if (isViewMatching)
-				{
-					return window.RootViewController;
-				}
-			}
-		}
-
-		return null;
-	}
-#endif
 
 	void SetDimmingBackgroundEffect()
 	{

--- a/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
@@ -95,10 +95,8 @@ public class MauiPopup : UIViewController
 		_ = View ?? throw new InvalidOperationException($"{nameof(View)} cannot be null.");
 		_ = VirtualView ?? throw new InvalidOperationException($"{nameof(VirtualView)} cannot be null.");
 
-		UIViewController? rootViewController;
-
 		var pagehandler = VirtualView.Parent.Handler as PageHandler;
-		rootViewController = pagehandler?.ViewController ?? WindowStateManager.Default.GetCurrentUIViewController() ?? throw new InvalidOperationException($"{nameof(PageHandler.ViewController)} cannot be null.");
+		var rootViewController = pagehandler?.ViewController ?? WindowStateManager.Default.GetCurrentUIViewController() ?? throw new InvalidOperationException($"{nameof(PageHandler.ViewController)} cannot be null.");
 		ViewController ??= rootViewController;
 		SetDimmingBackgroundEffect();
 	}


### PR DESCRIPTION
This PR solves an issue with where a MacCatalyst application has multi-windows enabled, but when creating a popup, it opens up to a random window instead of the correct one.

 ### Description of Change ###

There is an issue with this line of code:
`var rootViewController = WindowStateManager.Default.GetCurrentUIViewController() ?? throw new InvalidOperationException($"{nameof(PageHandler.ViewController)} cannot be null.");`

It assumes that the application will be in a single-window state (e.g. Shell app). However, with MacOS, apps [can also be multi-window applications](https://learn.microsoft.com/en-us/dotnet/maui/fundamentals/windows#multi-window-support).

This fix looks through all windows, locates its "View" (e.g. ContentPage), then compares it against the Parent View of the Popup. If it matches, then that is where the popup will display. Previously, it displayed on whatever window this method returned: `WindowStateManager.Default.GetCurrentUIViewController()`

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #1275 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [X] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [X] Rebased on top of `main` at time of PR (fresh fork, nothing to rebase)
 - [X] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###
With these code changes, the existing demo app still works without issues. When it comes to creating a demo for this fix, this would require a massive rewrite of the demo app, since the main UI is coded as a Shell app (single window).
 
