### PR TITLE
Remove the old code to set the status bar behavior values

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/StatusBarBehaviorPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/StatusBarBehaviorPage.xaml.cs
@@ -9,12 +9,4 @@ public partial class StatusBarBehaviorPage : BasePage<StatusBarBehaviorViewModel
 	{
 		InitializeComponent();
 	}
-
-	protected override void OnNavigatedTo(NavigatedToEventArgs args)
-	{
-		base.OnNavigatedTo(args);
-
-		var statusBarColor = Color.FromRgb(BindingContext.RedSliderValue, BindingContext.GreenSliderValue, BindingContext.BlueSliderValue);
-		CommunityToolkit.Maui.Core.Platform.StatusBar.SetColor(statusBarColor);
-	}
 }


### PR DESCRIPTION
This might not be completely necessary as it doesn't currently conflicting with our samples page but... the code removed here does conflict if a developer opts for just providing a value into the `StatusBarBehavior` (e.g. 

```xaml
<Page.Behaviors>
        <mct:StatusBarBehavior
              StatusBarColor="Red"
              StatusBarStyle="{Binding Source={x:Reference Page}, Path=BindingContext.StatusBarStyle}" />
 </Page.Behaviors>
```

The resulting behaviour will be that no Color will exist and the status bar (at least on iOS) will be Black.