### PR TITLE
Add SystemNavigationBar behavior for android

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/AppShell.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/AppShell.xaml.cs
@@ -43,6 +43,7 @@ public partial class AppShell : Shell
 		CreateViewModelMapping<SelectAllTextBehaviorPage, SelectAllTextBehaviorViewModel, BehaviorsGalleryPage, BehaviorsGalleryViewModel>(),
 		CreateViewModelMapping<SetFocusOnEntryCompletedBehaviorPage, SetFocusOnEntryCompletedBehaviorViewModel, BehaviorsGalleryPage, BehaviorsGalleryViewModel>(),
 		CreateViewModelMapping<StatusBarBehaviorPage, StatusBarBehaviorViewModel, BehaviorsGalleryPage, BehaviorsGalleryViewModel>(),
+		CreateViewModelMapping<SystemNavigationBarBehaviorPage, SystemNavigationBarBehaviorViewModel, BehaviorsGalleryPage, BehaviorsGalleryViewModel>(),
 		CreateViewModelMapping<TextValidationBehaviorPage, TextValidationBehaviorViewModel, BehaviorsGalleryPage, BehaviorsGalleryViewModel>(),
 		CreateViewModelMapping<UriValidationBehaviorPage, UriValidationBehaviorViewModel, BehaviorsGalleryPage, BehaviorsGalleryViewModel>(),
 		CreateViewModelMapping<UserStoppedTypingBehaviorPage, UserStoppedTypingBehaviorViewModel, BehaviorsGalleryPage, BehaviorsGalleryViewModel>(),

--- a/samples/CommunityToolkit.Maui.Sample/MauiProgram.cs
+++ b/samples/CommunityToolkit.Maui.Sample/MauiProgram.cs
@@ -119,6 +119,7 @@ public static class MauiProgram
 		services.AddTransientWithShellRoute<UriValidationBehaviorPage, UriValidationBehaviorViewModel>();
 		services.AddTransientWithShellRoute<UserStoppedTypingBehaviorPage, UserStoppedTypingBehaviorViewModel>();
 		services.AddTransientWithShellRoute<StatusBarBehaviorPage, StatusBarBehaviorViewModel>();
+		services.AddTransientWithShellRoute<SystemNavigationBarBehaviorPage, SystemNavigationBarBehaviorViewModel>();
 
 		// Add Converters Pages + ViewModels
 		services.AddTransientWithShellRoute<BoolToObjectConverterPage, BoolToObjectConverterViewModel>();

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/SystemNavigationBarBehaviorPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/SystemNavigationBarBehaviorPage.xaml
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <pages:BasePage
-    x:Class="CommunityToolkit.Maui.Sample.Pages.Behaviors.StatusBarBehaviorPage"
+    x:Class="CommunityToolkit.Maui.Sample.Pages.Behaviors.SystemNavigationBarBehaviorPage"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:mct="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
     xmlns:pages="clr-namespace:CommunityToolkit.Maui.Sample.Pages"
     xmlns:vm="clr-namespace:CommunityToolkit.Maui.Sample.ViewModels.Behaviors"
     x:Name="Page"
-    Title="StatusBarBehavior"
-    x:DataType="vm:StatusBarBehaviorViewModel"
-    x:TypeArguments="vm:StatusBarBehaviorViewModel">
+    Title="SystemNavigationBarBehavior"
+    x:DataType="vm:SystemNavigationBarBehaviorViewModel"
+    x:TypeArguments="vm:SystemNavigationBarBehaviorViewModel">
 
     <ContentPage.Resources>
         <ControlTemplate x:Key="RadioButtonTemplate">
@@ -73,16 +73,16 @@
     </ContentPage.Resources>
 
     <Page.Behaviors>
-        <mct:StatusBarBehavior
-            StatusBarColor="{Binding Source={x:Reference Page}, Path=BindingContext.StatusBarColor}"
-            StatusBarStyle="{Binding Source={x:Reference Page}, Path=BindingContext.StatusBarStyle}" />
+        <mct:SystemNavigationBarBehavior
+            SystemNavigationBarColor="{Binding Source={x:Reference Page}, Path=BindingContext.SystemNavigationBarColor}"
+            SystemNavigationBarStyle="{Binding Source={x:Reference Page}, Path=BindingContext.SystemNavigationBarStyle}" />
     </Page.Behaviors>
 
     <ScrollView Padding="{StaticResource ContentPadding}">
 
         <VerticalStackLayout Padding="15,0" Spacing="30">
 
