### PR TITLE
Fix IOS/MacOS AvataView background color with image bug

### DIFF
--- a/src/CommunityToolkit.Maui.UnitTests/Views/AvatarView/AvatarViewImageTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/AvatarView/AvatarViewImageTests.cs
@@ -138,7 +138,14 @@ public class AvatarViewImageTests : BaseHandlerTest
 		{
 			avatarImage.WidthRequest.Should().Be(73);
 			avatarImage.HeightRequest.Should().Be(37);
-			avatarImage.Clip.Should().BeOfType<RoundRectangleGeometry>();
+			if (OperatingSystem.IsIOS() || OperatingSystem.IsMacCatalyst() || OperatingSystem.IsMacOS())
+			{
+				avatarImage.Clip.Should().BeNull();
+			}
+			else
+			{
+				avatarImage.Clip.Should().BeOfType<RoundRectangleGeometry>();
+			}
 		}
 	}
 }

--- a/src/CommunityToolkit.Maui/Views/AvatarView.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/AvatarView.shared.cs
@@ -302,7 +302,10 @@ public class AvatarView : Border, IAvatarView, IBorderElement, IFontElement, ITe
 		AvatarView avatarView = (AvatarView)bindable;
 		CornerRadius corderRadius = (CornerRadius)newValue;
 
-		avatarView.StrokeShape = new RoundRectangle { CornerRadius = corderRadius };
+		avatarView.StrokeShape = new RoundRectangle
+		{
+			CornerRadius = corderRadius
+		};
 	}
 
 	static void OnImageSourcePropertyChanged(BindableObject bindable, object oldValue, object newValue)
@@ -351,6 +354,7 @@ public class AvatarView : Border, IAvatarView, IBorderElement, IFontElement, ITe
 			&& avatarImage.Source is not null)
 
 		{
+			Geometry? avatarImageClipGeometry = null;
 #if WINDOWS
 			double offsetX = 0;
 			double offsetY = 0;
@@ -361,14 +365,15 @@ public class AvatarView : Border, IAvatarView, IBorderElement, IFontElement, ITe
 			double imageWidth = Width - (StrokeThickness * 2) - Padding.Left - Padding.Right;
 			double imageHeight = Height - (StrokeThickness * 2) - Padding.Top - Padding.Bottom;
 
-			Rect rect = new(offsetX, offsetY, imageWidth, imageHeight);
-			Geometry? geometry = new RoundRectangleGeometry { CornerRadius = CornerRadius, Rect = rect };
-			
-			if (OperatingSystem.IsIOS() || OperatingSystem.IsMacCatalyst() || OperatingSystem.IsMacOS())
+			if (!OperatingSystem.IsIOS() && !OperatingSystem.IsMacCatalyst() && !OperatingSystem.IsMacOS())
 			{
-				geometry = null;
+				avatarImageClipGeometry = new RoundRectangleGeometry
+				{
+					CornerRadius = CornerRadius,
+					Rect = new(offsetX, offsetY, imageWidth, imageHeight)
+				};
 			}
-			
+
 			avatarImage.Clip = StrokeShape switch
 			{
 				Polyline polyLine => polyLine.Clip,
@@ -376,7 +381,7 @@ public class AvatarView : Border, IAvatarView, IBorderElement, IFontElement, ITe
 				Microsoft.Maui.Controls.Shapes.Path path => path.Clip,
 				Polygon polygon => polygon.Clip,
 				Rectangle rectangle => rectangle.Clip,
-				_ => geometry
+				_ => avatarImageClipGeometry
 			};
 		}
 	}

--- a/src/CommunityToolkit.Maui/Views/AvatarView.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/AvatarView.shared.cs
@@ -328,12 +328,6 @@ public class AvatarView : Border, IAvatarView, IBorderElement, IFontElement, ITe
 		avatarImage.Source = newValue;
 		if (newValue is not null)
 		{
-			// Work-around for iOS / MacOS bug that paints `Border.BackgroundColor` over top of `Border.Content` when an Image is used for `Border.Content`
-			if (OperatingSystem.IsIOS() || OperatingSystem.IsMacCatalyst() || OperatingSystem.IsMacOS())
-			{
-				BackgroundColor = Colors.Transparent;
-			}
-
 			Content = avatarImage;
 		}
 		else
