### PR TITLE
Fix Crash when removing USB drive

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Essentials/FileSaver/FileSaverImplementation.android.cs
+++ b/src/CommunityToolkit.Maui.Core/Essentials/FileSaver/FileSaverImplementation.android.cs
@@ -113,6 +113,7 @@ public sealed partial class FileSaverImplementation : IFileSaver
 			ArrayPool<byte>.Shared.Return(buffer);
 		}
 
+		parcelFileDescriptor?.Close();
 		return uri.ToPhysicalPath() ?? throw new FileSaveException($"Unable to resolve absolute path where the file was saved '{uri}'.");
 	}
 }


### PR DESCRIPTION
 ### Description of Change ###
Manually close OpenFileDescriptor

 ### Linked Issues ###
#1588

 - Fixes #
Fix Crash when removing USB drive