-            <Label Text="Slide to change StatusBar color" />
+            <Label Text="Slide to change SystemNavigationBar color" />
 
             <Slider
                 Margin="20,10"
@@ -113,7 +113,7 @@
 
             <VerticalStackLayout Spacing="15">
 
-                <Label Text="Select StatusBar style" />
+                <Label Text="Select SystemNavigationBar style" />
 
                 <RadioButton VerticalOptions="Center" IsChecked="{Binding IsDefaultChecked}">
                     <RadioButton.Content>

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/SystemNavigationBarBehaviorPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/SystemNavigationBarBehaviorPage.xaml.cs
@@ -1,0 +1,20 @@
+using CommunityToolkit.Maui.Sample.ViewModels.Behaviors;
+
+namespace CommunityToolkit.Maui.Sample.Pages.Behaviors;
+
+public partial class SystemNavigationBarBehaviorPage : BasePage<SystemNavigationBarBehaviorViewModel>
+{
+	public SystemNavigationBarBehaviorPage(SystemNavigationBarBehaviorViewModel viewModel)
+		: base(viewModel)
+	{
+		InitializeComponent();
+	}
+
+	protected override void OnNavigatedTo(NavigatedToEventArgs args)
+	{
+		base.OnNavigatedTo(args);
+
+		var systemNavigationBarColor = Color.FromRgb(BindingContext.RedSliderValue, BindingContext.GreenSliderValue, BindingContext.BlueSliderValue);
+		CommunityToolkit.Maui.Core.Platform.SystemNavigationBar.SetColor(systemNavigationBarColor);
+	}
+}

--- a/samples/CommunityToolkit.Maui.Sample/Resources/Styles/Colors.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Resources/Styles/Colors.xaml
@@ -15,7 +15,6 @@
     <Color x:Key="DarkLabelTextColor">#000000</Color>
     <Color x:Key="DarkLabelPlaceholderColor">#333d47</Color>
     <Color x:Key="SoftBorderBackgroundColor">#ecf0f9</Color>
-    <Color x:Key="StatusbarColor">#1976D2</Color>
     <Color x:Key="NavBarColor">#1976D2</Color>
 
     <Color x:Key="Pink">Pink</Color>

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Behaviors/BehaviorsGalleryViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Behaviors/BehaviorsGalleryViewModel.cs
@@ -58,6 +58,9 @@ public class BehaviorsGalleryViewModel : BaseGalleryViewModel
 
 			SectionModel.Create<StatusBarBehaviorViewModel>(nameof(StatusBarBehavior),
 				"Change the Status Bar color."),
+
+			SectionModel.Create<SystemNavigationBarBehaviorViewModel>(nameof(SystemNavigationBarBehavior),
+				"Change the System Navigation Bar color."),
 		})
 	{
 	}

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Behaviors/SystemNavigationBarBehaviorViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Behaviors/SystemNavigationBarBehaviorViewModel.cs
@@ -1,0 +1,37 @@
+﻿using CommunityToolkit.Maui.Core;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace CommunityToolkit.Maui.Sample.ViewModels.Behaviors;
+public partial class SystemNavigationBarBehaviorViewModel : BaseViewModel
+{
+	[ObservableProperty]
+	[NotifyPropertyChangedFor(nameof(SystemNavigationBarColor))]
+	int redSliderValue, greenSliderValue, blueSliderValue;
+
+	[ObservableProperty]
+	[NotifyPropertyChangedFor(nameof(SystemNavigationBarStyle))]
+	bool isLightContentChecked, isDarkContentChecked, isDefaultChecked = true;
+
+	public Color SystemNavigationBarColor => Color.FromRgb(RedSliderValue, GreenSliderValue, BlueSliderValue);
+
+	public SystemNavigationBarStyle SystemNavigationBarStyle
+	{
+		get
+		{
+			if (IsDefaultChecked)
+			{
+				return SystemNavigationBarStyle.Default;
+			}
+			if (IsLightContentChecked)
+			{
+				return SystemNavigationBarStyle.LightContent;
+			}
+			if (IsDarkContentChecked)
+			{
+				return SystemNavigationBarStyle.DarkContent;
+			}
+
+			throw new NotSupportedException($"{nameof(SystemNavigationBarStyle)} {SystemNavigationBarStyle} is not supported.");
+		}
+	}
+}

