### PR TITLE
[BUG] [Windows] UniformItemsLayout item positioning not correct #1553

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Layouts/UniformItemsLayoutManager.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Layouts/UniformItemsLayoutManager.shared.cs
@@ -30,10 +30,15 @@ public class UniformItemsLayoutManager : LayoutManager
 		var width = rectangle.Width - uniformItemsLayout.Padding.HorizontalThickness;
 		var visibleChildren = uniformItemsLayout.Where(x => x.Visibility == Visibility.Visible).ToArray();
 
+		if (visibleChildren.Length == 0 || width == 0)
+		{
+			return rectangle.Size;
+		}
+
 		var columns = GetColumnsCount(visibleChildren.Length, width);
 		var rows = GetRowsCount(visibleChildren.Length, columns);
 
-		var boundsWidth = columns == 0 ? 0 : width / columns;
+		var boundsWidth = width / columns;
 		var boundsHeight = childHeight;
 		var bounds = new Rect(0, 0, boundsWidth, boundsHeight);
 		var count = 0;
@@ -51,7 +56,7 @@ public class UniformItemsLayoutManager : LayoutManager
 			}
 		}
 
-		return bounds.Size;
+		return rectangle.Size;
 	}
 
 	/// <summary>

--- a/src/CommunityToolkit.Maui.UnitTests/Layouts/UniformItemsLayoutTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Layouts/UniformItemsLayoutTests.cs
@@ -99,14 +99,14 @@ public class UniformItemsLayoutTests : BaseTest
 	[Fact]
 	public void ArrangeChildrenUniformItemsLayout()
 	{
-		var expectedSize = new Size(childWidth, childHeight);
-		uniformChild = new TestView(expectedSize);
+		var childSize = new Size(childWidth, childHeight);
+		uniformChild = new TestView(childSize);
 		uniformItemsLayout.CrossPlatformMeasure(double.PositiveInfinity, double.PositiveInfinity);
 		var rect = new Rect(0, 0, childWidth * childCount, childHeight * childCount);
 		uniformItemsLayout.Layout(rect);
 		var actualSize = uniformItemsLayout.CrossPlatformArrange(rect);
 
-		Assert.Equal(expectedSize, actualSize);
+		Assert.Equal(childSize * childCount, actualSize);
 	}
 
 	class TestView : View


### PR DESCRIPTION

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #1553

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [ ] Rebased on top of `main` at time of PR
 - [ ] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

![image](https://github.com/CommunityToolkit/Maui/assets/33021114/1e2f890e-5783-44a6-88c9-373a7bbccb78)
 
