### PR TITLE
Fix a bug when specifying an Popup's Anchor on Windows

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Views/Popup/PopupExtensions.windows.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Popup/PopupExtensions.windows.cs
@@ -138,7 +138,11 @@ public static class PopupExtensions
 
 		var verticalOptions = popup.VerticalOptions;
 		var horizontalOptions = popup.HorizontalOptions;
-		if (IsTopLeft(verticalOptions, horizontalOptions))
+		if (popup.Anchor is not null)
+		{
+			mauiPopup.DesiredPlacement = PopupPlacementMode.Top;
+		}
+		else if (IsTopLeft(verticalOptions, horizontalOptions))
 		{
 			mauiPopup.DesiredPlacement = PopupPlacementMode.TopEdgeAlignedLeft;
 			mauiPopup.HorizontalOffset = (popupParentFrame.Width - popupParentFrame.Width * horizontalOptionsPositiveNegativeMultiplier) / 2;
@@ -234,15 +238,11 @@ public static class PopupExtensions
 			mauiPopup.HorizontalOffset = (popupParentFrame.Width - contentSize.Width * horizontalOptionsPositiveNegativeMultiplier) / 2;
 			mauiPopup.VerticalOffset = (popupParentFrame.Height - contentSize.Height) / 2;
 		}
-		else if (popup.Anchor is null)
+		else
 		{
 			mauiPopup.DesiredPlacement = PopupPlacementMode.Auto;
 			mauiPopup.HorizontalOffset = (popupParentFrame.Width - contentSize.Width * horizontalOptionsPositiveNegativeMultiplier) / 2;
 			mauiPopup.VerticalOffset = (popupParentFrame.Height - contentSize.Height) / 2;
-		}
-		else
-		{
-			mauiPopup.DesiredPlacement = PopupPlacementMode.Top;
 		}
 
 		static bool IsTopLeft(LayoutAlignment verticalOptions, LayoutAlignment horizontalOptions) => verticalOptions == LayoutAlignment.Start && horizontalOptions == LayoutAlignment.Start;


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

This PR resolves the issue where Popup is not displayed near the anchor when specifying Popup anchor.

 ### Description of Change ###

