### PR TITLE
Fix Hot Reload with Popup

### DIFF
--- a/src/CommunityToolkit.Maui.UnitTests/Views/Popup/PopupTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/Popup/PopupTests.cs
@@ -323,6 +323,38 @@ public class PopupTests : BaseHandlerTest
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task ShowPopup_IsLogicalChild()
+	{
+		var app = Application.Current ?? throw new NullReferenceException();
+
+		var page = new ContentPage
+		{
+			Content = new Label
+			{
+				Text = "Hello there"
+			}
+		};
+
+		// Make sure that our page will have a Handler
+		CreateViewHandler<MockPageHandler>(page);
+
+		app.MainPage = page;
+
+		// Make sure that our popup will have a Handler
+		CreateElementHandler<MockPopupHandler>(popup);
+
+		Assert.NotNull(popup.Handler);
+		Assert.NotNull(page.Handler);
+
+		Assert.Single(page.LogicalChildrenInternal);
+		page.ShowPopup((MockPopup)popup);
+		Assert.Equal(2, page.LogicalChildrenInternal.Count);
+
+		await((MockPopup)popup).CloseAsync(token: CancellationToken.None);
+		Assert.Single(page.LogicalChildrenInternal);
+	}
+
 	class MockPopup : Popup
 	{
 		public MockPopup()

--- a/src/CommunityToolkit.Maui/HandlerImplementation/Popup/Popup.macios.cs
+++ b/src/CommunityToolkit.Maui/HandlerImplementation/Popup/Popup.macios.cs
@@ -25,12 +25,11 @@ public partial class Popup
 			var mauiContext = virtualView.Handler?.MauiContext ?? throw new NullReferenceException(nameof(IMauiContext));
 			var view = (View?)virtualView.Content ?? throw new InvalidOperationException($"{nameof(IPopup.Content)} can't be null here.");
 			view.SetBinding(BindingContextProperty, new Binding { Source = virtualView, Path = BindingContextProperty.PropertyName });
-			var parent = virtualView.Parent as Element;
 			var contentPage = new ContentPage
 			{
-				Content = view,
-				Parent = parent
+				Content = view
 			};
+			var parent = virtualView.Parent as Element;
 			parent?.AddLogicalChild(contentPage);
 
 			return (PageHandler)contentPage.ToHandler(mauiContext);

--- a/src/CommunityToolkit.Maui/HandlerImplementation/Popup/Popup.macios.cs
+++ b/src/CommunityToolkit.Maui/HandlerImplementation/Popup/Popup.macios.cs
@@ -25,11 +25,13 @@ public partial class Popup
 			var mauiContext = virtualView.Handler?.MauiContext ?? throw new NullReferenceException(nameof(IMauiContext));
 			var view = (View?)virtualView.Content ?? throw new InvalidOperationException($"{nameof(IPopup.Content)} can't be null here.");
 			view.SetBinding(BindingContextProperty, new Binding { Source = virtualView, Path = BindingContextProperty.PropertyName });
+			var parent = virtualView.Parent as Element;
 			var contentPage = new ContentPage
 			{
 				Content = view,
-				Parent = virtualView.Parent as Element
+				Parent = parent
 			};
+			parent?.AddLogicalChild(contentPage);
 
 			return (PageHandler)contentPage.ToHandler(mauiContext);
 		}

--- a/src/CommunityToolkit.Maui/Views/Popup/Popup.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/Popup.shared.cs
@@ -351,7 +351,12 @@ public partial class Popup : Element, IPopup, IWindowController, IPropertyPropag
 		((IResourceDictionary)resources).ValuesChanged -= OnResourcesChanged;
 
 		await popupDismissedTaskCompletionSource.Task.WaitAsync(token);
-		Parent = null;
+
+		if (Parent is not null)
+		{
+			Parent.RemoveLogicalChild(this);
+			Parent = null;
+		}
 
 		dismissWeakEventManager.HandleEvent(this, new PopupClosedEventArgs(result, wasDismissedByTappingOutsideOfPopup), nameof(Closed));
 	}

--- a/src/CommunityToolkit.Maui/Views/Popup/Popup.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/Popup.shared.cs
@@ -355,7 +355,6 @@ public partial class Popup : Element, IPopup, IWindowController, IPropertyPropag
 		if (Parent is not null)
 		{
 			Parent.RemoveLogicalChild(this);
-			Parent = null;
 		}
 
 		dismissWeakEventManager.HandleEvent(this, new PopupClosedEventArgs(result, wasDismissedByTappingOutsideOfPopup), nameof(Closed));

