### PR TITLE
Add support for setting badge count using `UNUserNotificationCenter` …

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Essentials/Badge/BadgeImplementation.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Essentials/Badge/BadgeImplementation.macios.cs
@@ -17,6 +17,19 @@ public class BadgeImplementation : IBadge
 			}
 		});
 
-		UIApplication.SharedApplication.ApplicationIconBadgeNumber = (int)count;
+		if (OperatingSystem.IsIOSVersionAtLeast(17))
+		{
+			UNUserNotificationCenter.Current.SetBadgeCount(new IntPtr((int)count), (error) =>
+			{
+				if (error is not null)
+				{
+					Trace.WriteLine($"Error setting the Badge Count: {error.Description}");
+				}
+			});
+		}
+		else
+		{
+			UIApplication.SharedApplication.ApplicationIconBadgeNumber = (int)count;
+		}
 	}
 }


### PR DESCRIPTION
…on iOS 17 and above.

- Added a conditional check to use `UNUserNotificationCenter` for setting the badge count if the iOS version is at least 17.
- If the iOS version is below 17, continue to set the badge count using `UIApplication.SharedApplication.ApplicationIconBadgeNumber`.

This change ensures that the badge count can be set correctly on devices running iOS 17 and above, while maintaining compatibility with older versions of iOS.

<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [ ] Rebased on top of `main` at time of PR
 - [ ] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