--- a/src/CommunityToolkit.Maui.Core/Platform/SystemNavigationBar/SystemNavigationBar.android.cs
+++ b/src/CommunityToolkit.Maui.Core/Platform/SystemNavigationBar/SystemNavigationBar.android.cs
@@ -1,0 +1,71 @@
+﻿using System.Runtime.Versioning;
+using Android.OS;
+using Android.Views;
+using AndroidX.Core.View;
+using Microsoft.Maui.Platform;
+using Activity = Android.App.Activity;
+
+namespace CommunityToolkit.Maui.Core.Platform;
+
+[SupportedOSPlatform("Android23.0")] // SystemNavigationBar is only supported on Android 23.0+
+static partial class SystemNavigationBar
+{
+	static Activity Activity => Microsoft.Maui.ApplicationModel.Platform.CurrentActivity ?? throw new InvalidOperationException("Android Activity can't be null.");
+
+	static void PlatformSetColor(Color color)
+	{
+		if (IsSupported())
+		{
+			Activity.Window?.SetNavigationBarColor(color.ToPlatform());
+		}
+	}
+
+	static void PlatformSetStyle(SystemNavigationBarStyle style)
+	{
+		if (!IsSupported())
+		{
+			return;
+		}
+
+		switch (style)
+		{
+			case SystemNavigationBarStyle.DarkContent:
+				SetSystemNavigationBarAppearance(Activity, true);
+				break;
+
+			case SystemNavigationBarStyle.Default:
+			case SystemNavigationBarStyle.LightContent:
+				SetSystemNavigationBarAppearance(Activity, false);
+				break;
+
+			default:
+				throw new NotSupportedException($"{nameof(SystemNavigationBarStyle)} {style} is not yet supported on Android");
+		}
+	}
+
+	static void SetSystemNavigationBarAppearance(Activity activity, bool isLightSystemNavigationBars)
+	{
+		var window = GetCurrentWindow(activity);
+		var windowController = WindowCompat.GetInsetsController(window, window.DecorView);
+		windowController.AppearanceLightNavigationBars = isLightSystemNavigationBars;
+
+		static Window GetCurrentWindow(Activity activity)
+		{
+			var window = activity.Window ?? throw new InvalidOperationException($"{nameof(activity.Window)} cannot be null");
+			window.ClearFlags(WindowManagerFlags.TranslucentStatus);
+			window.AddFlags(WindowManagerFlags.DrawsSystemBarBackgrounds);
+			return window;
+		}
+	}
+
+	static bool IsSupported()
+	{
+		if (OperatingSystem.IsAndroidVersionAtLeast((int)BuildVersionCodes.M))
+		{
+			return true;
+		}
+
+		System.Diagnostics.Trace.WriteLine($"This functionality is not available. Minimum supported API is {(int)BuildVersionCodes.M}");
+		return false;
+	}
+}

--- a/src/CommunityToolkit.Maui.Core/Platform/SystemNavigationBar/SystemNavigationBar.ios.cs
+++ b/src/CommunityToolkit.Maui.Core/Platform/SystemNavigationBar/SystemNavigationBar.ios.cs
@@ -1,0 +1,17 @@
+﻿using System.Runtime.Versioning;
+
+namespace CommunityToolkit.Maui.Core.Platform;
+
+[UnsupportedOSPlatform("iOS")]
+static partial class SystemNavigationBar
+{
+	static void PlatformSetColor(Color color)
+	{
+		throw new NotSupportedException("iOS does not currently support changing the iOS system navigation bar color");
+	}
+
+	static void PlatformSetStyle(SystemNavigationBarStyle style)
+	{
+		throw new NotSupportedException("iOS does not currently support changing the iOS system navigation bar color");
+	}
+}

