### PR TITLE
Avatar sample updated to include badges

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/AvatarView/AvatarViewImagesPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/AvatarView/AvatarViewImagesPage.xaml
@@ -91,42 +91,135 @@
         </VerticalStackLayout.Resources>
         <Label Style="{StaticResource Description}" Text="AvatarView can use local or URL image sources." />
         <Line Style="{StaticResource HR}" />
-        <mct:AvatarView
-            HeightRequest="32"
-            SemanticProperties.Description="Sample small AvatarView showing using a local image."
-            Style="{StaticResource AvatarViewImagesSmallLocal}"
-            WidthRequest="32" />
-        <mct:AvatarView
-            HeightRequest="32"
-            SemanticProperties.Description="Sample small AvatarView showing using a URL image."
-            Style="{StaticResource AvatarViewImagesSmallURL}"
-            WidthRequest="32" />
-        <mct:AvatarView
-            HeightRequest="48"
-            SemanticProperties.Description="Sample AvatarView showing using a local image."
-            Style="{StaticResource AvatarViewImagesDefaultLocal}"
-            WidthRequest="48" />
-        <mct:AvatarView
-            HeightRequest="48"
-            SemanticProperties.Description="Sample AvatarView showing using a URL image."
-            Style="{StaticResource AvatarViewImagesDefaultURL}"
-            WidthRequest="48" />
-        <mct:AvatarView
-            HeightRequest="62"
-            SemanticProperties.Description="Sample large AvatarView showing using a local image."
-            Style="{StaticResource AvatarViewImagesLargeLocal}"
-            WidthRequest="62" />
+        <Grid 
+            ColumnDefinitions="Auto" 
+            HorizontalOptions="Center"
+            RowDefinitions="Auto">
+            <mct:AvatarView
+                Grid.Row="0"
+                Grid.Column="0"
+                HeightRequest="32"
+                SemanticProperties.Description="Sample small AvatarView showing using a local image."
+                Style="{StaticResource AvatarViewImagesSmallLocal}"
+                WidthRequest="32" />
+            <Border
+                Grid.Row="0"
+                Grid.Column="0"
+                HeightRequest="16" 
+                WidthRequest="16"
+                StrokeShape="RoundRectangle 16"
+                HorizontalOptions="End"
+                VerticalOptions="Start"
+                StrokeThickness="0"
+                BackgroundColor="Red"
+                Margin="0,0,0,0">
+                <Label 
+                    Text="8" 
+                    FontSize="11" 
+                    HorizontalTextAlignment="Center"
+                    VerticalTextAlignment="Center"
+                    TextColor="White" />
+            </Border>
+        </Grid>
+
+        <Grid 
+          ColumnDefinitions="Auto" 
+          HorizontalOptions="Center"
+          RowDefinitions="Auto">
+            <mct:AvatarView
+                HeightRequest="32"
+                SemanticProperties.Description="Sample small AvatarView showing using a URL image."
+                Style="{StaticResource AvatarViewImagesSmallURL}"
+                WidthRequest="32" />
+            <Border
+                Grid.Row="0"
+                Grid.Column="0"
+                StrokeShape="RoundRectangle 8"
+                HorizontalOptions="End"
+                VerticalOptions="Start"
+                StrokeThickness="0"
+                BackgroundColor="Green"
+                Margin="40,0,0,0"
+                Padding="6,2,6,1">
+                <Label 
+                    Text="1200k" 
+                    FontSize="11" 
+                    HorizontalTextAlignment="Center"
+                    VerticalTextAlignment="Center"
+                    TextColor="White" />
+            </Border>
+        </Grid>
+        <Grid 
+          ColumnDefinitions="Auto" 
+          HorizontalOptions="Center"
+          RowDefinitions="Auto">
+            <mct:AvatarView
+                HeightRequest="48"
+                SemanticProperties.Description="Sample AvatarView showing using a local image."
+                Style="{StaticResource AvatarViewImagesDefaultLocal}"
+                WidthRequest="48" />
+            <Image
+                HorizontalOptions="End"
+                VerticalOptions="Start"
+                Grid.Row="0"
+                Grid.Column="0"
+                Source="dotnet_bot.png" 
+                HeightRequest="24" 
+                WidthRequest="24"/>
+        </Grid>
+        <Grid 
+          ColumnDefinitions="Auto" 
+          HorizontalOptions="Center"
+          RowDefinitions="Auto">
+            <mct:AvatarView
+                HeightRequest="48"
+                SemanticProperties.Description="Sample AvatarView showing using a URL image."
+                Style="{StaticResource AvatarViewImagesDefaultURL}"
+                WidthRequest="48" />
+            <Path 
+                Grid.Row="0"
+                Grid.Column="0"
+                Stroke="Yellow"                  
+                Fill="Red"
+                Aspect="Uniform"
+                HorizontalOptions="Start"
+                VerticalOptions="Start"
+                HeightRequest="24"
+                WidthRequest="24"
+                Data="M8.0886959,0L8.687694,0C12.279728,0.2989963 14.275696,2.2949993 15.971676,4.9890003 16.271724,4.5899982 16.470699,4.1909961 16.670711,3.8920001 18.765678,0.89799553 23.056684,-1.0980074 27.247655,0.79800445 28.544711,1.3970038 29.842683,2.2949993 30.740692,3.5919966 31.239652,4.3909931 31.837675,5.6880059 31.93765,6.8849973 32.336696,10.677006 30.740692,13.470998 29.442659,15.866003L26.648658,15.866003C26.149696,15.168005 26.050697,14.069998 25.351663,13.571004 24.453716,14.369009 24.353679,15.966009 23.75572,17.064001 23.156721,17.263006 22.457687,16.96401 21.759691,17.163 21.260667,17.761999 20.960681,19.359001 20.761707,20.257011 20.761707,19.458 20.561695,17.761999 20.462695,16.664007 20.262683,14.668997 20.162708,12.472997 19.963674,10.278004 19.863698,9.3800086 19.963674,8.1830015 19.164724,8.1830015 18.566703,8.1830015 18.466728,9.3800086 18.466728,9.9790077 18.266715,12.07401 17.867731,14.27001 17.468683,16.465002 16.969722,15.467001 16.670711,14.27001 16.171687,14.27001 15.57269,14.668997 15.27368,15.36701 14.973692,15.966009L13.975708,15.966009C13.876709,15.666998 13.576723,15.567007 13.277712,15.567007 12.878725,15.567007 12.47974,15.966009 12.47974,16.465002 12.47974,16.96401 12.878725,17.362997 13.277712,17.362997 13.476686,17.362997 13.776735,17.263006 13.876709,17.064001 14.375732,17.163 15.073729,17.064001 15.57269,17.064001 15.871701,16.664007 15.971676,16.265005 16.171687,15.966009 16.76971,16.763998 16.670711,18.161003 17.767694,18.660011 18.166679,18.361 18.266715,17.961998 18.366691,17.463003 18.566703,16.066 18.865714,14.569006 19.065725,13.071996 19.065725,12.873006 19.164724,11.675008 19.264699,11.375997 19.464712,14.069998 19.763723,17.761999 19.963674,20.556007 20.062671,21.354011 20.262683,21.554008 20.861682,21.953011 21.360704,21.554008 21.459703,21.454002 21.659715,20.855003 21.958665,20.157005 22.0587,19.359001 22.258712,18.560005 22.757675,18.461006 23.75572,18.760002 24.353679,18.461006 24.852703,17.662008 25.052713,16.364996 25.4517,15.567007 25.750711,16.066 25.950662,16.763998 26.249671,17.163L28.844699,17.163C28.445651,17.761999 27.846654,18.361 27.447667,18.760002 24.253703,22.352013 20.162708,25.545008 16.071712,27.641001 10.982733,24.84701 5.6937417,20.955009 2.4007186,15.567007 0.90371192,13.071996 -0.79226869,8.9810066 0.40475065,5.3889946 0.60476232,4.8900012 0.90371192,4.4899921 1.2037603,3.9909992 2.4007183,1.7959909 5.0947441,2.1702817E-07 8.0886959,0z" />
+
+        </Grid>
+        <Grid 
+            ColumnDefinitions="Auto" 
+            HorizontalOptions="Center"
+            RowDefinitions="Auto">
+            <mct:AvatarView
+                HeightRequest="62"
+                SemanticProperties.Description="Sample large AvatarView showing using a local image."
+                Style="{StaticResource AvatarViewImagesLargeLocal}"
+                WidthRequest="62" />
+            <Path 
+                Grid.Row="0"
+                Grid.Column="0"
+                Stroke="Black"
+                Aspect="Uniform"
+                HorizontalOptions="End"
+                VerticalOptions="End"
+                HeightRequest="24"
+                WidthRequest="24"
+                Data="M13.908992,16.207977L32.000049,16.207977 32.000049,31.999985 13.908992,30.109983z M0,16.207977L11.904009,16.207977 11.904009,29.900984 0,28.657984z M11.904036,2.0979624L11.904036,14.202982 2.7656555E-05,14.202982 2.7656555E-05,3.3409645z M32.000058,0L32.000058,14.203001 13.909059,14.203001 13.909059,1.8890382z" />
+        </Grid>
         <mct:AvatarView
             HeightRequest="62"
             SemanticProperties.Description="Sample large AvatarView showing using a URL image."
             Style="{StaticResource AvatarViewImagesLarge}"
             WidthRequest="62">
