### PR TITLE
BUG FIX: Fix MediaElement within Carousel Crash

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.macios.cs
@@ -1,7 +1,6 @@
 ﻿using CommunityToolkit.Maui.Core.Views;
 using CommunityToolkit.Maui.Views;
 using Microsoft.Maui.Handlers;
-using Microsoft.Maui.Platform;
 
 namespace CommunityToolkit.Maui.Core.Handlers;
 
@@ -20,22 +19,8 @@ public partial class MediaElementHandler : ViewHandler<MediaElement, MauiMediaEl
 								VirtualView,
 								Dispatcher.GetForCurrentThread() ?? throw new InvalidOperationException($"{nameof(IDispatcher)} cannot be null"));
 
-		// Retrieve the parenting page so we can provide that to the platform control
-		var parent = VirtualView.Parent;
-		while (parent is not null)
-		{
-			if (parent is Page)
-			{
-				break;
-			}
-
-			parent = parent.Parent;
-		}
-
-		var parentPage = (parent as Page)?.ToHandler(MauiContext);
-
 		var (_, playerViewController) = mediaManager.CreatePlatformView();
-		return new(playerViewController, parentPage?.ViewController);
+		return new (playerViewController, VirtualView);
 	}
 
 	/// <inheritdoc/>

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.macios.cs
@@ -1,6 +1,9 @@
 ﻿using AVKit;
-using CommunityToolkit.Maui.Views;
 using UIKit;
+using Microsoft.Maui.Handlers;
+using CommunityToolkit.Maui.Views;
+using Microsoft.Maui.Controls.Handlers.Compatibility;
+using Microsoft.Maui.Controls.Platform.Compatibility;
 
 namespace CommunityToolkit.Maui.Core.Views;
 
@@ -9,37 +12,171 @@ namespace CommunityToolkit.Maui.Core.Views;
 /// </summary>
 public class MauiMediaElement : UIView
 {
+	AVPlayerViewController? playerViewController = null;
+	Element? rootElement = null;
+	
 	/// <summary>
 	/// Initializes a new instance of the <see cref="MauiMediaElement"/> class.
 	/// </summary>
 	/// <param name="playerViewController">The <see cref="AVPlayerViewController"/> that acts as the platform media player.</param>
-	/// <param name="parentViewController">The <see cref="UIViewController"/> that acts as the parent for <paramref name="playerViewController"/>.</param>
+	/// <param name="virtualView">The <see cref="Element"/> that is that virtual vie/>.</param>
 	/// <exception cref="NullReferenceException">Thrown when <paramref name="playerViewController"/><c>.View</c> is <see langword="null"/>.</exception>
-	public MauiMediaElement(AVPlayerViewController playerViewController, UIViewController? parentViewController)
-	{
-		ArgumentNullException.ThrowIfNull(playerViewController.View);
-		playerViewController.View.Frame = Bounds;
+	public MauiMediaElement(AVPlayerViewController playerViewController, Element virtualView)
+    {
+        ArgumentNullException.ThrowIfNull(playerViewController.View);
+        ArgumentNullException.ThrowIfNull(virtualView);
+
+        this.playerViewController = playerViewController;
+
+        // Zero out the original implementation
+        //RemoveFromParents();
+
+        TrySetSubview(virtualView);
+    }
+
+    void TrySetSubview(Element virtualView)
+    {
+        // Try and find parent controller on virtualView
+        // If it's not found, try to find the view controller for the page
+        var parentViewController = FindParentController(virtualView) ?? FindPageController(virtualView);
+
+        if (parentViewController is null)
+        {
+            // If no ViewController was found, try to wait for adding the view to a parent
+            // This is needed when the MediaElement is part of a CollectionView or CarouselView cell
+            rootElement = FindRootElement(virtualView);
+            rootElement.ParentChanging += ElementParentChanging;
+        }
+        else
+        {
+            if (rootElement is not null)
+			{
+				rootElement.ParentChanging -= ElementParentChanging;
+			}
+
+			rootElement = null;
+        }
+
+        SetSubviewWithParentController(parentViewController);
+    }
+
+    void SetSubviewWithParentController(UIViewController? parentViewController)
+    {
+        RemoveFromParents();
+
+        if (playerViewController is not { View: not null })
+        {
+	        return;
+        }
+
+        playerViewController.View.Frame = Bounds;
 
 #if IOS16_0_OR_GREATER || MACCATALYST16_1_OR_GREATER
-		// On iOS 16+ and macOS 13+ the AVPlayerViewController has to be added to a parent ViewController, otherwise the transport controls won't be displayed.
-		var viewController = parentViewController ?? WindowStateManager.Default.GetCurrentUIViewController();
+        // On iOS 16+ and macOS 13+ the AVPlayerViewController has to be added to a parent ViewController, otherwise the transport controls won't be displayed.
 
-		// If we don't find the viewController, assume it's not Shell and still continue, the transport controls will still be displayed
-		if (viewController?.View is not null)
-		{
-			// Zero out the safe area insets of the AVPlayerViewController
-			UIEdgeInsets insets = viewController.View.SafeAreaInsets;
-			playerViewController.AdditionalSafeAreaInsets =
-				new UIEdgeInsets(insets.Top * -1, insets.Left, insets.Bottom * -1, insets.Right);
+        parentViewController ??= WindowStateManager.Default.GetCurrentUIViewController();
 
+        if (parentViewController?.View is not null)
+        {
+	        // Zero out the safe area insets of the AVPlayerViewController
+	        UIEdgeInsets insets = parentViewController.View.SafeAreaInsets;
+	        playerViewController.AdditionalSafeAreaInsets =
+		        new UIEdgeInsets(insets.Top * -1, insets.Left, insets.Bottom * -1, insets.Right);
+	        // Add the View from the AVPlayerViewController to the parent ViewController
+	        parentViewController.AddChildViewController(playerViewController);
+	        parentViewController.View.AddSubview(playerViewController.View);
 
-			// Add the View from the AVPlayerViewController to the parent ViewController
-			viewController.AddChildViewController(playerViewController);
-			viewController.View.AddSubview(playerViewController.View);
-		}
-
+	        playerViewController.DidMoveToParentViewController(parentViewController);
+        }
 #endif
 
-		AddSubview(playerViewController.View);
-	}
+        AddSubview(playerViewController.View);
+    }
+
+    void RemoveFromParents()
+    {
+        foreach (var subview in Subviews)
+        {
+            subview.RemoveFromSuperview();
+        }
+
+        playerViewController?.RemoveFromParentViewController();
+        playerViewController?.View?.RemoveFromSuperview();
+    }
+
+    UIViewController? FindParentController(Element element)
+    {
+        // Does this element have a ViewController?
+        if (element.Handler?.PlatformView is UIResponder { NextResponder: UIViewController viewController })
+        {
+            // Is it the right ViewController?
+            var controller = GetCorrectController(viewController);
+            if (controller is not null)
+            {
+                return controller;
+            }
+        }
+
+        // Try to find the controller in the parent element
+        if (element.Parent is not null)
+        {
+            return FindParentController(element.Parent);
+        }
+
+        return null;
+    }
+
+    static UIViewController? GetCorrectController(UIViewController controller)
+    {
+        return controller switch
+        {
+            NavigationRenderer => null, // If a NavigationPage is used, the Page ViewController needs to be used instead
+            ShellFlyoutRenderer => controller, // Shell support
+            UICollectionViewController => controller, // CollectionView and CarouselView support
+            UINavigationController navigationController => navigationController.VisibleViewController, // Simple Shell support
+            _ => null
+        };
+    }
+
+    static UIViewController? FindPageController(Element element)
+    {
+        if (element.Handler is PageHandler pageHandler)
+        {
+            return pageHandler.ViewController;
+        }
+
+        return FindPageController(element.Parent);
+    }
+
+    static Element FindRootElement(Element element)
+    {
+        while (element.Parent is not null)
+        {
+            element = element.Parent;
+        }
+
+        return element;
+    }
+
+    void ElementParentChanging(object? sender, ParentChangingEventArgs e)
+    {
+        TrySetSubview(e.NewParent);
+    }
+    
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="disposing"></param>
+    protected override void Dispose(bool disposing)
+    {
+	    base.Dispose(disposing);
+
+	    if (rootElement is not null)
+	    {
+		    rootElement.ParentChanging -= ElementParentChanging;
+	    }
+
+	    playerViewController = null;
+	    rootElement = null;
+    }
 }

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.macios.cs
@@ -74,7 +74,9 @@ public class MauiMediaElement : UIView
 #if IOS16_0_OR_GREATER || MACCATALYST16_1_OR_GREATER
         // On iOS 16+ and macOS 13+ the AVPlayerViewController has to be added to a parent ViewController, otherwise the transport controls won't be displayed.
 