--- a/src/CommunityToolkit.Maui.Core/Platform/SystemNavigationBar/SystemNavigationBar.macos.cs
+++ b/src/CommunityToolkit.Maui.Core/Platform/SystemNavigationBar/SystemNavigationBar.macos.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Runtime.Versioning;
+
+namespace CommunityToolkit.Maui.Core.Platform;
+
+[UnsupportedOSPlatform("MacCatalyst"), UnsupportedOSPlatform("MacOS")]
+static partial class SystemNavigationBar
+{
+	static void PlatformSetColor(Color color)
+	{
+		throw new NotSupportedException("MacCatalyst does not currently support changing the macOS system navigation bar color");
+	}
+
+	static void PlatformSetStyle(SystemNavigationBarStyle style)
+	{
+		throw new NotSupportedException("MacCatalyst does not currently support changing the macOS system navigation bar color");
+	}
+}

--- a/src/CommunityToolkit.Maui.Core/Platform/SystemNavigationBar/SystemNavigationBar.net.cs
+++ b/src/CommunityToolkit.Maui.Core/Platform/SystemNavigationBar/SystemNavigationBar.net.cs
@@ -1,0 +1,8 @@
+namespace CommunityToolkit.Maui.Core.Platform;
+
+static partial class SystemNavigationBar
+{
+	static void PlatformSetColor(Color color) => throw new NotSupportedException($"{nameof(PlatformSetColor)} is only supported on Android 23 and later");
+
+	static void PlatformSetStyle(SystemNavigationBarStyle style) => throw new NotSupportedException($"{nameof(PlatformSetStyle)} is only supported on Android 23 and later");
+}

--- a/src/CommunityToolkit.Maui.Core/Platform/SystemNavigationBar/SystemNavigationBar.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Platform/SystemNavigationBar/SystemNavigationBar.shared.cs
@@ -1,0 +1,21 @@
+﻿namespace CommunityToolkit.Maui.Core.Platform;
+
+/// <summary>
+/// Class that hold the method to customize the SystemNavigationBar
+/// </summary>
+public static partial class SystemNavigationBar
+{
+	/// <summary>
+	/// Method to change the color of the system navigation bar.
+	/// </summary>
+	/// <param name="color">The <see cref="Color"/> that will be set to the system navigation bar.</param>
+	public static void SetColor(Color? color) =>
+		PlatformSetColor(color ?? Colors.Transparent);
+
+	/// <summary>
+	/// Method to change the style of the system navigation bar.
+	/// </summary>
+	/// <param name="systemNavigationBarStyle"> The <see cref="SystemNavigationBarStyle"/> that will used by system navigation bar.</param>
+	public static void SetStyle(SystemNavigationBarStyle systemNavigationBarStyle) =>
+		PlatformSetStyle(systemNavigationBarStyle);
+}

--- a/src/CommunityToolkit.Maui.Core/Platform/SystemNavigationBar/SystemNavigationBar.tizen.cs
+++ b/src/CommunityToolkit.Maui.Core/Platform/SystemNavigationBar/SystemNavigationBar.tizen.cs
@@ -1,0 +1,18 @@
+﻿using System.Runtime.Versioning;
+using Microsoft.Maui.Platform;
+
+namespace CommunityToolkit.Maui.Core.Platform;
+
+[UnsupportedOSPlatform("Tizen")]
+static partial class SystemNavigationBar
+{
+	static void PlatformSetColor(Color color)
+	{
+		throw new NotSupportedException("Tizen does not currently support changing the system navigation bar color");
+	}
+
+	static void PlatformSetStyle(SystemNavigationBarStyle style)
+	{
+		throw new NotSupportedException("Tizen does not currently support changing the system navigation bar color");
+	}
+}

--- a/src/CommunityToolkit.Maui.Core/Platform/SystemNavigationBar/SystemNavigationBar.windows.cs
+++ b/src/CommunityToolkit.Maui.Core/Platform/SystemNavigationBar/SystemNavigationBar.windows.cs
@@ -1,0 +1,17 @@
+﻿using System.Runtime.Versioning;
+
+namespace CommunityToolkit.Maui.Core.Platform;
+
+[UnsupportedOSPlatform("Windows")]
+static partial class SystemNavigationBar
+{
+	static void PlatformSetColor(Color color)
+	{
+		throw new NotSupportedException("WinUI does not currently support changing the Windows system navigation bar color");
+	}
+
+	static void PlatformSetStyle(SystemNavigationBarStyle style)
+	{
+		throw new NotSupportedException("WinUI does not currently support changing the Windows system navigation bar color");
+	}
+}

