### PR TITLE
Use fully qualified namespace for Colors reference in TextToColorGenerator

### DIFF
--- a/src/CommunityToolkit.Maui.SourceGenerators/Generators/TextColorToGenerator.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Generators/TextColorToGenerator.cs
@@ -25,6 +25,7 @@ class TextColorToGenerator : IIncrementalGenerator
 	const string iAnimatableInterface = "Microsoft.Maui.Controls.IAnimatable";
 	const string mauiControlsAssembly = "Microsoft.Maui.Controls";
 	const string mauiColorFullName = "global::Microsoft.Maui.Graphics.Color";
+	const string mauiColorsFullName = "global::Microsoft.Maui.Graphics.Colors";
 
 	public void Initialize(IncrementalGeneratorInitializationContext context)
 	{
@@ -152,7 +153,7 @@ namespace {{textStyleClassMetadata.Namespace}};
 
 		//Although TextColor is defined as not-nullable, it CAN be null
 		//If null => set it to Transparent as Animation will crash on null BackgroundColor
-		element.TextColor ??= Colors.Transparent;
+		element.TextColor ??= {{mauiColorsFullName}}.Transparent;
 
 		var animationCompletionSource = new TaskCompletionSource<bool>();
 


### PR DESCRIPTION
This change should prevent "ambiguous reference" error to occur when other packages are included in a MAUI project that provide their own Color objects.

Examples of such libraries is MudBlazor.

 ### Description of Change ###

In the source code generator use a fully qualified namespace to the Color object, so Color is changed into global::Microsoft.Maui.Graphics.Colors following the example for the similar solution for of #1331 

As per previous PR, no tests added, current tests are sufficient to cover this change (and using the wrong value fail).

 ### Linked Issues ###

 - Fixes #1535 

 ### PR Checklist ###

 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [X] Rebased on top of `main` at time of PR
 - [X] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###
