### PR TITLE
Addition of size calculation for Label placed in Popup and correction of size calculation when Popup Size is not specified

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Views/Popup/PopupExtensions.android.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Popup/PopupExtensions.android.cs
@@ -2,7 +2,9 @@
 using Android.Graphics.Drawables;
 using Android.OS;
 using Android.Views;
+using AndroidX.AppCompat.Widget;
 using Microsoft.Maui.Platform;
+using static Android.Views.View;
 using AColorRes = Android.Resource.Color;
 using APoint = Android.Graphics.Point;
 using ARect = Android.Graphics.Rect;
@@ -174,14 +176,26 @@ public static class PopupExtensions
 			ArgumentNullException.ThrowIfNull(popup.Content);
 
 			var density = context.Resources?.DisplayMetrics?.Density ?? throw new InvalidOperationException($"Unable to determine density. {nameof(context.Resources.DisplayMetrics)} cannot be null");
+			var view = popup.Content.ToPlatform();
 
 			if (popup.Size.IsZero)
 			{
 				if (double.IsNaN(popup.Content.Width) || double.IsNaN(popup.Content.Height))
 				{
-					var size = popup.Content.Measure(windowSize.Width / density, windowSize.Height / density);
-					realContentWidth = (int)context.ToPixels(size.Width);
-					realContentHeight = (int)context.ToPixels(size.Height);
+					if (view is not null)
+					{
+						bool isRootView = true;
+						Measure(
+							view,
+							(int)(double.IsNaN(popup.Content.Width) ? windowSize.Width : (int)context.ToPixels(popup.Content.Width)),
+							(int)(double.IsNaN(popup.Content.Height) ? windowSize.Height : (int)context.ToPixels(popup.Content.Height)),
+							double.IsNaN(popup.Content.Width) && popup.HorizontalOptions != LayoutAlignment.Fill,
+							double.IsNaN(popup.Content.Height) && popup.VerticalOptions != LayoutAlignment.Fill,
+							ref isRootView
+						);
+						realContentWidth = view.MeasuredWidth;
+						realContentHeight = view.MeasuredHeight;
+					}
 
 					if (double.IsNaN(popup.Content.Width))
 					{
@@ -200,12 +214,20 @@ public static class PopupExtensions
 			}
 			else
 			{
-				realWidth = (int)context.ToPixels(popup.Size.Width);
-				realHeight = (int)context.ToPixels(popup.Size.Height);
-
-				var size = popup.Content.Measure(popup.Size.Width, popup.Size.Height);
-				realContentWidth = (int)context.ToPixels(size.Width);
-				realContentHeight = (int)context.ToPixels(size.Height);
+				if (view is not null)
+				{
+					bool isRootView = true;
+					Measure(
+						view,
+						(int)context.ToPixels(popup.Size.Width),
+						(int)context.ToPixels(popup.Size.Height),
+						false,
+						false,
+						ref isRootView
+					);
+					realContentWidth = view.MeasuredWidth;
+					realContentHeight = view.MeasuredHeight;
+				}
 			}
 
 			realWidth = Math.Min(realWidth is 0 ? realContentWidth : realWidth, (int)windowSize.Width);
@@ -215,6 +237,40 @@ public static class PopupExtensions
 			{
 				realWidth = (int)(context.Resources?.DisplayMetrics?.WidthPixels * 0.8 ?? throw new InvalidOperationException($"Unable to determine width. {nameof(context.Resources.DisplayMetrics)} cannot be null"));
 				realHeight = (int)(context.Resources?.DisplayMetrics?.HeightPixels * 0.6 ?? throw new InvalidOperationException($"Unable to determine height. {nameof(context.Resources.DisplayMetrics)} cannot be null"));
+			}
+		}
+
+		static void Measure(AView view, int width, int height, bool isNanWidth, bool isNanHeight, ref bool isRootView)
+		{
+			if (isRootView)
+			{
+				isRootView = false;
+				view.Measure(
+					MeasureSpec.MakeMeasureSpec(width, !isNanWidth ? MeasureSpecMode.Exactly : MeasureSpecMode.AtMost),
+					MeasureSpec.MakeMeasureSpec(height, !isNanHeight ? MeasureSpecMode.Exactly : MeasureSpecMode.AtMost)
+				);
+			}
+
+			if (view is AppCompatTextView)
+			{
+				// https://github.com/dotnet/maui/issues/2019
+				// https://github.com/dotnet/maui/pull/2059
+				var layoutParams = view.LayoutParameters;
+				view.Measure(
+					MeasureSpec.MakeMeasureSpec(width, (layoutParams?.Width == LinearLayout.LayoutParams.WrapContent && !isNanWidth) ? MeasureSpecMode.Exactly : MeasureSpecMode.Unspecified),
+					MeasureSpec.MakeMeasureSpec(height, (layoutParams?.Height == LinearLayout.LayoutParams.WrapContent && !isNanHeight) ? MeasureSpecMode.Exactly : MeasureSpecMode.Unspecified)
+				);
+			}
+
+			if (view is ViewGroup viewGroup)
+			{
+				for (int i = 0; i < viewGroup.ChildCount; i++)
+				{
+					if (viewGroup.GetChildAt(i) is AView childView)
+					{
+						Measure(childView, width, height, isNanWidth, isNanHeight, ref isRootView);
+					}
+				}
 			}
 		}
 

--- a/src/CommunityToolkit.Maui.Core/Views/Popup/PopupExtensions.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Popup/PopupExtensions.macios.cs
@@ -43,7 +43,7 @@ public static class PopupExtensions
 			if (double.IsNaN(popup.Content.Width) || double.IsNaN(popup.Content.Height))
 			{
 				var content = popup.Content.ToPlatform(popup.Handler?.MauiContext ?? throw new InvalidOperationException($"{nameof(popup.Handler.MauiContext)} Cannot Be Null"));
-				var contentSize = content.SizeThatFits(new CGSize(frame.Width, frame.Height));
+				var contentSize = content.SizeThatFits(new CGSize(double.IsNaN(popup.Content.Width) ? frame.Width : popup.Content.Width, double.IsNaN(popup.Content.Height) ? frame.Height : popup.Content.Height));
 				var width = contentSize.Width;
 				var height = contentSize.Height;
 

--- a/src/CommunityToolkit.Maui.Core/Views/Popup/PopupExtensions.windows.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Popup/PopupExtensions.windows.cs
@@ -79,7 +79,7 @@ public static class PopupExtensions
 		{
 			if (double.IsNaN(popup.Content.Width) || (double.IsNaN(popup.Content.Height)))
 			{
-				currentSize = popup.Content.Measure(popupParent.Bounds.Width, popupParent.Bounds.Height);
+				currentSize = popup.Content.Measure(double.IsNaN(popup.Content.Width) ? popupParent.Bounds.Width : popup.Content.Width, double.IsNaN(popup.Content.Height) ? popupParent.Bounds.Height : popup.Content.Height);
 
 				if (double.IsNaN(popup.Content.Width))
 				{


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

This PR will correct the following:
1. Correct so that VerticalTextAlignment and HorizontalTextAlignment function correctly when a label is placed in the Popup's content.
2. When Popup Size is not specified and WidthRequest and HeightRequest of Popup Content are specified, change the Popup so that it is displayed at the intended size.

 ### Description of Change ###

Below is the first change.

[src\CommunityToolkit.Maui.Core\Views\Popup\PopupExtensions.android.cs]

    static void Measure(AView view, int width, int height, bool isNanWidth, bool isNanHeight, ref bool isRootView)
    {
        if (isRootView)
        {
            isRootView = false;
            view.Measure(
                MeasureSpec.MakeMeasureSpec(width, !isNanWidth ? MeasureSpecMode.Exactly : MeasureSpecMode.AtMost),
                MeasureSpec.MakeMeasureSpec(height, !isNanHeight ? MeasureSpecMode.Exactly : MeasureSpecMode.AtMost)
            );
        }

        if (view is AppCompatTextView)
        {
            // https://github.com/dotnet/maui/issues/2019
            // https://github.com/dotnet/maui/pull/2059
            var layoutParams = view.LayoutParameters;
            view.Measure(
                MeasureSpec.MakeMeasureSpec(width, (layoutParams?.Width == LinearLayout.LayoutParams.WrapContent && !isNanWidth) ? MeasureSpecMode.Exactly : MeasureSpecMode.Unspecified),
                MeasureSpec.MakeMeasureSpec(height, (layoutParams?.Height == LinearLayout.LayoutParams.WrapContent && !isNanHeight) ? MeasureSpecMode.Exactly : MeasureSpecMode.Unspecified)
            );
        }

        if (view is ViewGroup viewGroup)
        {
            for (int i = 0; i < viewGroup.ChildCount; i++)
            {
                if (viewGroup.GetChildAt(i) is AView childView)
                {
                    Measure(childView, width, height, isNanWidth, isNanHeight, ref isRootView);
                }
            }
        }
    }

    static void CalculateSizes(IPopup popup, Context context, Size windowSize, ref int realWidth, ref int realHeight, ref int realContentWidth, ref int realContentHeight)
    {
        ArgumentNullException.ThrowIfNull(popup.Content);

        var density = context.Resources?.DisplayMetrics?.Density ?? throw new InvalidOperationException($"Unable to determine density. {nameof(context.Resources.DisplayMetrics)} cannot be null");
        var view = popup.Content.ToPlatform();

        if (popup.Size.IsZero)
        {
            if (double.IsNaN(popup.Content.Width) || double.IsNaN(popup.Content.Height))
            {
                if (view is not null)
                {
                    bool isRootView = true;
                    Measure(
                        view,
                        (int)(double.IsNaN(popup.Content.Width) ? windowSize.Width : (int)context.ToPixels(popup.Content.Width)),
                        (int)(double.IsNaN(popup.Content.Height) ? windowSize.Height : (int)context.ToPixels(popup.Content.Height)),
                        double.IsNaN(popup.Content.Width) && popup.HorizontalOptions != LayoutAlignment.Fill,
                        double.IsNaN(popup.Content.Height) && popup.VerticalOptions != LayoutAlignment.Fill,
                        ref isRootView
                    );
                    realContentWidth = view.MeasuredWidth;
                    realContentHeight = view.MeasuredHeight;
                }

                if (double.IsNaN(popup.Content.Width))
                {
                    realContentWidth = popup.HorizontalOptions == LayoutAlignment.Fill ? (int)windowSize.Width : realContentWidth;
                }
                if (double.IsNaN(popup.Content.Height))
                {
                    realContentHeight = popup.VerticalOptions == LayoutAlignment.Fill ? (int)windowSize.Height : realContentHeight;
                }
            }
            else
            {
                realContentWidth = (int)context.ToPixels(popup.Content.Width);
                realContentHeight = (int)context.ToPixels(popup.Content.Height);
            }
        }
        else
        {
            if (view is not null)
            {
                bool isRootView = true;
                Measure(
                    view,
                    (int)context.ToPixels(popup.Size.Width),
                    (int)context.ToPixels(popup.Size.Height),
                    false,
                    false,
                    ref isRootView
                );
                realContentWidth = view.MeasuredWidth;
                realContentHeight = view.MeasuredHeight;
            }
        }

        realWidth = Math.Min(realWidth is 0 ? realContentWidth : realWidth, (int)windowSize.Width);
        realHeight = Math.Min(realHeight is 0 ? realContentHeight : realHeight, (int)windowSize.Height);

        if (realHeight is 0 || realWidth is 0)
        {
            realWidth = (int)(context.Resources?.DisplayMetrics?.WidthPixels * 0.8 ?? throw new InvalidOperationException($"Unable to determine width. {nameof(context.Resources.DisplayMetrics)} cannot be null"));
            realHeight = (int)(context.Resources?.DisplayMetrics?.HeightPixels * 0.6 ?? throw new InvalidOperationException($"Unable to determine height. {nameof(context.Resources.DisplayMetrics)} cannot be null"));
        }
    }

It has been reported in .NET MAUI Issue [#2019](https://github.com/dotnet/maui/issues/2019) that on Android, VerticalTextAlignment and HorizontalTextAlignment do not work when Fill is specified for LayoutAlignment.
In PR [#2059](https://github.com/dotnet/maui/pull/2059), the issue is resolved by calling the Measure method with MeasureSpecMode.Exactly specified as the Measure method argument. To accomplish the same thing, I defined a new Measure method and called it.

Below is the second change.

[src\CommunityToolkit.Maui.Core\Views\Popup\PopupExtensions.android.cs]

    static void CalculateSizes(IPopup popup, Context context, Size windowSize, ref int realWidth, ref int realHeight, ref int realContentWidth, ref int realContentHeight)
    {
        ArgumentNullException.ThrowIfNull(popup.Content);

        var density = context.Resources?.DisplayMetrics?.Density ?? throw new InvalidOperationException($"Unable to determine density. {nameof(context.Resources.DisplayMetrics)} cannot be null");
        var view = popup.Content.ToPlatform();

        if (popup.Size.IsZero)
        {
            if (double.IsNaN(popup.Content.Width) || double.IsNaN(popup.Content.Height))
            {
                if (view is not null)
                {
                    bool isRootView = true;
                    Measure(
                        view,
                        (int)(double.IsNaN(popup.Content.Width) ? windowSize.Width : (int)context.ToPixels(popup.Content.Width)),
                        (int)(double.IsNaN(popup.Content.Height) ? windowSize.Height : (int)context.ToPixels(popup.Content.Height)),
                        double.IsNaN(popup.Content.Width) && popup.HorizontalOptions != LayoutAlignment.Fill,
                        double.IsNaN(popup.Content.Height) && popup.VerticalOptions != LayoutAlignment.Fill,
                        ref isRootView
                    );
                    realContentWidth = view.MeasuredWidth;
                    realContentHeight = view.MeasuredHeight;
                }

                if (double.IsNaN(popup.Content.Width))
                {
                    realContentWidth = popup.HorizontalOptions == LayoutAlignment.Fill ? (int)windowSize.Width : realContentWidth;
                }
                if (double.IsNaN(popup.Content.Height))
                {
                    realContentHeight = popup.VerticalOptions == LayoutAlignment.Fill ? (int)windowSize.Height : realContentHeight;
                }
            }
            else
            {
                realContentWidth = (int)context.ToPixels(popup.Content.Width);
                realContentHeight = (int)context.ToPixels(popup.Content.Height);
            }
        }
        else
        {
            ... omit
        }
        ... omit
    }

[src\CommunityToolkit.Maui.Core\Views\Popup\PopupExtensions.macios.cs]

    public static void SetSize(this MauiPopup mauiPopup, in IPopup popup)
    {
        ArgumentNullException.ThrowIfNull(popup.Content);

        CGRect frame;

        if (mauiPopup.ViewController?.View?.Window is UIWindow window)
        {
            frame = window.Frame;
        }
        else
        {
            frame = UIScreen.MainScreen.Bounds;
        }

        CGSize currentSize;

        if (popup.Size.IsZero)
        {
            if (double.IsNaN(popup.Content.Width) || double.IsNaN(popup.Content.Height))
            {
                var content = popup.Content.ToPlatform(popup.Handler?.MauiContext ?? throw new InvalidOperationException($"{nameof(popup.Handler.MauiContext)} Cannot Be Null"));
                var contentSize = content.SizeThatFits(new CGSize(double.IsNaN(popup.Content.Width) ? frame.Width : popup.Content.Width, double.IsNaN(popup.Content.Height) ? frame.Height : popup.Content.Height));
                var width = contentSize.Width;
                var height = contentSize.Height;

                if (double.IsNaN(popup.Content.Width))
                {
                    width = popup.HorizontalOptions == Microsoft.Maui.Primitives.LayoutAlignment.Fill ? frame.Size.Width : width;
                }
                if (double.IsNaN(popup.Content.Height))
                {
                    height = popup.VerticalOptions == Microsoft.Maui.Primitives.LayoutAlignment.Fill ? frame.Size.Height : height;
                }

                currentSize = new CGSize(width, height);
            }
            else
            {
                currentSize = new CGSize(popup.Content.Width, popup.Content.Height);
            }
        }
        else
        {
            currentSize = new CGSize(popup.Size.Width, popup.Size.Height);
        }

    #if MACCATALYST
        currentSize.Width = NMath.Min(currentSize.Width, frame.Size.Width - defaultPopoverLayoutMargin * 2 - popupMargin * 2);
        currentSize.Height = NMath.Min(currentSize.Height, frame.Size.Height - defaultPopoverLayoutMargin * 2 - popupMargin * 2);
    #else
        currentSize.Width = NMath.Min(currentSize.Width, frame.Size.Width);
        currentSize.Height = NMath.Min(currentSize.Height, frame.Size.Height);
    #endif
        mauiPopup.PreferredContentSize = currentSize;
    }

[src\CommunityToolkit.Maui.Core\Views\Popup\PopupExtensions.windows.cs]

    public static void SetSize(this Popup mauiPopup, IPopup popup, IMauiContext? mauiContext)
    {
        ArgumentNullException.ThrowIfNull(mauiContext);
        ArgumentNullException.ThrowIfNull(popup.Content);

        const double defaultBorderThickness = 0;
        const double defaultSize = 600;

        var popupParent = mauiContext.GetPlatformWindow();
        var currentSize = new Size { Width = defaultSize, Height = defaultSize / 2 };

        if (popup.Size.IsZero)
        {
            if (double.IsNaN(popup.Content.Width) || (double.IsNaN(popup.Content.Height)))
            {
                currentSize = popup.Content.Measure(double.IsNaN(popup.Content.Width) ? popupParent.Bounds.Width : popup.Content.Width, double.IsNaN(popup.Content.Height) ? popupParent.Bounds.Height : popup.Content.Height);

                if (double.IsNaN(popup.Content.Width))
                {
                    currentSize.Width = popup.HorizontalOptions == LayoutAlignment.Fill ? popupParent.Bounds.Width : currentSize.Width;
                }
                if (double.IsNaN(popup.Content.Height))
                {
                    currentSize.Height = popup.VerticalOptions == LayoutAlignment.Fill ? popupParent.Bounds.Height : currentSize.Height;
                }
            }
            else
            {
                currentSize.Width = popup.Content.Width;
                currentSize.Height = popup.Content.Height;
            }
        }
        else
        {
            currentSize.Width = popup.Size.Width;
            currentSize.Height = popup.Size.Height;
        }

        currentSize.Width = Math.Min(currentSize.Width, popupParent.Bounds.Width);
        currentSize.Height = Math.Min(currentSize.Height, popupParent.Bounds.Height);

        mauiPopup.Width = currentSize.Width;
        mauiPopup.Height = currentSize.Height;
        mauiPopup.MinWidth = mauiPopup.MaxWidth = currentSize.Width + (defaultBorderThickness * 2);
        mauiPopup.MinHeight = mauiPopup.MaxHeight = currentSize.Height + (defaultBorderThickness * 2);

        if (mauiPopup.Child is FrameworkElement control)
        {
            control.Width = mauiPopup.Width;
            control.Height = mauiPopup.Height;
        }
    }

Fixed the width and height passed when calling the Measure method when the Popup size is unspecified.
If the Popup size is unspecified and the Popup Content Size is unspecified, the screen size is passed. If the Popup size is unspecified and the Popup Content size is specified, the Popup Content size is passed. I have modified it as follows.

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #1450

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/XYZ <!-- Replace XYZ with your docs PR #. The checkbox will be automatically checked once the docs PR has been merged -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
Below are the verification results for the first modification.

I tested it with the following layout.

    <toolkit:Popup xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
        xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
        x:Class="MauiComm_VerityPopupSize.PopupPage1"
        Size="320,240"
        Color="Transparent">
        <Grid>
            <Label Text="Hello, World!" FontSize="32" BackgroundColor="LightBlue" VerticalTextAlignment="Center"  HorizontalTextAlignment="Center" />
            <Button Text="Click me" VerticalOptions="Start" HorizontalOptions="Center" />
        </Grid>
    </toolkit:Popup>

These are the execution results for each platform.

<table>
  <tr>
    <td>[Android]</td>
    <td>[iOS]</td>
    <td>[Windows]</td>
  </tr>
  <tr>
    <td><img width="250" src="https://github.com/CommunityToolkit/Maui/assets/125236133/ed36f88d-d2b9-4bf3-9b4f-851fae961d60" /></td>
    <td><img width="250" src="https://github.com/CommunityToolkit/Maui/assets/125236133/d09638ee-5cf7-45fa-b90e-e2957e59c677" /></td>
    <td><img width="250" src="https://github.com/CommunityToolkit/Maui/assets/125236133/314d5725-5731-486e-96b7-151fe0cd916f" /></td>
  </tr>
</table>

You can see that the Popup is displayed as expected on all platforms.

Below are the verification results for the second modification.

I tested it with the following layout.

    <toolkit:Popup xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
        xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
        x:Class="MauiComm_VerityPopupSize.PopupPage1"
        Color="Transparent">
        <Grid WidthRequest="320">
            <Label Text="Hello, World!" FontSize="32" BackgroundColor="LightBlue" VerticalTextAlignment="Center"  HorizontalTextAlignment="Center" />
            <Button Text="Click me" VerticalOptions="Start" HorizontalOptions="Center" />
        </Grid>
    </toolkit:Popup>

These are the execution results for each platform.

<table>
  <tr>
    <td>[Android]</td>
    <td>[iOS]</td>
    <td>[Windows]</td>
  </tr>
  <tr>
    <td><video controls width="250" src="https://github.com/CommunityToolkit/Maui/assets/125236133/73eee32d-56d8-4f92-92f5-ecdd6291d51d" /></td>
    <td><video controls width="250" src="https://github.com/CommunityToolkit/Maui/assets/125236133/7c8765c8-410d-4ad8-9aa2-e9f4b92bf8cf" /></td>
    <td><video controls width="250" src="https://github.com/CommunityToolkit/Maui/assets/125236133/c5f0106c-4d41-4696-ae7d-62d7b7e34457" /></td>
  </tr>
</table>

I tested it with the following layout.

    <toolkit:Popup xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
        xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
        x:Class="MauiComm_VerityPopupSize.PopupPage1"
        Color="Transparent">
        <Grid HeightRequest="240">
            <Label Text="Hello, World!" FontSize="32" BackgroundColor="LightBlue" VerticalTextAlignment="Center"  HorizontalTextAlignment="Center" />
            <Button Text="Click me" VerticalOptions="Start" HorizontalOptions="Center" />
        </Grid>
    </toolkit:Popup>

These are the execution results for each platform.

<table>
  <tr>
    <td>[Android]</td>
    <td>[iOS]</td>
    <td>[Windows]</td>
  </tr>
  <tr>
    <td><video controls width="250" src="https://github.com/CommunityToolkit/Maui/assets/125236133/c9ef375c-2623-49c1-8856-501726d5b214" /></td>
    <td><video controls width="250" src="https://github.com/CommunityToolkit/Maui/assets/125236133/d2164665-e07e-4fc7-90fd-2c64b9060df3" /></td>
    <td><video controls width="250" src="https://github.com/CommunityToolkit/Maui/assets/125236133/b20fc96a-7899-4ad0-9a99-057e551654f2" /></td>
  </tr>
</table>

You can see that the Popup is displayed as expected on all platforms.

Finally, the results of verification that there is no impact on PRs created so far are shown below.

I tested it with the following layout. [Confirm Issue #1423]

    <toolkit:Popup xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
        xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
        Size="300,300"
        HorizontalOptions="Center"
        VerticalOptions="Center"
        x:Class="MauiComm_VerityPopupSize.PopupPage4">

        <Grid>
            <Grid ColumnDefinitions="*" RowDefinitions="auto,auto,auto" >
                <Label x:Name="testlabel1" BackgroundColor="Red" HorizontalTextAlignment="Center" />
                <Label x:Name="testlabel2" Grid.Row="1" />

                <VerticalStackLayout Grid.Row="2" Spacing="4">
                    <Label x:Name="testlabel3" BackgroundColor="Red" HorizontalTextAlignment="Center"></Label>
                    <Label x:Name="testlabel4"></Label>
                </VerticalStackLayout>
            </Grid>

            <Grid WidthRequest="10" HeightRequest="10" BackgroundColor="Blue" VerticalOptions="Start" HorizontalOptions="Start" />
            <Grid WidthRequest="10" HeightRequest="10" BackgroundColor="Blue" VerticalOptions="Start" HorizontalOptions="End" />
            <Grid WidthRequest="10" HeightRequest="10" BackgroundColor="Blue" VerticalOptions="End" HorizontalOptions="Start" />
            <Grid WidthRequest="10" HeightRequest="10" BackgroundColor="Blue" VerticalOptions="End" HorizontalOptions="End" />
        </Grid>
    </toolkit:Popup>

These are the execution results for each platform.

<table>
  <tr>
    <td>[Android]</td>
    <td>[iOS]</td>
    <td>[Windows]</td>
  </tr>
  <tr>
    <td><img width="250" src="https://github.com/CommunityToolkit/Maui/assets/125236133/06501143-b43f-478a-89ff-97838d7615ba" /></td>
    <td><img width="250" src="https://github.com/CommunityToolkit/Maui/assets/125236133/f1d0d4b2-c15a-4d8e-9412-34313f48e62e" /></td>
    <td><img width="250" src="https://github.com/CommunityToolkit/Maui/assets/125236133/965caeac-f493-4d98-9bf9-0879a0f9beb0" /></td>
  </tr>
</table>

I tested it with the following layout. [Confirm Issue #1353]

    <toolkit:Popup xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
        xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
        x:Class="MauiComm_VerityPopupSize.PopupPage5">

        <VerticalStackLayout>
            <Label Text="Popup" FontSize="20"/>
            <BoxView HeightRequest="3" Color="AliceBlue" />
            <Label x:Name="txt1" Text="Short String" />
            <Label x:Name="txt2" Text="Long String1 Long String2 Long String3 Long String4 Long String5 Long String6 Long String7 Long String8 Long String9 Long String10 Long String" />
        </VerticalStackLayout>
    </toolkit:Popup>

These are the execution results for each platform.

<table>
  <tr>
    <td>[Android]</td>
    <td>[iOS]</td>
    <td>[Windows]</td>
  </tr>
  <tr>
    <td><img width="250" src="https://github.com/CommunityToolkit/Maui/assets/125236133/803eb81a-e7d1-448a-93f2-03faa21e9ab3" /></td>
    <td><img width="250" src="https://github.com/CommunityToolkit/Maui/assets/125236133/5f50da04-ad5d-44b8-b141-c57a3088d292" /></td>
    <td><img width="250" src="https://github.com/CommunityToolkit/Maui/assets/125236133/805d9e7f-acc3-46a5-b132-02c42c262547" /></td>
  </tr>
</table>

I tested it with the following layout. [Confirm PR #1361]

    <toolkit:Popup xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
        xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
        x:Class="MauiComm_VerityPopupSize.PopupPage2">
        <Grid>
            <Label Text="1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ" TextColor="Black" HorizontalOptions="Start" />
        </Grid>
    </toolkit:Popup>

These are the execution results for each platform.

<table>
  <tr>
    <td>[Android]</td>
    <td>[iOS]</td>
    <td>[Windows]</td>
  </tr>
  <tr>
    <td><video controls width="250" src="https://github.com/CommunityToolkit/Maui/assets/125236133/c9f71930-84c8-4e45-965d-32e65c62f5fa" /></td>
    <td><video controls width="250" src="https://github.com/CommunityToolkit/Maui/assets/125236133/bd6e5bd5-95a5-45a7-9add-f7c332c5a051" /></td>
    <td><video controls width="250" src="https://github.com/CommunityToolkit/Maui/assets/125236133/29cf1908-b8e4-4ed0-b473-ddd2d11d4212" /></td>
  </tr>
</table>

You can see that the Popup is displayed as expected on all platforms.