--- a/src/CommunityToolkit.Maui/Views/Popup/PopupExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/PopupExtensions.shared.cs
@@ -114,7 +114,11 @@ public static partial class PopupExtensions
 	static void CreatePopup(Page page, Popup popup)
 	{
 		var mauiContext = GetMauiContext(page);
-		popup.Parent = page.GetCurrentPage();
+
+		var parent = page.GetCurrentPage();
+		popup.Parent = parent;
+		parent.AddLogicalChild(popup);
+
 		var platformPopup = popup.ToHandler(mauiContext);
 		platformPopup.Invoke(nameof(IPopup.OnOpened));
 	}

--- a/src/CommunityToolkit.Maui/Views/Popup/PopupExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/PopupExtensions.shared.cs
@@ -116,7 +116,6 @@ public static partial class PopupExtensions
 		var mauiContext = GetMauiContext(page);
 
 		var parent = page.GetCurrentPage();
-		popup.Parent = parent;
 		parent.AddLogicalChild(popup);
 
 		var platformPopup = popup.ToHandler(mauiContext);

--- a/src/CommunityToolkit.Maui/Views/Popup/PopupExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/PopupExtensions.shared.cs
@@ -116,7 +116,7 @@ public static partial class PopupExtensions
 		var mauiContext = GetMauiContext(page);
 
 		var parent = page.GetCurrentPage();
-		parent.AddLogicalChild(popup);
+		parent?.AddLogicalChild(popup);
 
 		var platformPopup = popup.ToHandler(mauiContext);
 		platformPopup.Invoke(nameof(IPopup.OnOpened));

--- a/src/CommunityToolkit.Maui/Views/Popup/PopupExtensions.windows.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/PopupExtensions.windows.cs
@@ -12,7 +12,10 @@ public static partial class PopupExtensions
 	static void PlatformShowPopup(Popup popup, IMauiContext mauiContext)
 	{
 		var window = mauiContext.GetPlatformWindow().GetWindow() ?? throw new NullReferenceException("Window is null.");
-		popup.Parent = ((Page)window.Content).GetCurrentPage();
+
+		Page parent = ((Page)window.Content).GetCurrentPage();
+		popup.Parent = parent;
+		parent.AddLogicalChild(popup);
 
 		var platform = popup.ToHandler(mauiContext);
 		platform?.Invoke(nameof(IPopup.OnOpened));

--- a/src/CommunityToolkit.Maui/Views/Popup/PopupExtensions.windows.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/PopupExtensions.windows.cs
@@ -14,7 +14,7 @@ public static partial class PopupExtensions
 		var window = mauiContext.GetPlatformWindow().GetWindow() ?? throw new NullReferenceException("Window is null.");
 
 		Page parent = ((Page)window.Content).GetCurrentPage();
-		parent.AddLogicalChild(popup);
+		parent?.AddLogicalChild(popup);
 
 		var platform = popup.ToHandler(mauiContext);
 		platform?.Invoke(nameof(IPopup.OnOpened));

--- a/src/CommunityToolkit.Maui/Views/Popup/PopupExtensions.windows.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/PopupExtensions.windows.cs
@@ -14,7 +14,6 @@ public static partial class PopupExtensions
 		var window = mauiContext.GetPlatformWindow().GetWindow() ?? throw new NullReferenceException("Window is null.");
 
 		Page parent = ((Page)window.Content).GetCurrentPage();
-		popup.Parent = parent;
 		parent.AddLogicalChild(popup);
 
 		var platform = popup.ToHandler(mauiContext);


### PR DESCRIPTION
 ### Description of Change ###

Call `AddLogicalChild`/`RemoveLogicalChild` when the popup is shown/closed so that popups are included in the logical (and visual) tree, so that Hot Reload works for them. The Live Visual Tree VS UI now shows popup content as well.

As Shane explained to me, the rule as of MAUI in .NET8 is that whenever `Parent` is set on an `Element` currently, `AddLogicalChild` should be called on the new parent instead. `AddLogicalChild` takes care of both updating the children and parent, whereas updating the `Parent` only updates the parent not children (and will likely be deprecated). Likewise, `RemoveLogicalChild` should be called when the Parent is set to null currently.

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->

 ### Linked Issues ###
 Fixes #620 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
