### PR TITLE
Memory leak on TintedImageBehavior fix

### DIFF
--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.android.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.android.cs
@@ -16,6 +16,7 @@ public partial class IconTintColorBehavior
 	{
 		ApplyTintColor(bindable, platformView);
 
+		bindable.PropertyChanged += OnElementPropertyChanged;
 		this.PropertyChanged += (s, e) =>
 		{
 			if (e.PropertyName == TintColorProperty.PropertyName)
@@ -26,13 +27,15 @@ public partial class IconTintColorBehavior
 	}
 
 	/// <inheritdoc/>
-	protected override void OnDetachedFrom(View bindable, AView platformView) =>
+	protected override void OnDetachedFrom(View bindable, AView platformView)
+	{
 		ClearTintColor(bindable, platformView);
+		bindable.PropertyChanged -= OnElementPropertyChanged;
+	}
 
 	void ApplyTintColor(View element, AView control)
 	{
 		var color = TintColor;
-		element.PropertyChanged += OnElementPropertyChanged;
 
 		switch (control)
 		{
@@ -98,7 +101,6 @@ public partial class IconTintColorBehavior
 
 	void ClearTintColor(View element, AView control)
 	{
-		element.PropertyChanged -= OnElementPropertyChanged;
 		switch (control)
 		{
 			case ImageView image:

--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.macios.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.macios.cs
@@ -39,12 +39,14 @@ public partial class IconTintColorBehavior
 	}
 
 	/// <inheritdoc/>
-	protected override void OnDetachedFrom(View bindable, UIView platformView) =>
+	protected override void OnDetachedFrom(View bindable, UIView platformView)
+	{
+		bindable.PropertyChanged -= OnElementPropertyChanged;
 		ClearTintColor(platformView, bindable);
+	}
 
 	void ClearTintColor(UIView platformView, View element)
 	{
-		element.PropertyChanged -= OnElementPropertyChanged;
 		switch (platformView)
 		{
 			case UIImageView imageView:


### PR DESCRIPTION
We subscribe to OnElementPropertyChanged only once - OnAttached - instead of each time the TintColor is changed

Every time when color was applied, the void was added to event handler. It causes that every next ImageSource change, invoked heavy color logic multiple times

 ### Description of Change ###

Move dispose and subscibe logic right place in ImageTintBehavior

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #1612 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [X] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [ ] Rebased on top of `main` at time of PR
 - [X] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

 <!-- 
Any android, sample project from issue
 -->
 
