### PR TITLE
Fix `Popup.RemapForControls()`

### DIFF
--- a/src/CommunityToolkit.Maui/HandlerImplementation/Popup/Popup.shared.cs
+++ b/src/CommunityToolkit.Maui/HandlerImplementation/Popup/Popup.shared.cs
@@ -18,6 +18,5 @@ public partial class Popup
 	internal static new void RemapForControls()
 	{
 		PopupHandler.PopUpCommandMapper = ControlPopUpCommandMapper;
-		Element.RemapForControls();
 	}
 }

--- a/src/CommunityToolkit.Maui/HandlerImplementation/Popup/Popup.shared.cs
+++ b/src/CommunityToolkit.Maui/HandlerImplementation/Popup/Popup.shared.cs
@@ -15,8 +15,9 @@ public partial class Popup
 #endif
 	};
 
-	internal static void RemapForControls()
+	internal static new void RemapForControls()
 	{
 		PopupHandler.PopUpCommandMapper = ControlPopUpCommandMapper;
+		Element.RemapForControls();
 	}
 }


### PR DESCRIPTION
 ### Description of Change ###

In .NET 8, .NET MAUI added a new method to `Element` using the same method signature, `RemapForControls()`.

Since `Popup` inherits from `Element`, `Popup.RemapForControls()` is now unintentionally hiding `Element.RemapForControls()`.

https://github.com/dotnet/maui/blob/8e933a7a7a46fdb586918e7414345d978cb0878d/src/Controls/src/Core/Element/Element.Mapper.cs#L9-L22

```cs
public partial class Element
{
  /// <summary>
  /// Maps UI information to platform-specific implementations for accessibility services
  /// </summary>
  [Obsolete("Use ViewHandler.ViewMapper instead.")]
  public static IPropertyMapper<Maui.IElement, IElementHandler> ControlsElementMapper = new ControlsMapper<IElement, IElementHandler>(ViewHandler.ViewMapper);
  internal static void RemapForControls()
  {
	  ViewHandler.ViewMapper.ReplaceMapping<Maui.IElement, IElementHandler>(AutomationProperties.IsInAccessibleTreeProperty.PropertyName, MapAutomationPropertiesIsInAccessibleTree);
	  ViewHandler.ViewMapper.ReplaceMapping<Maui.IElement, IElementHandler>(AutomationProperties.ExcludedWithChildrenProperty.PropertyName, MapAutomationPropertiesExcludedWithChildren);
  }
}
```

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)


 ### Additional information ###

I confirmed that `Popup.RemapForControls()` can safely override `Element.RemapForControls()` and does not need to call it because `.UseMauiApp<T>()` always calls `Element.RemapForControls`: https://github.com/dotnet/maui/blob/8e933a7a7a46fdb586918e7414345d978cb0878d/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs#L44
