### PR TITLE
Removes the transparent color set on Android when null

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/IconTintColorBehaviorPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/IconTintColorBehaviorPage.xaml
@@ -8,8 +8,7 @@
 	xmlns:vm="clr-namespace:CommunityToolkit.Maui.Sample.ViewModels.Behaviors"
 	Title="IconTintColorBehaviorPage"
 	x:DataType="vm:IconTintColorBehaviorViewModel"
-	x:TypeArguments="vm:IconTintColorBehaviorViewModel"
-	x:Name="this">
+	x:TypeArguments="vm:IconTintColorBehaviorViewModel">
 	<ScrollView>
 		<Grid
 			Padding="20" 
@@ -83,12 +82,13 @@
 			</ImageButton>
 
 			<ImageButton
+				x:Name="ToggleColorImageButton"
 				Grid.Row="4"
 				Grid.Column="2"
 				Command="{Binding ChangeColorCommand}"
 				Source="shield.png">
 				<ImageButton.Behaviors>
-					<mct:IconTintColorBehavior TintColor="{Binding Source={x:Reference this}, Path=BindingContext.ToggleableIconTintColor}" />
+					<mct:IconTintColorBehavior TintColor="{Binding Source={x:Reference ToggleColorImageButton}, Path=BindingContext.ToggleableIconTintColor}" />
 				</ImageButton.Behaviors>
 			</ImageButton>
 
@@ -97,13 +97,13 @@
 				Grid.Column="2"
 				FontSize="Micro"
 				FontAttributes="Italic"
-				Text="The ImageButton above uses Binding in order to change the TintColor. Click it!"/>
+				Text="This ImageButton uses Bindings to change the TintColor. Click it!"/>
 			<Label
 				Grid.Row="5"
 				Grid.Column="1"
 				FontSize="Micro"
 				FontAttributes="Italic"
-				Text="The ImageButton above updates the image source. Click it!"/>
+				Text="This ImageButton uses Bindings to change the ImageSource. Click it!"/>
 		
 		</Grid>
 		

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/IconTintColorBehaviorPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/IconTintColorBehaviorPage.xaml
@@ -73,11 +73,10 @@
 				Source="shield.png" />
 
 			<ImageButton
-				x:Name="UpdateImage"
 				Grid.Row="4"
 				Grid.Column="1"
-				Clicked="ChangeSource_Clicked"
-				Source="shield.png">
+				Command="{Binding ToggleImageButtonCommand, Mode=OneTime}"
+				Source="{Binding ToggleableImageSource}">
 				<ImageButton.Behaviors>
 					<mct:IconTintColorBehavior TintColor="Red" />
 				</ImageButton.Behaviors>
@@ -86,10 +85,10 @@
 			<ImageButton
 				Grid.Row="4"
 				Grid.Column="2"
-				Command="{Binding ChangeCommand}"
+				Command="{Binding ChangeColorCommand}"
 				Source="shield.png">
 				<ImageButton.Behaviors>
-					<mct:IconTintColorBehavior TintColor="{Binding Source={x:Reference this}, Path=BindingContext.ChangedColor}" />
+					<mct:IconTintColorBehavior TintColor="{Binding Source={x:Reference this}, Path=BindingContext.ToggleableIconTintColor}" />
 				</ImageButton.Behaviors>
 			</ImageButton>
 

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/IconTintColorBehaviorPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/IconTintColorBehaviorPage.xaml.cs
@@ -9,22 +9,4 @@ public partial class IconTintColorBehaviorPage : BasePage<IconTintColorBehaviorV
 	{
 		InitializeComponent();
 	}
-
-	void ChangeSource_Clicked(System.Object sender, System.EventArgs e)
-	{
-		var imageSource = (ImageButton)sender;
-		var selectedImage = imageSource.Source as FileImageSource;
-
-		if (selectedImage is not null)
-		{
-			if (selectedImage.File == "dotnet_bot.png")
-			{
-				UpdateImage.Source = "shield.png";
-			}
-			else
-			{
-				UpdateImage.Source = "dotnet_bot.png";
-			}
-		}
-	}
 }

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Behaviors/IconTintColorBehaviorViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Behaviors/IconTintColorBehaviorViewModel.cs
@@ -23,7 +23,7 @@ public partial class IconTintColorBehaviorViewModel : BaseViewModel
 		{
 			dotnetBotImageFileName => shieldImageFileName,
 			shieldImageFileName => dotnetBotImageFileName,
-			_ => throw new Exception("Invalid image source")
+			_ => throw new NotSupportedException("Invalid image source")
 		};
 	}
 

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Behaviors/IconTintColorBehaviorViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Behaviors/IconTintColorBehaviorViewModel.cs
@@ -5,15 +5,37 @@ namespace CommunityToolkit.Maui.Sample.ViewModels.Behaviors;
 
 public partial class IconTintColorBehaviorViewModel : BaseViewModel
 {
-	[RelayCommand]
-	void Change()
-	{
-		IsChanged = !IsChanged;
-	}
+	const string dotnetBotImageFileName = "dotnet_bot.png";
+	const string shieldImageFileName = "shield.png";
+
+	static readonly IEnumerator<Color?> toggleableColorsEnumerator = new List<Color?> { Colors.Red, Colors.Green, null }.GetEnumerator();
+
+	[ObservableProperty] 
+	string toggleableImageSource = shieldImageFileName;
 
 	[ObservableProperty]
-	[NotifyPropertyChangedFor(nameof(ChangedColor))]
-	bool isChanged;
+	Color? toggleableIconTintColor = toggleableColorsEnumerator.Current;
 
-	public Color ChangedColor => IsChanged ? Colors.Red : Colors.Green;
+	[RelayCommand]
+	void ToggleImageButton()
+	{
+		ToggleableImageSource = ToggleableImageSource switch
+		{
+			dotnetBotImageFileName => shieldImageFileName,
+			shieldImageFileName => dotnetBotImageFileName,
+			_ => throw new Exception("Invalid image source")
+		};
+	}
+
+	[RelayCommand]
+	void ChangeColor()
+	{
+		if (!toggleableColorsEnumerator.MoveNext())
+		{
+			toggleableColorsEnumerator.Reset();
+			toggleableColorsEnumerator.MoveNext();
+		}
+
+		ToggleableIconTintColor =  toggleableColorsEnumerator.Current;
+	}
 }

--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.android.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.android.cs
@@ -52,7 +52,7 @@ public partial class IconTintColorBehavior
 			if (color is null)
 			{
 				image.ClearColorFilter();
-				color = Colors.Transparent;
+				return;
 			}
 
 			image.SetColorFilter(new PorterDuffColorFilter(color.ToPlatform(), PorterDuff.Mode.SrcIn ?? throw new InvalidOperationException("PorterDuff.Mode.SrcIn should not be null at runtime.")));


### PR DESCRIPTION
### Description of Change ###

Removes the transparent color that was being set on Android when the icon tint color value is set to null.

 ### Linked Issues ###

 - Fixes [#1579](https://github.com/CommunityToolkit/Maui/issues/1579)

 ### PR Checklist ###
 - [ x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [ x] Rebased on top of `main` at time of PR
 - [ x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: Not required.
 
