### PR TITLE
Fix Media Element Position Bug for Android and IOS

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/MediaElement.shared.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/MediaElement.shared.cs
@@ -526,6 +526,7 @@ public class MediaElement : View, IMediaElement, IDisposable
 		}
 
 		InvalidateMeasure();
+		InitializeTimer();
 	}
 
 	void OnSourcePropertyChanging(MediaSource? oldValue)

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.android.cs
@@ -115,6 +115,7 @@ public partial class MediaManager : Java.Lang.Object, IPlayer.IListener
 		if (playbackState is IPlayer.StateReady)
 		{
 			MediaElement.Duration = TimeSpan.FromMilliseconds(Player.Duration < 0 ? 0 : Player.Duration);
+			MediaElement.Position = TimeSpan.FromMilliseconds(Player.CurrentPosition < 0 ? 0: Player.CurrentPosition);
 		}
 	}
 


### PR DESCRIPTION
 - Bug fix

 ### Description of Change ###
Fixes position tracking not working when changing sources in media element on Android and IOS.

 ### Linked Issues ###

 - Fixes #1545

 ### PR Checklist ###
 
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

This change fixes the problem but events are firing multiple times like clear timers runs a bunch of times on android when I was looking at it. Is it needed for it to fire so many times? Can we handle this better? It seems the way we are handling events is slightly different depending on device. 

On windows this was not an issue. But at least on Android it looks like we are doing things completely differently in handling the same things. Is there any plan to change this and maybe improve it? I am happy to work on it if someone has any idea on how to make this better.
 
I am inexperienced and I may be completely wrong but I have a ton of time if anyone thinks it would be a good idea to unify all of these behaviors into a single way of doing things. If that is ok I will make start a discussion and see where it goes. At this time I am looking for opinions on whether it is a good idea.