### PR TITLE
Fix Media Element Transport controls visibility

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.windows.cs
@@ -65,7 +65,7 @@ public class MauiMediaElement : Grid, IDisposable
 			HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Right,
 			VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Top,
 			Visibility = mediaPlayerElement.TransportControls.Visibility,
-		Width = 40,
+			Width = 40,
 			Height = 40
 		};
 		buttonContainer.Children.Add(image);

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.windows.cs
@@ -64,7 +64,8 @@ public class MauiMediaElement : Grid, IDisposable
 		{
 			HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Right,
 			VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Top,
-			Width = 40,
+			Visibility = Microsoft.UI.Xaml.Visibility.Collapsed,
+		Width = 40,
 			Height = 40
 		};
 		buttonContainer.Children.Add(image);
@@ -134,6 +135,11 @@ public class MauiMediaElement : Grid, IDisposable
 	async void OnMediaPlayerElementPointerMoved(object sender, PointerRoutedEventArgs e)
 	{
 		e.Handled = true;
+		if (mediaPlayerElement.TransportControls.Visibility == Microsoft.UI.Xaml.Visibility.Collapsed)
+		{
+			buttonContainer.Visibility = Microsoft.UI.Xaml.Visibility.Collapsed;
+			return;
+		}
 		mediaPlayerElement.PointerMoved -= OnMediaPlayerElementPointerMoved;
 		buttonContainer.Visibility = Microsoft.UI.Xaml.Visibility.Visible;
 

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.windows.cs
@@ -64,7 +64,7 @@ public class MauiMediaElement : Grid, IDisposable
 		{
 			HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Right,
 			VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Top,
-			Visibility = Microsoft.UI.Xaml.Visibility.Collapsed,
+			Visibility = mediaPlayerElement.TransportControls.Visibility,
 		Width = 40,
 			Height = 40
 		};
@@ -135,11 +135,13 @@ public class MauiMediaElement : Grid, IDisposable
 	async void OnMediaPlayerElementPointerMoved(object sender, PointerRoutedEventArgs e)
 	{
 		e.Handled = true;
+		buttonContainer.Visibility = mediaPlayerElement.TransportControls.Visibility;
+
 		if (mediaPlayerElement.TransportControls.Visibility == Microsoft.UI.Xaml.Visibility.Collapsed)
 		{
-			buttonContainer.Visibility = Microsoft.UI.Xaml.Visibility.Collapsed;
 			return;
 		}
+
 		mediaPlayerElement.PointerMoved -= OnMediaPlayerElementPointerMoved;
 		buttonContainer.Visibility = Microsoft.UI.Xaml.Visibility.Visible;
 


### PR DESCRIPTION
 ### Description of Change ###
1. In the `MauiMediaElement` constructor, we added setting of the `Visibility`. Now, the `Visibility` property is set to `Collapsed` in the constructor.

2. A new conditional statement has been added to the `OnMediaPlayerElementPointerMoved` method. If the `Visibility` property of `mediaPlayerElement.TransportControls` is `Collapsed`, the `Visibility` property of `buttonContainer` is also set to `Collapsed` and the method returns early. This behavior was not present in the previous version of the method.

### Video of Bug

https://github.com/CommunityToolkit/Maui/assets/4167863/cd2226fa-2d1e-4c7e-8e24-db59f039698f




### Video with Fix applied


https://github.com/CommunityToolkit/Maui/assets/4167863/296a27ec-3e9b-4078-bfcc-f95b03c39118





 ### Linked Issues ###

 - Fixes #1745

 ### PR Checklist ###
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###
This applies to a windows specific issue with a button that did not comply with the transport control settings. This PR fixes that and the button is now compliant. If the transport controls are turned off while the controls are visible the full screen controls will stay on until it time out but will not reappear until the controls are turned back on.