--- a/src/CommunityToolkit.Maui.Core/Primitives/SystemNavigationBarStyle.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Primitives/SystemNavigationBarStyle.shared.cs
@@ -1,0 +1,20 @@
+﻿namespace CommunityToolkit.Maui.Core;
+
+/// <summary>
+/// Enum that represents the possible style values for the device
+/// </summary>
+public enum SystemNavigationBarStyle
+{
+	/// <summary>
+	/// The default style value
+	/// </summary>
+	Default = 0,
+	/// <summary>
+	/// Light style value
+	/// </summary>
+	LightContent = 1,
+	/// <summary>
+	/// Dark style value
+	/// </summary>
+	DarkContent = 2
+}

--- a/src/CommunityToolkit.Maui.UnitTests/Behaviors/SystemNavigationBarBehaviorTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Behaviors/SystemNavigationBarBehaviorTests.cs
@@ -1,0 +1,57 @@
+﻿using CommunityToolkit.Maui.Behaviors;
+using CommunityToolkit.Maui.Core;
+using FluentAssertions;
+using Xunit;
+
+namespace CommunityToolkit.Maui.UnitTests.Behaviors;
+
+public class SystemNavigationBarBehaviorTests : BaseTest
+{
+	[Fact]
+	public void VerifyDefaults()
+	{
+		var systemNavigationBarBehavior = new SystemNavigationBarBehavior();
+
+		Assert.Equal(Colors.Transparent, systemNavigationBarBehavior.SystemNavigationBarColor);
+		Assert.Equal(SystemNavigationBarStyle.Default, systemNavigationBarBehavior.SystemNavigationBarStyle);
+	}
+
+	[Fact]
+	public void VerifyAttachToPageSucceeds()
+	{
+		var systemNavigationBarBehavior = new SystemNavigationBarBehavior();
+
+		var contentPage = new Page
+		{
+			Behaviors = { systemNavigationBarBehavior }
+		};
+
+		Assert.Single(contentPage.Behaviors.OfType<SystemNavigationBarBehavior>());
+	}
+
+	[Fact]
+	public void VerifyAttachToViewLabelFails()
+	{
+		var systemNavigationBarBehavior = new SystemNavigationBarBehavior();
+
+		var view = new View();
+
+		Assert.Throws<InvalidOperationException>(() => view.Behaviors.Add(systemNavigationBarBehavior));
+	}
+
+	[Fact]
+	public void VerifySystemNavigationBarColorCallsOnPropertyChangedThrowsExceptionOnUnsupportedPlatform()
+	{
+		var systemNavigationBarBehavior = new SystemNavigationBarBehavior();
+		var exception = Assert.Throws<NotSupportedException>(() => systemNavigationBarBehavior.SystemNavigationBarColor = Colors.Red);
+		exception.Message.Should().Be("PlatformSetColor is only supported on Android 23 and later");
+	}
+
+	[Fact]
+	public void VerifySystemNavigationBarStyleCallsOnPropertyChangedThrowsExceptionOnUnsupportedPlatform()
+	{
+		var systemNavigationBarBehavior = new SystemNavigationBarBehavior();
+		var exception = Assert.Throws<NotSupportedException>(() => systemNavigationBarBehavior.SystemNavigationBarStyle = SystemNavigationBarStyle.DarkContent);
+		exception.Message.Should().Be("PlatformSetStyle is only supported on Android 23 and later");
+	}
+}

--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/StatusBar/StatusBarBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/StatusBar/StatusBarBehavior.shared.cs
@@ -21,7 +21,7 @@ public class StatusBarBehavior : PlatformBehavior<Page>
 
 
 	/// <summary>
-	/// <see cref="BindableProperty"/> that manages the StatusBarColor property.
+	/// <see cref="BindableProperty"/> that manages the StatusBarStyle property.
 	/// </summary>
 	public static readonly BindableProperty StatusBarStyleProperty =
 		BindableProperty.Create(nameof(StatusBarStyle), typeof(StatusBarStyle), typeof(StatusBarBehavior), StatusBarStyle.Default);
@@ -36,7 +36,7 @@ public class StatusBarBehavior : PlatformBehavior<Page>
 	}
 
 	/// <summary>