When I corrected the [popup's display position and size](https://github.com/CommunityToolkit/Maui/commit/22b158aa77b3763e5ef145fd7a1ca2d034176e21), I did not give top priority to the conditional branch when Anchor was specified, so the conditional branch when VerticalOptions and HorizontalOptions were specified took priority. This is my mistake, sorry.

I modified the conditional branch as follows.

[src\CommunityToolkit.Maui.Core\Views\Popup\PopupExtensions.windows.cs]

    public static void SetLayout(this Popup mauiPopup, IPopup popup, IMauiContext? mauiContext)
    {
        ArgumentNullException.ThrowIfNull(mauiContext);
        ArgumentNullException.ThrowIfNull(popup.Content);

        var popupParent = mauiContext.GetPlatformWindow();
        popup.Content.Measure(double.PositiveInfinity, double.PositiveInfinity);
        var contentSize = popup.Content.ToPlatform(mauiContext).DesiredSize;
        var popupParentFrame = popupParent.Bounds;

        var isFlowDirectionRightToLeft = popup.Content?.FlowDirection == Microsoft.Maui.FlowDirection.RightToLeft;
        var horizontalOptionsPositiveNegativeMultiplier = isFlowDirectionRightToLeft ? -1 : 1;

        var verticalOptions = popup.VerticalOptions;
        var horizontalOptions = popup.HorizontalOptions;
        if (popup.Anchor is not null)
        {
            mauiPopup.DesiredPlacement = PopupPlacementMode.Top;
        }
        else if (IsTopLeft(verticalOptions, horizontalOptions))
        {
            mauiPopup.DesiredPlacement = PopupPlacementMode.TopEdgeAlignedLeft;
            mauiPopup.HorizontalOffset = (popupParentFrame.Width - popupParentFrame.Width * horizontalOptionsPositiveNegativeMultiplier) / 2;
            mauiPopup.VerticalOffset = 0;
        }
        else if (IsTop(verticalOptions, horizontalOptions))
        {
            mauiPopup.DesiredPlacement = PopupPlacementMode.Top;
            mauiPopup.HorizontalOffset = (popupParentFrame.Width - contentSize.Width * horizontalOptionsPositiveNegativeMultiplier) / 2;
            mauiPopup.VerticalOffset = 0;
        }
        else if (IsTopRight(verticalOptions, horizontalOptions))
        {
            mauiPopup.DesiredPlacement = PopupPlacementMode.TopEdgeAlignedRight;
            mauiPopup.HorizontalOffset = (popupParentFrame.Width + popupParentFrame.Width * horizontalOptionsPositiveNegativeMultiplier) / 2 - contentSize.Width * horizontalOptionsPositiveNegativeMultiplier;
            mauiPopup.VerticalOffset = 0;
        }
        else if (IsRight(verticalOptions, horizontalOptions))
        {
            mauiPopup.DesiredPlacement = PopupPlacementMode.Right;
            mauiPopup.HorizontalOffset = (popupParentFrame.Width + popupParentFrame.Width * horizontalOptionsPositiveNegativeMultiplier) / 2 - contentSize.Width * horizontalOptionsPositiveNegativeMultiplier;
            mauiPopup.VerticalOffset = (popupParentFrame.Height - contentSize.Height) / 2;
        }
        else if (IsBottomRight(verticalOptions, horizontalOptions))
        {
            mauiPopup.DesiredPlacement = PopupPlacementMode.BottomEdgeAlignedRight;
            mauiPopup.HorizontalOffset = (popupParentFrame.Width + popupParentFrame.Width * horizontalOptionsPositiveNegativeMultiplier) / 2 - contentSize.Width * horizontalOptionsPositiveNegativeMultiplier;
            mauiPopup.VerticalOffset = popupParentFrame.Height - contentSize.Height;
        }
        else if (IsBottom(verticalOptions, horizontalOptions))
        {
            mauiPopup.DesiredPlacement = PopupPlacementMode.Bottom;
            mauiPopup.HorizontalOffset = (popupParentFrame.Width - contentSize.Width * horizontalOptionsPositiveNegativeMultiplier) / 2;
            mauiPopup.VerticalOffset = popupParentFrame.Height - contentSize.Height;
        }
        else if (IsBottomLeft(verticalOptions, horizontalOptions))
        {
            mauiPopup.DesiredPlacement = PopupPlacementMode.BottomEdgeAlignedLeft;
            mauiPopup.HorizontalOffset = (popupParentFrame.Width - popupParentFrame.Width * horizontalOptionsPositiveNegativeMultiplier) / 2;
            mauiPopup.VerticalOffset = popupParentFrame.Height - contentSize.Height;
        }
        else if (IsLeft(verticalOptions, horizontalOptions))
        {
            mauiPopup.DesiredPlacement = PopupPlacementMode.Left;
            mauiPopup.HorizontalOffset = (popupParentFrame.Width - popupParentFrame.Width * horizontalOptionsPositiveNegativeMultiplier) / 2;
            mauiPopup.VerticalOffset = (popupParentFrame.Height - contentSize.Height) / 2;
        }
        else if (IsCenter(verticalOptions, horizontalOptions))
        {
            mauiPopup.DesiredPlacement = PopupPlacementMode.Auto;
            mauiPopup.HorizontalOffset = (popupParentFrame.Width - contentSize.Width * horizontalOptionsPositiveNegativeMultiplier) / 2;
            mauiPopup.VerticalOffset = (popupParentFrame.Height - contentSize.Height) / 2;
        }
        else if (IsFillLeft(verticalOptions, horizontalOptions))
        {
            mauiPopup.DesiredPlacement = PopupPlacementMode.Auto;
            mauiPopup.HorizontalOffset = (popupParentFrame.Width - popupParentFrame.Width * horizontalOptionsPositiveNegativeMultiplier) / 2;
            mauiPopup.VerticalOffset = (popupParentFrame.Height - contentSize.Height) / 2;
        }
        else if (IsFillCenter(verticalOptions, horizontalOptions))
        {
            mauiPopup.DesiredPlacement = PopupPlacementMode.Auto;
            mauiPopup.HorizontalOffset = (popupParentFrame.Width - contentSize.Width * horizontalOptionsPositiveNegativeMultiplier) / 2;
            mauiPopup.VerticalOffset = (popupParentFrame.Height - contentSize.Height) / 2;
        }
        else if (IsFillRight(verticalOptions, horizontalOptions))
        {
            mauiPopup.DesiredPlacement = PopupPlacementMode.Auto;
            mauiPopup.HorizontalOffset = (popupParentFrame.Width + popupParentFrame.Width * horizontalOptionsPositiveNegativeMultiplier) / 2 - contentSize.Width * horizontalOptionsPositiveNegativeMultiplier;
            mauiPopup.VerticalOffset = (popupParentFrame.Height - contentSize.Height) / 2;
        }
        else if (IsTopFill(verticalOptions, horizontalOptions))
        {
            mauiPopup.DesiredPlacement = PopupPlacementMode.Auto;
            mauiPopup.HorizontalOffset = (popupParentFrame.Width - contentSize.Width * horizontalOptionsPositiveNegativeMultiplier) / 2;
            mauiPopup.VerticalOffset = 0;
        }
        else if (IsCenterFill(verticalOptions, horizontalOptions))
        {
            mauiPopup.DesiredPlacement = PopupPlacementMode.Auto;
            mauiPopup.HorizontalOffset = (popupParentFrame.Width - contentSize.Width * horizontalOptionsPositiveNegativeMultiplier) / 2;
            mauiPopup.VerticalOffset = (popupParentFrame.Height - contentSize.Height) / 2;
        }
        else if (IsBottomFill(verticalOptions, horizontalOptions))
        {
            mauiPopup.DesiredPlacement = PopupPlacementMode.Auto;
            mauiPopup.HorizontalOffset = (popupParentFrame.Width - contentSize.Width * horizontalOptionsPositiveNegativeMultiplier) / 2;
            mauiPopup.VerticalOffset = popupParentFrame.Height - contentSize.Height;
        }
        else if (IsFill(verticalOptions, horizontalOptions))
        {
            mauiPopup.DesiredPlacement = PopupPlacementMode.Auto;
            mauiPopup.HorizontalOffset = (popupParentFrame.Width - contentSize.Width * horizontalOptionsPositiveNegativeMultiplier) / 2;
            mauiPopup.VerticalOffset = (popupParentFrame.Height - contentSize.Height) / 2;
        }
        else
        {
            mauiPopup.DesiredPlacement = PopupPlacementMode.Auto;
            mauiPopup.HorizontalOffset = (popupParentFrame.Width - contentSize.Width * horizontalOptionsPositiveNegativeMultiplier) / 2;
            mauiPopup.VerticalOffset = (popupParentFrame.Height - contentSize.Height) / 2;
        }
        ... omit
    }

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #1491

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###
Below are the verification results.

[With anchor specified]

https://github.com/CommunityToolkit/Maui/assets/125236133/c8119829-5dc1-4369-8e44-4803aad566b5

[When no anchor specified]

https://github.com/CommunityToolkit/Maui/assets/125236133/3ebfe00b-7374-4926-a02b-6582c4ae35f6

You can see that when specifying an anchor and when not specifying an anchor, both work as intended.
 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
