### PR TITLE
Fix IOS crash when entering Full Screen

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml
@@ -9,7 +9,6 @@
              x:TypeArguments="viewModels:MediaElementViewModel"
              x:DataType="viewModels:MediaElementViewModel"
              x:Class="CommunityToolkit.Maui.Sample.Pages.Views.MediaElementPage"
-             Unloaded="MediaElementUnloaded"
              Title="MediaElement">
     <pages:BasePage.Resources>
         <toolkit:TimeSpanToSecondsConverter x:Key="TimeSpanConverter" />

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml.cs
@@ -118,6 +118,7 @@ public partial class MediaElementPage : BasePage<MediaElementViewModel>
 	protected override void OnNavigatedFrom(NavigatedFromEventArgs args)
 	{
 		base.OnNavigatedFrom(args);
+		MediaElement.Stop();
 		MediaElement.Handler?.DisconnectHandler();
 	}
 
@@ -244,10 +245,5 @@ public partial class MediaElementPage : BasePage<MediaElementViewModel>
 			popupMediaElement.Stop();
 			popupMediaElement.Handler?.DisconnectHandler();
 		};
-	}
-
-	void MediaElementUnloaded(object sender, EventArgs e)
-	{
-		MediaElement.Handler?.DisconnectHandler();
 	}
 }


### PR DESCRIPTION
- Bug fix

 ### Description of Change ###
The most significant changes involve the removal of the `MediaElementUnloaded` method and the `Unloaded` event handler from the `MediaElementPage.xaml.cs` and `MediaElementPage.xaml` files respectively. These were previously used to disconnect the handler when the media element was unloaded. Additionally, the `OnNavigatedFrom` method in the `MediaElementPage.xaml.cs` file was updated to stop the media element from playing when navigation away from the page occurs.

List of changes:

1. Removal of the `MediaElementUnloaded` method from the `MediaElementPage.xaml.cs` file. This method was previously used to disconnect the handler when the media element was unloaded.
2. Update to the `OnNavigatedFrom` method in the `MediaElementPage.xaml.cs` file to include a call to `MediaElement.Stop()`. This stops the media element from playing when navigation away from the page occurs.
3. Removal of the `Unloaded` event handler from the `MediaElementPage.xaml` file. This event handler was previously used to call the `MediaElementUnloaded` method when the media element was unloaded.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #1110

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

While adding Full Screen controls an `unloaded` event was added that called `MediaElement.Handler?.Disconnect();` When entering full screen on IOS this event was called. I do not know why IOS calls unload event for switching to or from full screen it just does. This issue is an IOS only issue. It does not affect Mac.

I have tested this PR against Windows, Mac Catalyst, IOS and Android with almost no issues. For unknown reasons when returning to normal mode from full screen on IOS it pauses playback. This does not happen in Mac Catalyst. This is the only issue with this PR atm. I have no idea why IOS pauses upon returning from full screen.
