### PR TITLE
Fix HLS CTD on Windows

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.windows.cs
@@ -254,7 +254,8 @@ partial class MediaManager : IDisposable
 
 			return;
 		}
-
+		MediaElement.Position = TimeSpan.Zero;
+		MediaElement.Duration = TimeSpan.Zero;
 		Player.AutoPlay = MediaElement.ShouldAutoPlay;
 
 		if (MediaElement.Source is UriMediaSource uriMediaSource)
@@ -417,7 +418,6 @@ partial class MediaManager : IDisposable
 		};
 
 		MediaElement?.CurrentStateChanged(newState);
-
 		if (sender.PlaybackState == MediaPlaybackState.Playing && sender.PlaybackRate == 0)
 		{
 			Dispatcher.Dispatch(() =>


### PR DESCRIPTION
 - Bug fix for HLS CTD on Windows
  
 ### Description of Change ###
 Reset position and duration when switching sources

 ### Linked Issues ###
Issue: [https://github.com/CommunityToolkit/Maui/issues/1538](https://github.com/CommunityToolkit/Maui/issues/1538)

 - Fixes #1538

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###
This issue is not directly an issue with media element as it is the slider that crashes. This PR fixes that issue. I checked android to see if the position and duration is reset when changing sources. It is not. It reset either on opening or when media fails. Do we want to go back and change this in the future? If we do we should check every device for this issue. Or is this intended behavior and only an issue in windows due to slider behavior on that platform?

This might give some insight into slider behavior and a current issue being tracked with it. [https://github.com/dotnet/maui/issues/12285](https://github.com/dotnet/maui/issues/12285)
 
