### PR TITLE
Add forced update of ScrollView on iOS

### DIFF
--- a/src/CommunityToolkit.Maui/Views/Expander/Expander.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Expander/Expander.shared.cs
@@ -251,6 +251,12 @@ public partial class Expander : ContentView, IExpander
 				ForceUpdateCellSize(collectionView, size, tapLocation);
 			}
 #endif
+#if IOS || MACCATALYST
+            else if (element is ScrollView scrollView)
+			{
+			    (scrollView as IView).InvalidateMeasure();
+			}
+#endif
 
 			element = element.Parent;
 		}

--- a/src/CommunityToolkit.Maui/Views/Expander/Expander.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Expander/Expander.shared.cs
@@ -254,7 +254,7 @@ public partial class Expander : ContentView, IExpander
 #if IOS || MACCATALYST
             else if (element is ScrollView scrollView)
 			{
-			    (scrollView as IView).InvalidateMeasure();
+			    ((IView)scrollView).InvalidateMeasure();
 			}
 #endif
 


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

This PR resolves the issue where the Expander tap does not work when the Expander is placed outside the display range of the ScrollView.

 ### Description of Change ###

Fixed to call InvalidateMeasure method if element.Parent is ScrollView.

[src\CommunityToolkit.Maui\Views\Expander\Expander.shared.cs]

    void ResizeExpanderInItemsView(TappedEventArgs tappedEventArgs)
    {
        if (Header is null)
        {
            return;
        }

        Element element = this;
        var size = IsExpanded
            ? Measure(double.PositiveInfinity, double.PositiveInfinity, MeasureFlags.IncludeMargins).Request
            : Header.Measure(double.PositiveInfinity, double.PositiveInfinity);

        while (element is not null)
        {
            if (element.Parent is ListView && element is Cell cell)
            {
    #if IOS || MACCATALYST
                throw new NotSupportedException($"{nameof(Expander)} is not yet supported in {nameof(ListView)}");
    #else
                cell.ForceUpdateSize();
    #endif
            }
    #if IOS || MACCATALYST || WINDOWS
            else if (element is CollectionView collectionView)
            {
                var tapLocation = tappedEventArgs.GetPosition(collectionView);
                ForceUpdateCellSize(collectionView, size, tapLocation);
            }
    #endif
    #if IOS || MACCATALYST
            else if (element is ScrollView scrollView)
            {
                (scrollView as IView).InvalidateMeasure();
            }
    #endif

            element = element.Parent;
        }
    }

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #1439

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
Below are the verification results.

https://github.com/CommunityToolkit/Maui/assets/125236133/2670b7de-85a1-4b2a-a95d-f302947f91ae

You can see that the Expander placed outside the visible range of the ScrollView is working.