### PR TITLE
Fix usage of MediaElement in CarouselView/CollectionView, etc.

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.macios.cs
@@ -20,25 +20,26 @@ public class MauiMediaElement : UIView
 		ArgumentNullException.ThrowIfNull(playerViewController.View);
 		playerViewController.View.Frame = Bounds;
 
-#if IOS16_0_OR_GREATER || MACCATALYST16_1_OR_GREATER
 		// On iOS 16+ and macOS 13+ the AVPlayerViewController has to be added to a parent ViewController, otherwise the transport controls won't be displayed.
-		var viewController = parentViewController ?? WindowStateManager.Default.GetCurrentUIViewController();
-
-		// If we don't find the viewController, assume it's not Shell and still continue, the transport controls will still be displayed
-		if (viewController?.View is not null)
+		// If the MediaElement is contained in, for example, a CarouselView, parentViewController will be null, but transport controls are still diesplayed.
+		if (parentViewController is not null && OperatingSystem.IsIOSVersionAtLeast(16) || OperatingSystem.IsMacCatalystVersionAtLeast(16, 1))
 		{
-			// Zero out the safe area insets of the AVPlayerViewController
-			UIEdgeInsets insets = viewController.View.SafeAreaInsets;
-			playerViewController.AdditionalSafeAreaInsets =
-				new UIEdgeInsets(insets.Top * -1, insets.Left, insets.Bottom * -1, insets.Right);
+			var viewController = parentViewController ?? WindowStateManager.Default.GetCurrentUIViewController();
+
+			// If we don't find the viewController, assume it's not Shell and still continue, the transport controls will still be displayed
+			if (viewController?.View is not null)
+			{
+				// Zero out the safe area insets of the AVPlayerViewController
+				UIEdgeInsets insets = viewController.View.SafeAreaInsets;
+				playerViewController.AdditionalSafeAreaInsets =
+					new UIEdgeInsets(insets.Top * -1, insets.Left, insets.Bottom * -1, insets.Right);
 
 
-			// Add the View from the AVPlayerViewController to the parent ViewController
-			viewController.AddChildViewController(playerViewController);
-			viewController.View.AddSubview(playerViewController.View);
+				// Add the View from the AVPlayerViewController to the parent ViewController
+				viewController.AddChildViewController(playerViewController);
+				viewController.View.AddSubview(playerViewController.View);
+			}
 		}
-
-#endif
 
 		AddSubview(playerViewController.View);
 	}


### PR DESCRIPTION
 ### Description of Change ###

The `MediaElement` transport controls keep giving issues in some cases. I think regular pages vs Shell now works well, however looking at #929 there are still issues when using it in a `CarouselView`. This PR should fix that.

 ### Linked Issues ###

 - Fixes #929

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->