-	/// Property that holds the value of the Status bar color. 
+	/// Property that holds the value of the Status bar style. 
 	/// </summary>
 	public StatusBarStyle StatusBarStyle
 	{

--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/SystemNavigationBar/SystemNavigationBarBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/SystemNavigationBar/SystemNavigationBarBehavior.shared.cs
@@ -1,0 +1,87 @@
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
+using CommunityToolkit.Maui.Core;
+using CommunityToolkit.Maui.Core.Platform;
+using CommunityToolkit.Maui.Extensions;
+
+namespace CommunityToolkit.Maui.Behaviors;
+
+/// <summary>
+/// <see cref="PlatformBehavior{TView,TPlatformView}"/> that controls the System navigation bar color
+/// </summary>
+[UnsupportedOSPlatform("Windows"), UnsupportedOSPlatform("MacCatalyst"), UnsupportedOSPlatform("MacOS"), UnsupportedOSPlatform("Tizen"), UnsupportedOSPlatform("iOS")]
+public class SystemNavigationBarBehavior : PlatformBehavior<Page>
+{
+	/// <summary>
+	/// <see cref="BindableProperty"/> that manages the SystemNavigationBarColor property.
+	/// </summary>
+	public static readonly BindableProperty SystemNavigationBarColorProperty =
+		BindableProperty.Create(nameof(SystemNavigationBarColor), typeof(Color), typeof(SystemNavigationBarBehavior), Colors.Transparent);
+
+
+	/// <summary>
+	/// <see cref="BindableProperty"/> that manages the SystemNavigationBarStyle property.
+	/// </summary>
+	public static readonly BindableProperty SystemNavigationBarStyleProperty =
+		BindableProperty.Create(nameof(SystemNavigationBarStyle), typeof(SystemNavigationBarStyle), typeof(SystemNavigationBarBehavior), SystemNavigationBarStyle.Default);
+
+	/// <summary>
+	/// Property that holds the value of the system navigation bar color. 
+	/// </summary>
+	public Color SystemNavigationBarColor
+	{
+		get => (Color)GetValue(SystemNavigationBarColorProperty);
+		set => SetValue(SystemNavigationBarColorProperty, value);
+	}
+
+	/// <summary>
+	/// Property that holds the value of the system navigation bar style. 
+	/// </summary>
+	public SystemNavigationBarStyle SystemNavigationBarStyle
+	{
+		get => (SystemNavigationBarStyle)GetValue(SystemNavigationBarStyleProperty);
+		set => SetValue(SystemNavigationBarStyleProperty, value);
+	}
+
+#if !(WINDOWS || MACCATALYST || TIZEN || IOS)
+
+	/// <inheritdoc /> 
+#if ANDROID
+	protected override void OnAttachedTo(Page bindable, Android.Views.View platformView)
+#else
+	protected override void OnAttachedTo(Page bindable, object platformView)
+#endif
+	{
+		SystemNavigationBar.SetColor(SystemNavigationBarColor);
+		SystemNavigationBar.SetStyle(SystemNavigationBarStyle);
+	}
+
+	/// <inheritdoc /> 
+	protected override void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+	{
+		base.OnPropertyChanged(propertyName);
+
+		if (string.IsNullOrWhiteSpace(propertyName))
+		{
+			return;
+		}
+
+#if ANDROID
+		if (Platform.CurrentActivity is null)
+		{
+			return;
+		}
+#endif
+
+		if (propertyName.IsOneOf(SystemNavigationBarColorProperty, VisualElement.WidthProperty, VisualElement.HeightProperty))
+		{
+			SystemNavigationBar.SetColor(SystemNavigationBarColor);
+		}
+		else if (propertyName == SystemNavigationBarStyleProperty.PropertyName)
+		{
+			SystemNavigationBar.SetStyle(SystemNavigationBarStyle);
+		}
+	}
+#endif
+}


### PR DESCRIPTION
 ### Description of Change ###

Implement the behavior for system navigation bar (android-specific).

 ### Linked Issues ###

#103

 ### PR Checklist ###
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

- This feature is not available on iOS. Should we hide the page link in the sample app on iOS? It does not seem to be the case for other features that are platform specific.
- StatusBar is only available for android>23, although according to the doc [here](https://developer.android.com/reference/android/view/Window#setStatusBarColor(int)), the min api is 21. I've also set min version 23 for system navigation bar.
- I've copied the StatusBarStyle enum to SystemNavigationBarStyle. It would be better to have a single SystemBarStyle enum, and share it for both system bars, but I don't think it's worth a breaking change for now.