### PR TITLE
Fix for MediaElement Android Resource file not found

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/MediaSource/MediaSource.shared.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/MediaSource/MediaSource.shared.cs
@@ -9,6 +9,7 @@ namespace CommunityToolkit.Maui.Views;
 [TypeConverter(typeof(MediaSourceConverter))]
 public abstract class MediaSource : Element
 {
+	static bool IsAndroid => DeviceInfo.Current.Platform == DevicePlatform.Android;
 	readonly WeakEventManager weakEventManager = new();
 
 	internal event EventHandler SourceChanged
@@ -37,7 +38,7 @@ public abstract class MediaSource : Element
 	/// </summary>
 	/// <param name="path">Full path to the resource file, relative to the application's resources folder.</param>
 	/// <returns>A <see cref="ResourceMediaSource"/> instance.</returns>
-	public static MediaSource FromResource(string? path) => new ResourceMediaSource { Path = path };
+	public static MediaSource FromResource(string? path) => new ResourceMediaSource { Path = IsAndroid ? $"Assets/{path}" : path };
 
 	/// <summary>
 	/// Creates a <see cref="UriMediaSource"/> from an string that contains an absolute URI.


### PR DESCRIPTION

 Before you submit please check that this work relates to one of the following:
 - Bug fix for Android when opening a media source from Resources

 ### Description of Change ###
Adds a check and modifies path for Resource if device type is Android

 ### Linked Issues ###
Linked issue fixed: [https://github.com/CommunityToolkit/Maui/issues/1399](https://github.com/CommunityToolkit/Maui/issues/1399)

 - Fixes #1399

 ### PR Checklist ###
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [ ] Rebased on top of `main` at time of PR
 - [ ] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

This adds a bool to check device type. If device type is android it modifies path to add the following prefix to path: "Assets/" This fixes a bug when selection Resource from device to playback video on android you get file not found. This fix is for android. Stock behavior is unchanged for all other devices.
 