@@ -367,8 +361,14 @@ public class AvatarView : Border, IAvatarView, IBorderElement, IFontElement, ITe
 			double imageWidth = Width - (StrokeThickness * 2) - Padding.Left - Padding.Right;
 			double imageHeight = Height - (StrokeThickness * 2) - Padding.Top - Padding.Bottom;
 
-			Rect rect = new(offsetX, offsetY, imageWidth, imageHeight);
-
+			Ellipse defaultEllipse = new Ellipse
+			{
+				HeightRequest = imageHeight,
+				MaximumHeightRequest = imageHeight,
+				WidthRequest = imageWidth,
+				MaximumWidthRequest = imageWidth,
+			};
+			
 			avatarImage.Clip = StrokeShape switch
 			{
 				Polyline polyLine => polyLine.Clip,
@@ -376,7 +376,7 @@ public class AvatarView : Border, IAvatarView, IBorderElement, IFontElement, ITe
 				Microsoft.Maui.Controls.Shapes.Path path => path.Clip,
 				Polygon polygon => polygon.Clip,
 				Rectangle rectangle => rectangle.Clip,
-				_ => new RoundRectangleGeometry { CornerRadius = CornerRadius, Rect = rect },
+				_ => defaultEllipse.Clip,
 			};
 		}
 	}

--- a/src/CommunityToolkit.Maui/Views/AvatarView.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/AvatarView.shared.cs
@@ -361,13 +361,13 @@ public class AvatarView : Border, IAvatarView, IBorderElement, IFontElement, ITe
 			double imageWidth = Width - (StrokeThickness * 2) - Padding.Left - Padding.Right;
 			double imageHeight = Height - (StrokeThickness * 2) - Padding.Top - Padding.Bottom;
 
-			Ellipse defaultEllipse = new Ellipse
+			Rect rect = new(offsetX, offsetY, imageWidth, imageHeight);
+			Geometry? geometry = new RoundRectangleGeometry { CornerRadius = CornerRadius, Rect = rect };
+			
+			if (OperatingSystem.IsIOS() || OperatingSystem.IsMacCatalyst() || OperatingSystem.IsMacOS())
 			{
-				HeightRequest = imageHeight,
-				MaximumHeightRequest = imageHeight,
-				WidthRequest = imageWidth,
-				MaximumWidthRequest = imageWidth,
-			};
+				geometry = null;
+			}
 			
 			avatarImage.Clip = StrokeShape switch
 			{
@@ -376,7 +376,7 @@ public class AvatarView : Border, IAvatarView, IBorderElement, IFontElement, ITe
 				Microsoft.Maui.Controls.Shapes.Path path => path.Clip,
 				Polygon polygon => polygon.Clip,
 				Rectangle rectangle => rectangle.Clip,
-				_ => defaultEllipse.Clip,
+				_ => geometry
 			};
 		}
 	}


### PR DESCRIPTION
 - Bug fix
 https://github.com/CommunityToolkit/Maui/issues/509


 ### Description of Change ###

This bug occurs if we use any instance of class derived from ``` GeometryGroup ```  as default clip for image in AvatarView on MacOs or IOS. In AvatarView ``` RoundRectangleGeometry ``` was used as default clip for image. This caused background color to overlay image.
<img width="473" alt="image" src="https://github.com/CommunityToolkit/Maui/assets/98330987/39f47975-4054-42b3-bcf6-a4b31d35ce22">

In this pull request I decided not to set clip object if AvatarView is used on IOS/MacOS with this approach background does not overlay image on IOS or MacOS and  ``` RoundRectangleGeometry ``` still be used as default image clip for other platforms.


How it looks in MacOS 
<img width="998" alt="image" src="https://github.com/CommunityToolkit/Maui/assets/98330987/8f029a86-8c2d-4b09-8b55-51ba9f9887fb">

In IOS
<img width="381" alt="image" src="https://github.com/CommunityToolkit/Maui/assets/98330987/336c37c5-06cf-4478-96b8-d1b556a4526f">