-            <mct:AvatarView.ImageSource>
-                <UriImageSource
+                <mct:AvatarView.ImageSource>
+                    <UriImageSource
                     CacheValidity="1"
                     CachingEnabled="True"
                     Uri="https://aka.ms/campus.jpg" />
-            </mct:AvatarView.ImageSource>
-        </mct:AvatarView>
+                </mct:AvatarView.ImageSource>
+            </mct:AvatarView>
     </VerticalStackLayout>
 </pages:BasePage>


### PR DESCRIPTION
 ### Description of Change ###

As discussed on the last .NET Community Toolkit Stand Up. This PR updates the Avatar sample to include badge views from label, images, and paths. They are set on different position as well just for demo purposes.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - #105

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [x] Documentation created or updated


 ### Additional information ###

Please find below screenshots of the badge on Windows, Android and iOS:

 
![Captura de pantalla 2024-01-05 085911](https://github.com/CommunityToolkit/Maui/assets/1047398/830d6e02-9a83-4024-8242-d3442fa4a229)
![Screenshot_1704466678](https://github.com/CommunityToolkit/Maui/assets/1047398/32f67bc1-9c6f-4ad1-a238-b2f6f54dced8)
![Captura de pantalla 2024-01-05 091013](https://github.com/CommunityToolkit/Maui/assets/1047398/da8f1e84-6133-444b-932f-e2736521002b)