-        parentViewController ??= WindowStateManager.Default.GetCurrentUIViewController();
+        var viewController = Shell.Current is not null
+	        ? WindowStateManager.Default.GetCurrentUIViewController()
+	        : parentViewController;
 
         if (parentViewController?.View is not null)
         {
@@ -107,7 +109,7 @@ public class MauiMediaElement : UIView
     UIViewController? FindParentController(Element element)
     {
         // Does this element have a ViewController?
-        if (element.Handler?.PlatformView is UIResponder { NextResponder: UIViewController viewController })
+        if (element.Handler?.PlatformView is UIResponder responder && responder.NextResponder is UIViewController viewController)
         {
             // Is it the right ViewController?
             var controller = GetCorrectController(viewController);
@@ -140,6 +142,11 @@ public class MauiMediaElement : UIView
 
     static UIViewController? FindPageController(Element element)
     {
+	    if (element is null)
+	    {
+		    return null;
+	    }
+	    
         if (element.Handler is PageHandler pageHandler)
         {
             return pageHandler.ViewController;


### PR DESCRIPTION
 ### Description of Change ###
Fixed the scenario when MediaElement is in a CarouselView, CollectionView, or Shell on iOS.
Shout out to @RadekVyM who figured out the changes need for this fix: https://github.com/RadekVyM/MauiBugs/tree/main/iOSMediaElement
https://github.com/CommunityToolkit/Maui/pull/1279#issuecomment-1647862453

 ### Linked Issues ###
 - Fixes #14417
 - Might Fix #1214 
 - Related to https://github.com/CommunityToolkit/Maui/pull/1279

 ### PR Checklist ###
I did test by adding my own page in the sample app that has a media element in a carousel view, but I didn't commit it because I don't think it belongs in the sample projects.

 - [X ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [X ] Rebased on top of `main` at time of PR
 - [X ] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->

 ### Additional information ###

 
