### PR TITLE
Add popup sizing page to cover more test scenarios

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/AppShell.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/AppShell.xaml.cs
@@ -129,6 +129,7 @@ public partial class AppShell : Shell
 		CreateViewModelMapping<PopupAnchorPage, PopupAnchorViewModel, ViewsGalleryPage, ViewsGalleryViewModel>(),
 		CreateViewModelMapping<PopupLayoutAlignmentPage, PopupLayoutAlignmentViewModel, ViewsGalleryPage, ViewsGalleryViewModel>(),
 		CreateViewModelMapping<PopupPositionPage, PopupPositionViewModel, ViewsGalleryPage, ViewsGalleryViewModel>(),
+		CreateViewModelMapping<PopupSizingIssuesPage, PopupSizingIssuesViewModel, ViewsGalleryPage, ViewsGalleryViewModel>(),
 		CreateViewModelMapping<SemanticOrderViewPage, SemanticOrderViewPageViewModel, ViewsGalleryPage, ViewsGalleryViewModel>(),
 		CreateViewModelMapping<ShowPopupInOnAppearingPage, ShowPopupInOnAppearingPageViewModel, ViewsGalleryPage, ViewsGalleryViewModel>(),
 		CreateViewModelMapping<StylePopupPage, StylePopupViewModel, ViewsGalleryPage, ViewsGalleryViewModel>(),

--- a/samples/CommunityToolkit.Maui.Sample/MauiProgram.cs
+++ b/samples/CommunityToolkit.Maui.Sample/MauiProgram.cs
@@ -199,6 +199,7 @@ public static class MauiProgram
 		services.AddTransientWithShellRoute<SemanticOrderViewPage, SemanticOrderViewPageViewModel>();
 		services.AddTransientWithShellRoute<ShowPopupInOnAppearingPage, ShowPopupInOnAppearingPageViewModel>();
 		services.AddTransientWithShellRoute<StylePopupPage, StylePopupViewModel>();
+		services.AddTransientWithShellRoute<PopupSizingIssuesPage, PopupSizingIssuesViewModel>();
 
 		// Add Popups
 		services.AddTransientPopup<CsharpBindingPopup, CsharpBindingPopupViewModel>();

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Alerts/AlertsGalleryPage.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Alerts/AlertsGalleryPage.cs
@@ -2,10 +2,7 @@
 
 namespace CommunityToolkit.Maui.Sample.Pages.Alerts;
 
-public class AlertsGalleryPage : BaseGalleryPage<AlertsGalleryViewModel>
+public class AlertsGalleryPage(IDeviceInfo deviceInfo, AlertsGalleryViewModel alertsGalleryViewModel) : BaseGalleryPage<AlertsGalleryViewModel>("Alerts", deviceInfo, alertsGalleryViewModel)
 {
-	public AlertsGalleryPage(IDeviceInfo deviceInfo, AlertsGalleryViewModel alertsGalleryViewModel)
-		: base("Alerts", deviceInfo, alertsGalleryViewModel)
-	{
-	}
+	
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Alerts/AlertsGalleryPage.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Alerts/AlertsGalleryPage.cs
@@ -4,5 +4,5 @@ namespace CommunityToolkit.Maui.Sample.Pages.Alerts;
 
 public class AlertsGalleryPage(IDeviceInfo deviceInfo, AlertsGalleryViewModel alertsGalleryViewModel) : BaseGalleryPage<AlertsGalleryViewModel>("Alerts", deviceInfo, alertsGalleryViewModel)
 {
-	
+
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Base/BaseGalleryPage.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Base/BaseGalleryPage.cs
@@ -20,10 +20,10 @@ public abstract class BaseGalleryPage<TViewModel> : BasePage<TViewModel> where T
 			.Bind(ItemsView.ItemsSourceProperty,
 				static (BaseGalleryViewModel vm) => vm.Items,
 				mode: BindingMode.OneTime)
-			.Invoke(collectionView => collectionView.SelectionChanged += HandleSelectionChanged);
+			.Invoke(static collectionView => collectionView.SelectionChanged += HandleSelectionChanged);
 	}
 
-	async void HandleSelectionChanged(object? sender, SelectionChangedEventArgs e)
+	static async void HandleSelectionChanged(object? sender, SelectionChangedEventArgs e)
 	{
 		ArgumentNullException.ThrowIfNull(sender);
 
@@ -35,76 +35,71 @@ public abstract class BaseGalleryPage<TViewModel> : BasePage<TViewModel> where T
 			await Shell.Current.GoToAsync(AppShell.GetPageRoute(sectionModel.ViewModelType));
 		}
 	}
-}
 
-class GalleryDataTemplate : DataTemplate
-{
-	public GalleryDataTemplate() : base(CreateDataTemplate)
+	sealed class GalleryDataTemplate() : DataTemplate(CreateDataTemplate)
 	{
 
-	}
+		enum Row { TopPadding, Content, BottomPadding }
+		enum Column { LeftPadding, Content, RightPadding }
 
-	enum Row { TopPadding, Content, BottomPadding }
-	enum Column { LeftPadding, Content, RightPadding }
-
-	static Grid CreateDataTemplate() => new()
-	{
-		RowDefinitions = Rows.Define(
-			(Row.TopPadding, 12),
-			(Row.Content, Star),
-			(Row.BottomPadding, 12)),
-
-		ColumnDefinitions = Columns.Define(
-			(Column.LeftPadding, 24),
-			(Column.Content, Star),
-			(Column.RightPadding, 24)),
-
-		Children =
+		static Grid CreateDataTemplate() => new()
 		{
-			new Card().Row(Row.Content).Column(Column.Content).DynamicResource(Border.StyleProperty, "BorderGalleryCard")
-		}
-	};
+			RowDefinitions = Rows.Define(
+				(Row.TopPadding, 12),
+				(Row.Content, Star),
+				(Row.BottomPadding, 12)),
 
-	class Card : Border
-	{
-		public Card()
-		{
-			Content = new Grid
+			ColumnDefinitions = Columns.Define(
+				(Column.LeftPadding, 24),
+				(Column.Content, Star),
+				(Column.RightPadding, 24)),
+
+			Children =
 			{
-				BackgroundColor = Colors.Transparent,
+				new Card().Row(Row.Content).Column(Column.Content).DynamicResource(StyleProperty, "BorderGalleryCard")
+			}
+		};
 
-				RowSpacing = 4,
-
-				RowDefinitions = Rows.Define(
-					(CardRow.Title, 24),
-					(CardRow.Description, Auto)),
-
-				ColumnDefinitions = Columns.Define(Star),
-
-				Children =
+		sealed class Card : Border
+		{
+			public Card()
+			{
+				Content = new Grid
 				{
-					new Label()
-						.Row(CardRow.Title)
-						.Bind(Label.TextProperty,
-							static (SectionModel section) => section.Title,
-							mode: BindingMode.OneTime)
-						.DynamicResource(Label.StyleProperty, "LabelSectionTitle"),
+					BackgroundColor = Colors.Transparent,
 
-					new Label
-						{
-							MaxLines = 4,
-							LineBreakMode = LineBreakMode.WordWrap
-						}
-						.Row(CardRow.Description).TextStart().TextTop()
-						.Bind(Label.TextProperty,
-							static (SectionModel section) => section.Description,
-							mode: BindingMode.OneTime)
-						.DynamicResource(Label.StyleProperty, "LabelSectionText")
-				}
-			};
+					RowSpacing = 4,
+
+					RowDefinitions = Rows.Define(
+						(CardRow.Title, 24),
+						(CardRow.Description, Auto)),
+
+					ColumnDefinitions = Columns.Define(Star),
+
+					Children =
+					{
+						new Label()
+							.Row(CardRow.Title)
+							.Bind(Label.TextProperty,
+								static (SectionModel section) => section.Title,
+								mode: BindingMode.OneTime)
+							.DynamicResource(Label.StyleProperty, "LabelSectionTitle"),
+
+						new Label
+							{
+								MaxLines = 4,
+								LineBreakMode = LineBreakMode.WordWrap
+							}
+							.Row(CardRow.Description).TextStart().TextTop()
+							.Bind(Label.TextProperty,
+								static (SectionModel section) => section.Description,
+								mode: BindingMode.OneTime)
+							.DynamicResource(Label.StyleProperty, "LabelSectionText")
+					}
+				};
+			}
 		}
-	}
 
-	enum CardRow { Title, Description }
-}
+		enum CardRow { Title, Description }
+	}
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Base/BaseGalleryPage.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Base/BaseGalleryPage.cs
@@ -14,20 +14,18 @@ public abstract class BaseGalleryPage<TViewModel> : BasePage<TViewModel> where T
 		Padding = 0;
 
 		Content = new CollectionView
-		{
-			SelectionMode = SelectionMode.Single,
-		}.ItemTemplate(new GalleryDataTemplate())
-		 .Bind(ItemsView.ItemsSourceProperty,
-					static (BaseGalleryViewModel vm) => vm.Items,
-					mode: BindingMode.OneTime)
-		 .Invoke(collectionView => collectionView.SelectionChanged += HandleSelectionChanged);
+			{
+				SelectionMode = SelectionMode.Single,
+			}.ItemTemplate(new GalleryDataTemplate())
+			.Bind(ItemsView.ItemsSourceProperty,
+				static (BaseGalleryViewModel vm) => vm.Items,
+				mode: BindingMode.OneTime)
+			.Invoke(collectionView => collectionView.SelectionChanged += HandleSelectionChanged);
 	}
 
 	async void HandleSelectionChanged(object? sender, SelectionChangedEventArgs e)
 	{
-		try
-		{
-			ArgumentNullException.ThrowIfNull(sender);
+		ArgumentNullException.ThrowIfNull(sender);
 
 		var collectionView = (CollectionView)sender;
 		collectionView.SelectedItem = null;
@@ -36,78 +34,77 @@ public abstract class BaseGalleryPage<TViewModel> : BasePage<TViewModel> where T
 		{
 			await Shell.Current.GoToAsync(AppShell.GetPageRoute(sectionModel.ViewModelType));
 		}
-		}
-		catch (Exception ex)
-		{
-			_ = ex;
-		}
-		
 	}
+}
 
-	class GalleryDataTemplate : DataTemplate
+class GalleryDataTemplate : DataTemplate
+{
+	public GalleryDataTemplate() : base(CreateDataTemplate)
 	{
-		public GalleryDataTemplate() : base(CreateDataTemplate)
-		{
 
-		}
-
-		enum Row { TopPadding, Content, BottomPadding }
-		enum Column { LeftPadding, Content, RightPadding }
-
-		static Grid CreateDataTemplate() => new()
-		{
-			RowDefinitions = Rows.Define(
-				(Row.TopPadding, 12),
-				(Row.Content, Star),
-				(Row.BottomPadding, 12)),
-
-			ColumnDefinitions = Columns.Define(
-				(Column.LeftPadding, 24),
-				(Column.Content, Star),
-				(Column.RightPadding, 24)),
-
-			Children =
-			{
-				new Card().Row(Row.Content).Column(Column.Content).DynamicResource(Border.StyleProperty, "BorderGalleryCard")
-			}
-		};
-
-		class Card : Border
-		{
-			public Card()
-			{
-				Content = new Grid
-				{
-					BackgroundColor = Colors.Transparent,
-
-					RowSpacing = 4,
-
-					RowDefinitions = Rows.Define(
-						(CardRow.Title, 24),
-						(CardRow.Description, Auto)),
-
-					ColumnDefinitions = Columns.Define(Star),
-
-					Children =
-					{
-						new Label()
-							.Row(CardRow.Title)
-							.Bind(Label.TextProperty,
-									static (SectionModel section) => section.Title,
-									mode: BindingMode.OneTime)
-							.DynamicResource(Label.StyleProperty, "LabelSectionTitle"),
-
-						new Label { MaxLines = 4, LineBreakMode = LineBreakMode.WordWrap }
-							.Row(CardRow.Description).TextStart().TextTop()
-							.Bind(Label.TextProperty,
-									static (SectionModel section) => section.Description,
-									mode: BindingMode.OneTime)
-							.DynamicResource(Label.StyleProperty, "LabelSectionText")
-					}
-				};
-			}
-		}
-
-		enum CardRow { Title, Description }
 	}
+
+	enum Row { TopPadding, Content, BottomPadding }
+	enum Column { LeftPadding, Content, RightPadding }
+
+	static Grid CreateDataTemplate() => new()
+	{
+		RowDefinitions = Rows.Define(
+			(Row.TopPadding, 12),
+			(Row.Content, Star),
+			(Row.BottomPadding, 12)),
+
+		ColumnDefinitions = Columns.Define(
+			(Column.LeftPadding, 24),
+			(Column.Content, Star),
+			(Column.RightPadding, 24)),
+
+		Children =
+		{
+			new Card().Row(Row.Content).Column(Column.Content).DynamicResource(Border.StyleProperty, "BorderGalleryCard")
+		}
+	};
+
+	class Card : Border
+	{
+		public Card()
+		{
+			Content = new Grid
+			{
+				BackgroundColor = Colors.Transparent,
+
+				RowSpacing = 4,
+
+				RowDefinitions = Rows.Define(
+					(CardRow.Title, 24),
+					(CardRow.Description, Auto)),
+
+				ColumnDefinitions = Columns.Define(Star),
+
+				Children =
+				{
+					new Label()
+						.Row(CardRow.Title)
+						.Bind(Label.TextProperty,
+							static (SectionModel section) => section.Title,
+							mode: BindingMode.OneTime)
+						.DynamicResource(Label.StyleProperty, "LabelSectionTitle"),
+
+					new Label
+						{
+							MaxLines = 4,
+							LineBreakMode = LineBreakMode.WordWrap
+						}
+						.Row(CardRow.Description).TextStart().TextTop()
+						.Bind(Label.TextProperty,
+							static (SectionModel section) => section.Description,
+							mode: BindingMode.OneTime)
+						.DynamicResource(Label.StyleProperty, "LabelSectionText")
+				}
+			};
+		}
+	}
+
+	enum CardRow { Title, Description }
+}
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Base/BaseGalleryPage.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Base/BaseGalleryPage.cs
@@ -25,7 +25,9 @@ public abstract class BaseGalleryPage<TViewModel> : BasePage<TViewModel> where T
 
 	async void HandleSelectionChanged(object? sender, SelectionChangedEventArgs e)
 	{
-		ArgumentNullException.ThrowIfNull(sender);
+		try
+		{
+			ArgumentNullException.ThrowIfNull(sender);
 
 		var collectionView = (CollectionView)sender;
 		collectionView.SelectedItem = null;
@@ -34,6 +36,12 @@ public abstract class BaseGalleryPage<TViewModel> : BasePage<TViewModel> where T
 		{
 			await Shell.Current.GoToAsync(AppShell.GetPageRoute(sectionModel.ViewModelType));
 		}
+		}
+		catch (Exception ex)
+		{
+			_ = ex;
+		}
+		
 	}
 
 	class GalleryDataTemplate : DataTemplate

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Base/BaseGalleryPage.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Base/BaseGalleryPage.cs
@@ -14,9 +14,9 @@ public abstract class BaseGalleryPage<TViewModel> : BasePage<TViewModel> where T
 		Padding = 0;
 
 		Content = new CollectionView
-			{
-				SelectionMode = SelectionMode.Single,
-			}.ItemTemplate(new GalleryDataTemplate())
+		{
+			SelectionMode = SelectionMode.Single,
+		}.ItemTemplate(new GalleryDataTemplate())
 			.Bind(ItemsView.ItemsSourceProperty,
 				static (BaseGalleryViewModel vm) => vm.Items,
 				mode: BindingMode.OneTime)

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Converters/ConvertersGalleryPage.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Converters/ConvertersGalleryPage.cs
@@ -4,5 +4,5 @@ namespace CommunityToolkit.Maui.Sample.Pages.Converters;
 
 public class ConvertersGalleryPage(IDeviceInfo deviceInfo, ConvertersGalleryViewModel convertersGalleryViewModel) : BaseGalleryPage<ConvertersGalleryViewModel>("Converters", deviceInfo, convertersGalleryViewModel)
 {
-	
+
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Converters/ConvertersGalleryPage.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Converters/ConvertersGalleryPage.cs
@@ -2,10 +2,7 @@
 
 namespace CommunityToolkit.Maui.Sample.Pages.Converters;
 
-public class ConvertersGalleryPage : BaseGalleryPage<ConvertersGalleryViewModel>
+public class ConvertersGalleryPage(IDeviceInfo deviceInfo, ConvertersGalleryViewModel convertersGalleryViewModel) : BaseGalleryPage<ConvertersGalleryViewModel>("Converters", deviceInfo, convertersGalleryViewModel)
 {
-	public ConvertersGalleryPage(IDeviceInfo deviceInfo, ConvertersGalleryViewModel convertersGalleryViewModel)
-		: base("Converters", deviceInfo, convertersGalleryViewModel)
-	{
-	}
+	
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Essentials/EssentialsGalleryPage.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Essentials/EssentialsGalleryPage.cs
@@ -4,5 +4,5 @@ namespace CommunityToolkit.Maui.Sample.Pages.Essentials;
 
 public class EssentialsGalleryPage(IDeviceInfo deviceInfo, EssentialsGalleryViewModel essentialsGalleryViewModel) : BaseGalleryPage<EssentialsGalleryViewModel>("Essentials", deviceInfo, essentialsGalleryViewModel)
 {
-	
+
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Essentials/EssentialsGalleryPage.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Essentials/EssentialsGalleryPage.cs
@@ -2,10 +2,7 @@
 
 namespace CommunityToolkit.Maui.Sample.Pages.Essentials;
 
-public class EssentialsGalleryPage : BaseGalleryPage<EssentialsGalleryViewModel>
+public class EssentialsGalleryPage(IDeviceInfo deviceInfo, EssentialsGalleryViewModel essentialsGalleryViewModel) : BaseGalleryPage<EssentialsGalleryViewModel>("Essentials", deviceInfo, essentialsGalleryViewModel)
 {
-	public EssentialsGalleryPage(IDeviceInfo deviceInfo, EssentialsGalleryViewModel essentialsGalleryViewModel)
-		: base("Essentials", deviceInfo, essentialsGalleryViewModel)
-	{
-	}
+	
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ExtensionsGalleryPage.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ExtensionsGalleryPage.cs
@@ -4,5 +4,5 @@ namespace CommunityToolkit.Maui.Sample.Pages.Extensions;
 
 public class ExtensionsGalleryPage(IDeviceInfo deviceInfo, ExtensionsGalleryViewModel extensionsGalleryViewModel) : BaseGalleryPage<ExtensionsGalleryViewModel>("Extensions", deviceInfo, extensionsGalleryViewModel)
 {
-	
+
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ExtensionsGalleryPage.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Extensions/ExtensionsGalleryPage.cs
@@ -2,10 +2,7 @@
 
 namespace CommunityToolkit.Maui.Sample.Pages.Extensions;
 
-public class ExtensionsGalleryPage : BaseGalleryPage<ExtensionsGalleryViewModel>
+public class ExtensionsGalleryPage(IDeviceInfo deviceInfo, ExtensionsGalleryViewModel extensionsGalleryViewModel) : BaseGalleryPage<ExtensionsGalleryViewModel>("Extensions", deviceInfo, extensionsGalleryViewModel)
 {
-	public ExtensionsGalleryPage(IDeviceInfo deviceInfo, ExtensionsGalleryViewModel extensionsGalleryViewModel)
-		: base("Extensions", deviceInfo, extensionsGalleryViewModel)
-	{
-	}
+	
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/ImageSources/ImageSourcesGalleryPage.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/ImageSources/ImageSourcesGalleryPage.cs
@@ -4,5 +4,5 @@ namespace CommunityToolkit.Maui.Sample.Pages.ImageSources;
 
 public class ImageSourcesGalleryPage(IDeviceInfo deviceInfo, ImageSourcesGalleryViewModel imageSourcesGalleryViewModel) : BaseGalleryPage<ImageSourcesGalleryViewModel>("Image Sources", deviceInfo, imageSourcesGalleryViewModel)
 {
-	
+
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/ImageSources/ImageSourcesGalleryPage.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/ImageSources/ImageSourcesGalleryPage.cs
@@ -2,10 +2,7 @@
 
 namespace CommunityToolkit.Maui.Sample.Pages.ImageSources;
 
-public class ImageSourcesGalleryPage : BaseGalleryPage<ImageSourcesGalleryViewModel>
+public class ImageSourcesGalleryPage(IDeviceInfo deviceInfo, ImageSourcesGalleryViewModel imageSourcesGalleryViewModel) : BaseGalleryPage<ImageSourcesGalleryViewModel>("Image Sources", deviceInfo, imageSourcesGalleryViewModel)
 {
-	public ImageSourcesGalleryPage(IDeviceInfo deviceInfo, ImageSourcesGalleryViewModel imageSourcesGalleryViewModel)
-		: base("Image Sources", deviceInfo, imageSourcesGalleryViewModel)
-	{
-	}
+	
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Layouts/LayoutsGalleryPage.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Layouts/LayoutsGalleryPage.cs
@@ -4,5 +4,5 @@ namespace CommunityToolkit.Maui.Sample.Pages.Layouts;
 
 public class LayoutsGalleryPage(IDeviceInfo deviceInfo, LayoutsGalleryViewModel layoutGalleryViewModel) : BaseGalleryPage<LayoutsGalleryViewModel>("Layouts", deviceInfo, layoutGalleryViewModel)
 {
-	
+
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Layouts/LayoutsGalleryPage.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Layouts/LayoutsGalleryPage.cs
@@ -2,10 +2,7 @@
 
 namespace CommunityToolkit.Maui.Sample.Pages.Layouts;
 
-public class LayoutsGalleryPage : BaseGalleryPage<LayoutsGalleryViewModel>
+public class LayoutsGalleryPage(IDeviceInfo deviceInfo, LayoutsGalleryViewModel layoutGalleryViewModel) : BaseGalleryPage<LayoutsGalleryViewModel>("Layouts", deviceInfo, layoutGalleryViewModel)
 {
-	public LayoutsGalleryPage(IDeviceInfo deviceInfo, LayoutsGalleryViewModel layoutGalleryViewModel)
-		: base("Layouts", deviceInfo, layoutGalleryViewModel)
-	{
-	}
+	
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/Popup/PopupSizingIssuesPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/Popup/PopupSizingIssuesPage.xaml
@@ -19,6 +19,9 @@
 
                 <Label Text="Padding" />
                 <Entry Text="{Binding Padding}" />
+                
+                <Label Text="Margin" />
+                <Entry Text="{Binding Margin}" />
 
                 <Button Text="Show Popup" Command="{Binding ShowPopupCommand}" CommandParameter="{Binding Source={x:Reference Self}}" />
             </VerticalStackLayout>

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/Popup/PopupSizingIssuesPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/Popup/PopupSizingIssuesPage.xaml
@@ -1,0 +1,28 @@
+﻿<pages:BasePage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                xmlns:pages="clr-namespace:CommunityToolkit.Maui.Sample.Pages"
+                xmlns:viewModels="clr-namespace:CommunityToolkit.Maui.Sample.ViewModels.Views"
+                x:Class="CommunityToolkit.Maui.Sample.Pages.Views.PopupSizingIssuesPage"
+                Title="MultiplePopupPage"
+                x:TypeArguments="viewModels:PopupSizingIssuesViewModel"
+                x:DataType="viewModels:PopupSizingIssuesViewModel"
+                x:Name="Self">
+
+    <ContentPage.Content>
+        <ScrollView>
+            <VerticalStackLayout Spacing="12">
+                <Label Text="Select a container to show a popup" />
+                <Picker 
+                    ItemsSource="{Binding Containers}" 
+                    SelectedItem="{Binding SelectedContainer}" 
+                    ItemDisplayBinding="{Binding Name}"/>
+
+                <Label Text="Padding" />
+                <Entry Text="{Binding Padding}" />
+
+                <Button Text="Show Popup" Command="{Binding ShowPopupCommand}" CommandParameter="{Binding Source={x:Reference Self}}" />
+            </VerticalStackLayout>
+        </ScrollView>
+    </ContentPage.Content>
+
+</pages:BasePage>

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/Popup/PopupSizingIssuesPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/Popup/PopupSizingIssuesPage.xaml.cs
@@ -1,0 +1,13 @@
+using CommunityToolkit.Maui.Sample.ViewModels.Views;
+
+namespace CommunityToolkit.Maui.Sample.Pages.Views;
+
+public partial class PopupSizingIssuesPage : BasePage<PopupSizingIssuesViewModel>
+{
+	public PopupSizingIssuesPage(
+		PopupSizingIssuesViewModel popupSizingIssuesViewModel)
+		: base(popupSizingIssuesViewModel)
+	{
+		InitializeComponent();
+	}
+}

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/Popup/PopupSizingIssuesPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/Popup/PopupSizingIssuesPage.xaml.cs
@@ -4,8 +4,7 @@ namespace CommunityToolkit.Maui.Sample.Pages.Views;
 
 public partial class PopupSizingIssuesPage : BasePage<PopupSizingIssuesViewModel>
 {
-	public PopupSizingIssuesPage(
-		PopupSizingIssuesViewModel popupSizingIssuesViewModel)
+	public PopupSizingIssuesPage(PopupSizingIssuesViewModel popupSizingIssuesViewModel)
 		: base(popupSizingIssuesViewModel)
 	{
 		InitializeComponent();

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/ViewsGalleryPage.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/ViewsGalleryPage.cs
@@ -4,5 +4,5 @@ namespace CommunityToolkit.Maui.Sample.Pages.Views;
 
 public class ViewsGalleryPage(IDeviceInfo deviceInfo, ViewsGalleryViewModel viewsGalleryViewModel) : BaseGalleryPage<ViewsGalleryViewModel>("Views", deviceInfo, viewsGalleryViewModel)
 {
-	
+
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/ViewsGalleryPage.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/ViewsGalleryPage.cs
@@ -2,10 +2,7 @@
 
 namespace CommunityToolkit.Maui.Sample.Pages.Views;
 
-public class ViewsGalleryPage : BaseGalleryPage<ViewsGalleryViewModel>
+public class ViewsGalleryPage(IDeviceInfo deviceInfo, ViewsGalleryViewModel viewsGalleryViewModel) : BaseGalleryPage<ViewsGalleryViewModel>("Views", deviceInfo, viewsGalleryViewModel)
 {
-	public ViewsGalleryPage(IDeviceInfo deviceInfo, ViewsGalleryViewModel viewsGalleryViewModel)
-		: base("Views", deviceInfo, viewsGalleryViewModel)
-	{
-	}
+	
 }

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Alerts/AlertsGalleryViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Alerts/AlertsGalleryViewModel.cs
@@ -2,14 +2,8 @@
 
 namespace CommunityToolkit.Maui.Sample.ViewModels.Alerts;
 
-public class AlertsGalleryViewModel : BaseGalleryViewModel
-{
-	public AlertsGalleryViewModel()
-		: base(new[]
-		{
-			SectionModel.Create<SnackbarViewModel>("Snackbar", "Show Snackbar"),
-			SectionModel.Create<ToastViewModel>("Toast", "Show Toast")
-		})
-	{
-	}
-}
+public class AlertsGalleryViewModel() : BaseGalleryViewModel(
+[
+	SectionModel.Create<SnackbarViewModel>("Snackbar", "Show Snackbar"), 
+	SectionModel.Create<ToastViewModel>("Toast", "Show Toast")
+]);

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Alerts/AlertsGalleryViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Alerts/AlertsGalleryViewModel.cs
@@ -4,6 +4,6 @@ namespace CommunityToolkit.Maui.Sample.ViewModels.Alerts;
 
 public class AlertsGalleryViewModel() : BaseGalleryViewModel(
 [
-	SectionModel.Create<SnackbarViewModel>("Snackbar", "Show Snackbar"), 
+	SectionModel.Create<SnackbarViewModel>("Snackbar", "Show Snackbar"),
 	SectionModel.Create<ToastViewModel>("Toast", "Show Toast")
 ]);

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Behaviors/BehaviorsGalleryViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Behaviors/BehaviorsGalleryViewModel.cs
@@ -3,62 +3,23 @@ using CommunityToolkit.Maui.Sample.Models;
 
 namespace CommunityToolkit.Maui.Sample.ViewModels.Behaviors;
 
-public class BehaviorsGalleryViewModel : BaseGalleryViewModel
-{
-	public BehaviorsGalleryViewModel()
-		: base(new[]
-		{
-			SectionModel.Create<EventToCommandBehaviorViewModel>(nameof(EventToCommandBehavior),
-				"Turns any event into a command that can be bound to"),
-
-			SectionModel.Create<MaskedBehaviorViewModel>(nameof(MaskedBehavior),
-				"Masked text in entry with specific pattern"),
-
-			SectionModel.Create<UserStoppedTypingBehaviorViewModel>(nameof(UserStoppedTypingBehavior),
-				"This behavior waits for the user to stop typing and then executes a Command"),
-
-			SectionModel.Create<MaxLengthReachedBehaviorViewModel>(nameof(MaxLengthReachedBehavior),
-				"This behavior invokes an EventHandler and executes a Command when the MaxLength of an InputView has been reached"),
-
-			SectionModel.Create<ProgressBarAnimationBehaviorViewModel>(nameof(ProgressBarAnimationBehavior),
-				"Animate the progress for the ProgressBar"),
-
-			SectionModel.Create<SetFocusOnEntryCompletedBehaviorViewModel>(nameof(SetFocusOnEntryCompletedBehavior),
-				"Set focus to another element when an entry is completed"),
-
-			SectionModel.Create<CharactersValidationBehaviorViewModel>(nameof(CharactersValidationBehavior),
-				"Changes an Entry's text color when an invalid string is provided."),
-
-			SectionModel.Create<TextValidationBehaviorViewModel>(nameof(TextValidationBehavior),
-				"Changes an Entry's text color when text validation is failed (based on regex)"),
-
-			SectionModel.Create<MultiValidationBehaviorViewModel>(nameof(MultiValidationBehavior),
-				"Combines multiple validation behavior"),
-
-			SectionModel.Create<UriValidationBehaviorViewModel>(nameof(UriValidationBehavior),
-				"Changes an Entry's text color when an invalid URI is provided"),
-
-			SectionModel.Create<RequiredStringValidationBehaviorViewModel>(nameof(RequiredStringValidationBehavior),
-				"Changes an Entry's text color when a required string is not provided"),
-
-			SectionModel.Create<NumericValidationBehaviorViewModel>(nameof(NumericValidationBehavior),
-				"Changes an Entry's text color when an invalid number is provided"),
-
-			SectionModel.Create<EmailValidationBehaviorViewModel>(nameof(EmailValidationBehavior),
-				"Changes an Entry's text color when an invalid e-mail address is provided"),
-
-			SectionModel.Create<AnimationBehaviorViewModel>(nameof(AnimationBehavior),
-				"Perform animation when a specified UI element event is triggered"),
-
-			SectionModel.Create<SelectAllTextBehaviorViewModel>(nameof(SelectAllTextBehavior),
-				"Select all text inside the Entry or Editor control."),
-
-			SectionModel.Create<IconTintColorBehaviorViewModel>(nameof(IconTintColorBehavior),
-				"Tint an icon with the selected color."),
-
-			SectionModel.Create<StatusBarBehaviorViewModel>(nameof(StatusBarBehavior),
-				"Change the Status Bar color."),
-		})
-	{
-	}
-}
+public class BehaviorsGalleryViewModel() : BaseGalleryViewModel(
+[
+	SectionModel.Create<EventToCommandBehaviorViewModel>(nameof(EventToCommandBehavior), "Turns any event into a command that can be bound to"),
+	SectionModel.Create<MaskedBehaviorViewModel>(nameof(MaskedBehavior), "Masked text in entry with specific pattern"),
+	SectionModel.Create<UserStoppedTypingBehaviorViewModel>(nameof(UserStoppedTypingBehavior), "This behavior waits for the user to stop typing and then executes a Command"),
+	SectionModel.Create<MaxLengthReachedBehaviorViewModel>(nameof(MaxLengthReachedBehavior), "This behavior invokes an EventHandler and executes a Command when the MaxLength of an InputView has been reached"),
+	SectionModel.Create<ProgressBarAnimationBehaviorViewModel>(nameof(ProgressBarAnimationBehavior), "Animate the progress for the ProgressBar"),
+	SectionModel.Create<SetFocusOnEntryCompletedBehaviorViewModel>(nameof(SetFocusOnEntryCompletedBehavior), "Set focus to another element when an entry is completed"),
+	SectionModel.Create<CharactersValidationBehaviorViewModel>(nameof(CharactersValidationBehavior), "Changes an Entry's text color when an invalid string is provided."),
+	SectionModel.Create<TextValidationBehaviorViewModel>(nameof(TextValidationBehavior), "Changes an Entry's text color when text validation is failed (based on regex)"),
+	SectionModel.Create<MultiValidationBehaviorViewModel>(nameof(MultiValidationBehavior), "Combines multiple validation behavior"),
+	SectionModel.Create<UriValidationBehaviorViewModel>(nameof(UriValidationBehavior), "Changes an Entry's text color when an invalid URI is provided"),
+	SectionModel.Create<RequiredStringValidationBehaviorViewModel>(nameof(RequiredStringValidationBehavior), "Changes an Entry's text color when a required string is not provided"),
+	SectionModel.Create<NumericValidationBehaviorViewModel>(nameof(NumericValidationBehavior), "Changes an Entry's text color when an invalid number is provided"),
+	SectionModel.Create<EmailValidationBehaviorViewModel>(nameof(EmailValidationBehavior), "Changes an Entry's text color when an invalid e-mail address is provided"),
+	SectionModel.Create<AnimationBehaviorViewModel>(nameof(AnimationBehavior), "Perform animation when a specified UI element event is triggered"),
+	SectionModel.Create<SelectAllTextBehaviorViewModel>(nameof(SelectAllTextBehavior), "Select all text inside the Entry or Editor control."),
+	SectionModel.Create<IconTintColorBehaviorViewModel>(nameof(IconTintColorBehavior), "Tint an icon with the selected color."),
+	SectionModel.Create<StatusBarBehaviorViewModel>(nameof(StatusBarBehavior), "Change the Status Bar color.")
+]);

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Converters/ConvertersGalleryViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Converters/ConvertersGalleryViewModel.cs
@@ -3,110 +3,39 @@ using CommunityToolkit.Maui.Sample.Models;
 
 namespace CommunityToolkit.Maui.Sample.ViewModels.Converters;
 
-public class ConvertersGalleryViewModel : BaseGalleryViewModel
-{
-	public ConvertersGalleryViewModel()
-		: base(new[]
-		{
-			SectionModel.Create<BoolToObjectConverterViewModel>(nameof(BoolToObjectConverter),
-				"A converter that allows users to convert a bool value binding to a specific object."),
-
-			SectionModel.Create<IsStringNullOrEmptyConverterViewModel>(nameof(IsStringNullOrEmptyConverter),
-				"A converter that allows users to convert an incoming binding to a bool value. This value represents if the incoming binding value is null or empty."),
-
-			SectionModel.Create<IsStringNotNullOrEmptyConverterViewModel>(nameof(IsStringNotNullOrEmptyConverter),
-				"A converter that allows users to convert an incoming binding to a bool value. This value represents if the incoming binding value is Not null or empty."),
-
-			SectionModel.Create<IsStringNullOrWhiteSpaceConverterViewModel>(nameof(IsStringNullOrWhiteSpaceConverter),
-				"A converter that allows users to convert an incoming binding to a bool value. This value represents if the incoming binding value is null or white space."),
-
-			SectionModel.Create<IsStringNotNullOrWhiteSpaceConverterViewModel>(nameof(IsStringNotNullOrWhiteSpaceConverter),
-				"A converter that allows users to convert an incoming binding to a bool value. This value represents if the incoming binding value is not null or white space."),
-
-			SectionModel.Create<InvertedBoolConverterViewModel>(nameof(InvertedBoolConverter),
-				"A converter that allows users to convert a bool value binding to its inverted value."),
-
-			SectionModel.Create<IsEqualConverterViewModel>(nameof(IsEqualConverter),
-				"A converter that allows users to convert any value binding to a bool depending on whether or not it is equal to a different value. "),
-
-			SectionModel.Create<IsNotEqualConverterViewModel>(nameof(IsNotEqualConverter),
-				"A converter that allows users to convert any value binding to a bool depending on whether or not it is not equal to a different value. "),
-
-			SectionModel.Create<DoubleToIntConverterViewModel>(nameof(DoubleToIntConverter),
-				"A converter that allows users to convert an incoming double value to an int."),
-
-			SectionModel.Create<IndexToArrayItemConverterViewModel>(nameof(IndexToArrayItemConverter),
-				"A converter that allows users to convert a int value binding to an item in an array."),
-
-			SectionModel.Create<IntToBoolConverterViewModel>(nameof(IntToBoolConverter),
-				"A converter that allows users to convert an incoming int value to a bool."),
-
-			SectionModel.Create<ItemTappedEventArgsConverterViewModel>(nameof(ItemTappedEventArgsConverter),
-				"A converter that allows you to extract the value from ItemTappedEventArgs that can be used in combination with EventToCommandBehavior"),
-
-			SectionModel.Create<TextCaseConverterViewModel>(nameof(TextCaseConverter),
-				"A converter that allows users to convert the casing of an incoming string type binding. The Type property is used to define what kind of casing will be applied to the string."),
-
-			SectionModel.Create<MultiConverterViewModel>(nameof(MultiConverter),
-				"This sample demonstrates how to use MultiBinding Converter"),
-
-			SectionModel.Create<DateTimeOffsetConverterViewModel>(nameof(DateTimeOffsetConverter),
-				"A converter that allows to convert from a DateTimeOffset type to a DateTime type"),
-
-			SectionModel.Create<VariableMultiValueConverterViewModel>(nameof(VariableMultiValueConverter),
-				"A converter that allows you to combine multiple boolean bindings into a single binding."),
-
-			SectionModel.Create<IsListNullOrEmptyConverterViewModel>(nameof(IsListNullOrEmptyConverter),
-				"A converter that allows you to check if collection is null or empty"),
-
-			SectionModel.Create<IsListNotNullOrEmptyConverterViewModel>(nameof(IsListNotNullOrEmptyConverter),
-				"A converter that allows you to check if collection is not null or empty"),
-
-			SectionModel.Create<ListToStringConverterViewModel>(nameof(ListToStringConverter),
-				"A converter that allows users to convert an incoming binding that implements IEnumerable to a single string value. The Separator property is used to join the items in the IEnumerable."),
-
-			SectionModel.Create<EnumToBoolConverterViewModel>(nameof(EnumToBoolConverter),
-				"A converter that allows you to convert an Enum to boolean value"),
-
-			SectionModel.Create<EnumToIntConverterViewModel>(nameof(EnumToIntConverter),
-				"A converter that allows you to convert an Enum to its underlying int value"),
-
-			SectionModel.Create<ImageResourceConverterViewModel>(nameof(ImageResourceConverter),
-				"A converter that allows you to convert embedded resource image id to an ImageSource"),
-
-			SectionModel.Create<MathExpressionConverterViewModel>(nameof(MathExpressionConverter),
-				"A converter that allows users to calculate an expression at runtime."),
-
-			SectionModel.Create<MultiMathExpressionConverterViewModel>(nameof(MultiMathExpressionConverter),
-				"A converter that allows users to calculate multiple math expressions at runtime."),
-
-			SectionModel.Create<StringToListConverterViewModel>(nameof(StringToListConverter),
-				"A converter that splits a string by the separator and returns the enumerable sequence of strings as the result."),
-
-			SectionModel.Create<ColorsConverterViewModel>("ColorConverters",
-				"A group of converters that convert a Color to your strings values (RGB, HEX, HSL, etc)"),
-
-			SectionModel.Create<SelectedItemEventArgsConverterViewModel>(nameof(SelectedItemEventArgsConverter),
-				"A converter that allows you to extract the selected item in a ListView from the SelectedItemChangedEventArgs object."),
-
-			SectionModel.Create<CompareConverterViewModel>(nameof(CompareConverter),
-				"A converter that compares two IComparable objects and returns a boolean value or one of two specified objects."),
-
-			SectionModel.Create<ByteArrayToImageSourceConverterViewModel>(nameof(ByteArrayToImageSourceConverter),
-				"A converter that allows the user to convert an incoming value from byte array and returns an object of type ImageSource. This object can then be used as the Source of an Image control.."),
-
-			SectionModel.Create<StateToBooleanConverterViewModel>(nameof(StateToBooleanConverter),
-				"A converter that allows the user to convert a LayoutState enum to a boolean value."),
-
-			SectionModel.Create<IsNotNullConverterViewModel>(nameof(IsNotNullConverter),
-				"A converter that allows users to convert an incoming `object?` to a bool."),
-
-			SectionModel.Create<IsNullConverterViewModel>(nameof(IsNullConverter),
-				"A converter that allows users to convert an incoming `object?` to a bool."),
-
-			SectionModel.Create<IsInRangeConverterViewModel>(nameof(IsInRangeConverter),
-				"A converter that returns a bool if the incoming object is within a defined range.")
-		})
-	{
-	}
-}
+public class ConvertersGalleryViewModel() : BaseGalleryViewModel(
+[
+	SectionModel.Create<BoolToObjectConverterViewModel>(nameof(BoolToObjectConverter), "A converter that allows users to convert a bool value binding to a specific object."),
+	SectionModel.Create<IsStringNullOrEmptyConverterViewModel>(nameof(IsStringNullOrEmptyConverter), "A converter that allows users to convert an incoming binding to a bool value. This value represents if the incoming binding value is null or empty."),
+	SectionModel.Create<IsStringNotNullOrEmptyConverterViewModel>(nameof(IsStringNotNullOrEmptyConverter), "A converter that allows users to convert an incoming binding to a bool value. This value represents if the incoming binding value is Not null or empty."),
+	SectionModel.Create<IsStringNullOrWhiteSpaceConverterViewModel>(nameof(IsStringNullOrWhiteSpaceConverter), "A converter that allows users to convert an incoming binding to a bool value. This value represents if the incoming binding value is null or white space."),
+	SectionModel.Create<IsStringNotNullOrWhiteSpaceConverterViewModel>(nameof(IsStringNotNullOrWhiteSpaceConverter), "A converter that allows users to convert an incoming binding to a bool value. This value represents if the incoming binding value is not null or white space."),
+	SectionModel.Create<InvertedBoolConverterViewModel>(nameof(InvertedBoolConverter), "A converter that allows users to convert a bool value binding to its inverted value."),
+	SectionModel.Create<IsEqualConverterViewModel>(nameof(IsEqualConverter), "A converter that allows users to convert any value binding to a bool depending on whether or not it is equal to a different value. "),
+	SectionModel.Create<IsNotEqualConverterViewModel>(nameof(IsNotEqualConverter), "A converter that allows users to convert any value binding to a bool depending on whether or not it is not equal to a different value. "),
+	SectionModel.Create<DoubleToIntConverterViewModel>(nameof(DoubleToIntConverter), "A converter that allows users to convert an incoming double value to an int."),
+	SectionModel.Create<IndexToArrayItemConverterViewModel>(nameof(IndexToArrayItemConverter), "A converter that allows users to convert a int value binding to an item in an array."),
+	SectionModel.Create<IntToBoolConverterViewModel>(nameof(IntToBoolConverter), "A converter that allows users to convert an incoming int value to a bool."),
+	SectionModel.Create<ItemTappedEventArgsConverterViewModel>(nameof(ItemTappedEventArgsConverter), "A converter that allows you to extract the value from ItemTappedEventArgs that can be used in combination with EventToCommandBehavior"),
+	SectionModel.Create<TextCaseConverterViewModel>(nameof(TextCaseConverter), "A converter that allows users to convert the casing of an incoming string type binding. The Type property is used to define what kind of casing will be applied to the string."),
+	SectionModel.Create<MultiConverterViewModel>(nameof(MultiConverter), "This sample demonstrates how to use MultiBinding Converter"),
+	SectionModel.Create<DateTimeOffsetConverterViewModel>(nameof(DateTimeOffsetConverter), "A converter that allows to convert from a DateTimeOffset type to a DateTime type"),
+	SectionModel.Create<VariableMultiValueConverterViewModel>(nameof(VariableMultiValueConverter), "A converter that allows you to combine multiple boolean bindings into a single binding."),
+	SectionModel.Create<IsListNullOrEmptyConverterViewModel>(nameof(IsListNullOrEmptyConverter), "A converter that allows you to check if collection is null or empty"),
+	SectionModel.Create<IsListNotNullOrEmptyConverterViewModel>(nameof(IsListNotNullOrEmptyConverter), "A converter that allows you to check if collection is not null or empty"),
+	SectionModel.Create<ListToStringConverterViewModel>(nameof(ListToStringConverter), "A converter that allows users to convert an incoming binding that implements IEnumerable to a single string value. The Separator property is used to join the items in the IEnumerable."),
+	SectionModel.Create<EnumToBoolConverterViewModel>(nameof(EnumToBoolConverter), "A converter that allows you to convert an Enum to boolean value"),
+	SectionModel.Create<EnumToIntConverterViewModel>(nameof(EnumToIntConverter), "A converter that allows you to convert an Enum to its underlying int value"),
+	SectionModel.Create<ImageResourceConverterViewModel>(nameof(ImageResourceConverter), "A converter that allows you to convert embedded resource image id to an ImageSource"),
+	SectionModel.Create<MathExpressionConverterViewModel>(nameof(MathExpressionConverter), "A converter that allows users to calculate an expression at runtime."),
+	SectionModel.Create<MultiMathExpressionConverterViewModel>(nameof(MultiMathExpressionConverter), "A converter that allows users to calculate multiple math expressions at runtime."),
+	SectionModel.Create<StringToListConverterViewModel>(nameof(StringToListConverter), "A converter that splits a string by the separator and returns the enumerable sequence of strings as the result."),
+	SectionModel.Create<ColorsConverterViewModel>("ColorConverters", "A group of converters that convert a Color to your strings values (RGB, HEX, HSL, etc)"),
+	SectionModel.Create<SelectedItemEventArgsConverterViewModel>(nameof(SelectedItemEventArgsConverter), "A converter that allows you to extract the selected item in a ListView from the SelectedItemChangedEventArgs object."),
+	SectionModel.Create<CompareConverterViewModel>(nameof(CompareConverter), "A converter that compares two IComparable objects and returns a boolean value or one of two specified objects."),
+	SectionModel.Create<ByteArrayToImageSourceConverterViewModel>(nameof(ByteArrayToImageSourceConverter), "A converter that allows the user to convert an incoming value from byte array and returns an object of type ImageSource. This object can then be used as the Source of an Image control.."),
+	SectionModel.Create<StateToBooleanConverterViewModel>(nameof(StateToBooleanConverter), "A converter that allows the user to convert a LayoutState enum to a boolean value."),
+	SectionModel.Create<IsNotNullConverterViewModel>(nameof(IsNotNullConverter), "A converter that allows users to convert an incoming `object?` to a bool."),
+	SectionModel.Create<IsNullConverterViewModel>(nameof(IsNullConverter), "A converter that allows users to convert an incoming `object?` to a bool."),
+	SectionModel.Create<IsInRangeConverterViewModel>(nameof(IsInRangeConverter), "A converter that returns a bool if the incoming object is within a defined range.")
+]);

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Essentials/EssentialsGalleryViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Essentials/EssentialsGalleryViewModel.cs
@@ -2,17 +2,11 @@
 
 namespace CommunityToolkit.Maui.Sample.ViewModels.Essentials;
 
-public class EssentialsGalleryViewModel : BaseGalleryViewModel
-{
-	public EssentialsGalleryViewModel()
-		: base(new[]
-		{
-			SectionModel.Create<AppThemeViewModel>("AppThemeResource", "AppThemeResource provides extension methods and markup extensions that make it easy to assign Light Theme, Dark Theme and Default Theme"),
-			SectionModel.Create<BadgeViewModel>("Badge", "Allows the user to set app icon badge count on the home screen"),
-			SectionModel.Create<FileSaverViewModel>("FileSaver", "Allows the user to save files to the filesystem"),
-			SectionModel.Create<FolderPickerViewModel>("FolderPicker", "Allows picking folders from the file system"),
-			SectionModel.Create<SpeechToTextViewModel>("SpeechToText", "Converts speech to text"),
-		})
-	{
-	}
-}
+public class EssentialsGalleryViewModel() : BaseGalleryViewModel(
+[
+	SectionModel.Create<AppThemeViewModel>("AppThemeResource", "AppThemeResource provides extension methods and markup extensions that make it easy to assign Light Theme, Dark Theme and Default Theme"),
+	SectionModel.Create<BadgeViewModel>("Badge", "Allows the user to set app icon badge count on the home screen"),
+	SectionModel.Create<FileSaverViewModel>("FileSaver", "Allows the user to save files to the filesystem"),
+	SectionModel.Create<FolderPickerViewModel>("FolderPicker", "Allows picking folders from the file system"),
+	SectionModel.Create<SpeechToTextViewModel>("SpeechToText", "Converts speech to text")
+]);

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Extensions/ExtensionsGalleryViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Extensions/ExtensionsGalleryViewModel.cs
@@ -5,18 +5,8 @@ using CommunityToolkit.Maui.Sample.ViewModels.Extensions;
 
 namespace CommunityToolkit.Maui.Sample.ViewModels.Converters;
 
-public class ExtensionsGalleryViewModel : BaseGalleryViewModel
-{
-	public ExtensionsGalleryViewModel()
-		: base(new[]
-		{
-			SectionModel.Create<ColorAnimationExtensionsViewModel>(nameof(ColorAnimationExtensions),
-				"Extension methods that provide color animations"),
-
-			SectionModel.Create<KeyboardExtensionsViewModel>(nameof(KeyboardExtensions),
-				"Extension methods that provide keyboard interactions"),
-		})
-	{
-
-	}
-}
+public class ExtensionsGalleryViewModel() : BaseGalleryViewModel(
+[
+	SectionModel.Create<ColorAnimationExtensionsViewModel>(nameof(ColorAnimationExtensions), "Extension methods that provide color animations"),
+	SectionModel.Create<KeyboardExtensionsViewModel>(nameof(KeyboardExtensions), "Extension methods that provide keyboard interactions")
+]);

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/ImageSources/ImageSourcesGalleryViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/ImageSources/ImageSourcesGalleryViewModel.cs
@@ -2,13 +2,7 @@
 
 namespace CommunityToolkit.Maui.Sample.ViewModels.ImageSources;
 
-public class ImageSourcesGalleryViewModel : BaseGalleryViewModel
-{
-	public ImageSourcesGalleryViewModel()
-		: base(new[]
-		{
-			SectionModel.Create<GravatarImageSourceViewModel>("GravatarImageSource", Colors.Red, "GravatarImageSource allows you to use as an Image source, a users Gravatar registered image via their email address."),
-		})
-	{
-	}
-}
+public class ImageSourcesGalleryViewModel() : BaseGalleryViewModel(
+[
+	SectionModel.Create<GravatarImageSourceViewModel>("GravatarImageSource", Colors.Red, "GravatarImageSource allows you to use as an Image source, a users Gravatar registered image via their email address.")
+]);

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Layouts/LayoutsGalleryViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Layouts/LayoutsGalleryViewModel.cs
@@ -3,20 +3,9 @@ using CommunityToolkit.Maui.Sample.Pages.Layouts;
 
 namespace CommunityToolkit.Maui.Sample.ViewModels.Layouts;
 
-public class LayoutsGalleryViewModel : BaseGalleryViewModel
-{
-	public LayoutsGalleryViewModel()
-		: base(new[]
-		{
-			SectionModel.Create<StateContainerViewModel>(nameof(StateContainerPage),
-				"Properties enabling any Layout derived element to become state-aware"),
-
-			SectionModel.Create<UniformItemsLayoutViewModel>(nameof(UniformItemsLayoutPage),
-				"A Grid where all rows and columns have the same size"),
-
-			SectionModel.Create<DockLayoutViewModel>(nameof(DockLayoutPage),
-				"A layout that positions its child elements along the edges of the container.")
-		})
-	{
-	}
-}
+public class LayoutsGalleryViewModel() : BaseGalleryViewModel(
+[
+	SectionModel.Create<StateContainerViewModel>(nameof(StateContainerPage), "Properties enabling any Layout derived element to become state-aware"),
+	SectionModel.Create<UniformItemsLayoutViewModel>(nameof(UniformItemsLayoutPage), "A Grid where all rows and columns have the same size"),
+	SectionModel.Create<DockLayoutViewModel>(nameof(DockLayoutPage), "A layout that positions its child elements along the edges of the container.")
+]);

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/PlatformSpecific/PlatformSpecificGalleryViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/PlatformSpecific/PlatformSpecificGalleryViewModel.cs
@@ -2,13 +2,7 @@
 
 namespace CommunityToolkit.Maui.Sample.ViewModels.PlatformSpecific;
 
-public sealed partial class PlatformSpecificGalleryViewModel : BaseGalleryViewModel
-{
-	public PlatformSpecificGalleryViewModel() : base(
-	[
-		SectionModel.Create<NavigationBarAndroidViewModel>("NavigationBar (Android)", "Change the Navigation Bar color on Android"),
-	])
-	{
-
-	}
-}
+public sealed class PlatformSpecificGalleryViewModel() : BaseGalleryViewModel(
+[
+	SectionModel.Create<NavigationBarAndroidViewModel>("NavigationBar (Android)", "Change the Navigation Bar color on Android"),
+]);

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Views/Popup/PopupSizingIssuesViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Views/Popup/PopupSizingIssuesViewModel.cs
@@ -6,13 +6,14 @@ namespace CommunityToolkit.Maui.Sample.ViewModels.Views;
 
 public partial class PopupSizingIssuesViewModel : BaseViewModel
 {
-    public IList<ContainerViewModel> Containers { get; } = new List<ContainerViewModel>
-    {
-        new ("HorizontalStackLayout", new ControlTemplate(() => new HorizontalStackLayout())),
+    public IList<ContainerViewModel> Containers { get; } =
+	[
+		new ("HorizontalStackLayout", new ControlTemplate(() => new HorizontalStackLayout())),
         new ("VerticalStackLayout", new ControlTemplate(() => new VerticalStackLayout())),
         new ("Border", new ControlTemplate(() => new Border())),
-        new ("Grid", new ControlTemplate(() => new Grid()))
-    };
+        new ("Grid", new ControlTemplate(() => new Grid())),
+        new ("CollectionView", new ControlTemplate(() => new CollectionView()))
+    ];
 
     [ObservableProperty, NotifyCanExecuteChangedFor(nameof(ShowPopupCommand))]
     ContainerViewModel? selectedContainer;
@@ -32,23 +33,33 @@ public partial class PopupSizingIssuesViewModel : BaseViewModel
 
 		container.GetType().GetProperty(nameof(IPaddingElement.Padding))?.SetValue(container, new Thickness(Padding));
 
-        var label = new Label
-        {
-            Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
-            HorizontalOptions = LayoutOptions.Center,
-            VerticalOptions = LayoutOptions.Center
-        };
+        const string longText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
 
-        container.GetType().GetProperty(nameof(IContentView.Content))?.SetValue(container, label);
+        container.GetType().GetProperty(nameof(IContentView.Content))?.SetValue(container, GetContentLabel(longText));
 
         if (container is Layout layout)
         {
-            layout.Children.Add(label);
+            layout.Children.Add(GetContentLabel(longText));
+        }
+        else if (container is ItemsView itemsView)
+        {
+            itemsView.ItemsSource = Enumerable.Repeat(longText, 10);
+            itemsView.ItemTemplate = new DataTemplate(() => GetContentLabel(longText));
         }
 
         popup.Content = container;
 
         page.ShowPopup(popup);
+    }
+
+	static Label GetContentLabel(string text)
+    {
+        return new Label
+        {
+            Text = text,
+            HorizontalOptions = LayoutOptions.Center,
+            VerticalOptions = LayoutOptions.Center
+        };
     }
 
     bool CanShowPopup(Page page) => SelectedContainer != null;

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Views/Popup/PopupSizingIssuesViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Views/Popup/PopupSizingIssuesViewModel.cs
@@ -1,0 +1,68 @@
+using CommunityToolkit.Maui.Views;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace CommunityToolkit.Maui.Sample.ViewModels.Views;
+
+public partial class PopupSizingIssuesViewModel : BaseViewModel
+{
+    public IList<ContainerViewModel> Containers { get; } = new List<ContainerViewModel>
+    {
+        new ("HorizontalStackLayout", new ControlTemplate(() => new HorizontalStackLayout())),
+        new ("VerticalStackLayout", new ControlTemplate(() => new VerticalStackLayout())),
+        new ("Border", new ControlTemplate(() => new Border())),
+        new ("Grid", new ControlTemplate(() => new Grid()))
+    };
+
+    [ObservableProperty, NotifyCanExecuteChangedFor(nameof(ShowPopupCommand))]
+    ContainerViewModel? selectedContainer;
+
+    [ObservableProperty]
+    int padding = 0;
+
+    [RelayCommand]
+    void OnShowPopup(Page page)
+    {
+        var popup = new Popup();
+
+		if (SelectedContainer?.ControlTemplate.LoadTemplate() is not View container)
+		{
+			return;
+		}
+
+		container.GetType().GetProperty(nameof(IPaddingElement.Padding))?.SetValue(container, new Thickness(Padding));
+
+        var label = new Label
+        {
+            Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+            HorizontalOptions = LayoutOptions.Center,
+            VerticalOptions = LayoutOptions.Center
+        };
+
+        container.GetType().GetProperty(nameof(IContentView.Content))?.SetValue(container, label);
+
+        if (container is Layout layout)
+        {
+            layout.Children.Add(label);
+        }
+
+        popup.Content = container;
+
+        page.ShowPopup(popup);
+    }
+
+    bool CanShowPopup(Page page) => SelectedContainer != null;
+}
+
+public partial class ContainerViewModel : ObservableObject
+{
+    public string Name { get; }
+
+    public ControlTemplate ControlTemplate { get; }
+
+    public ContainerViewModel(string name, ControlTemplate controlTemplate)
+    {
+        Name = name;
+        ControlTemplate = controlTemplate;
+    }
+}

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Views/ViewsGalleryViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Views/ViewsGalleryViewModel.cs
@@ -33,6 +33,7 @@ public sealed class ViewsGalleryViewModel : BaseGalleryViewModel
 			SectionModel.Create<ShowPopupInOnAppearingPageViewModel>("Show Popup in OnAppearing", Colors.Red, "Proves that we now support showing a popup before the platform is even ready."),
 			SectionModel.Create<SemanticOrderViewPageViewModel>("Semantic Order View", Colors.Red, "SemanticOrderView allows developers to indicate the focus order of visible controls when a user is navigating via TalkBack (Android), VoiceOver (iOS) or Narrator (Windows)."),
 			SectionModel.Create<StylePopupViewModel>("Popup Style Page", Colors.Red, "A page demonstrating how Popups can be styled in a .NET MAUI application."),
+			SectionModel.Create<PopupSizingIssuesViewModel>("Popup Sizing Issues Page", Colors.Red, "A page demonstrating how Popups can be styled in a .NET MAUI application."),
 		})
 	{
 	}

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Views/ViewsGalleryViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Views/ViewsGalleryViewModel.cs
@@ -3,38 +3,32 @@ using CommunityToolkit.Maui.Sample.ViewModels.Views.AvatarView;
 
 namespace CommunityToolkit.Maui.Sample.ViewModels.Views;
 
-public sealed class ViewsGalleryViewModel : BaseGalleryViewModel
-{
-	public ViewsGalleryViewModel()
-		: base(new[]
-		{
-			SectionModel.Create<AvatarViewBindablePropertiesViewModel>("AvatarView Bindable Properties Page", Colors.Red, "A page demonstrating how to bind to various AvatarView properties."),
-			SectionModel.Create<AvatarViewBordersViewModel>("AvatarView Borders Page", Colors.Red, "A page demonstrating AvatarView borders."),
-			SectionModel.Create<AvatarViewColorsViewModel>("AvatarView Colors Page", Colors.Red, "A page demonstrating AvatarViews with different color options."),
-			SectionModel.Create<AvatarViewDayOfWeekViewModel>("AvatarView Day of Week Page", Colors.Red, "A page demonstrating AvatarViews as a Day of the Week."),
-			SectionModel.Create<AvatarViewGesturesViewModel>("AvatarView Gestures Page", Colors.Red, "A page demonstrating AvatarViews with different gesture options."),
-			SectionModel.Create<AvatarViewImagesViewModel>("AvatarView Images Page", Colors.Red, "A page demonstrating AvatarViews with different image options."),
-			SectionModel.Create<AvatarViewKeyboardViewModel>("AvatarView Keyboard Page", Colors.Red, "A page demonstrating AvatarViews aligned as a Keyboard."),
-			SectionModel.Create<AvatarViewRatingViewModel>("AvatarView Rating Page", Colors.Red, "A page demonstrating AvatarViews as a star rating."),
-			SectionModel.Create<AvatarViewShadowsViewModel>("AvatarView Shadows Page", Colors.Red, "A page demonstrating AvatarViews with various shadow options."),
-			SectionModel.Create<AvatarViewShapesViewModel>("AvatarView Shapes Page", Colors.Red, "A page demonstrating AvatarViews with various shape options."),
-			SectionModel.Create<AvatarViewSizesViewModel>("AvatarView Sizes Page", Colors.Red, "A page demonstrating AvatarViews with various size options."),
-			SectionModel.Create<CustomSizeAndPositionPopupViewModel>("Custom Size and Positioning Popup", Colors.Red, "Displays a basic popup anywhere on the screen with a custom size using VerticalOptions and HorizontalOptions."),
-			SectionModel.Create<DrawingViewViewModel>("DrawingView", Colors.Red, "DrawingView provides a canvas for users to \"paint\" on the screen. The drawing can also be captured and displayed as an Image."),
-			SectionModel.Create<ExpanderViewModel>("Expander Page", Colors.Red, "Expander allows collapse and expand content."),
-			SectionModel.Create<BasicMapsViewModel>("Windows Maps Basic Page", Colors.Red, "A page demonstrating a basic example of .NET MAUI Maps for Windows."),
-			SectionModel.Create<MapsPinsViewModel>("Windows Maps Pins Page", Colors.Red, "A page demonstrating .NET MAUI Maps for Windows with Pins."),
-			SectionModel.Create<LazyViewViewModel>("LazyView", Colors.Red, "LazyView is a view that allows you to load its children in a delayed manner."),
-			SectionModel.Create<MediaElementViewModel>("MediaElement", Colors.Red, "MediaElement is a view for playing video and audio"),
-			SectionModel.Create<MultiplePopupViewModel>("Mutiple Popups Page", Colors.Red, "A page demonstrating multiple different Popups"),
-			SectionModel.Create<PopupPositionViewModel>("Custom Positioning Popup", Colors.Red, "Displays a basic popup anywhere on the screen using VerticalOptions and HorizontalOptions"),
-			SectionModel.Create<PopupAnchorViewModel>("Anchor Popup", Colors.Red, "Popups can be anchored to other view's on the screen"),
-			SectionModel.Create<PopupLayoutAlignmentViewModel>("Popup Layout Page", Colors.Red, "Popup.Content demonstrated using different layouts"),
-			SectionModel.Create<ShowPopupInOnAppearingPageViewModel>("Show Popup in OnAppearing", Colors.Red, "Proves that we now support showing a popup before the platform is even ready."),
-			SectionModel.Create<SemanticOrderViewPageViewModel>("Semantic Order View", Colors.Red, "SemanticOrderView allows developers to indicate the focus order of visible controls when a user is navigating via TalkBack (Android), VoiceOver (iOS) or Narrator (Windows)."),
-			SectionModel.Create<StylePopupViewModel>("Popup Style Page", Colors.Red, "A page demonstrating how Popups can be styled in a .NET MAUI application."),
-			SectionModel.Create<PopupSizingIssuesViewModel>("Popup Sizing Issues Page", Colors.Red, "A page demonstrating how Popups can be styled in a .NET MAUI application."),
-		})
-	{
-	}
-}
+public sealed class ViewsGalleryViewModel() : BaseGalleryViewModel(
+[
+	SectionModel.Create<AvatarViewBindablePropertiesViewModel>("AvatarView Bindable Properties Page", Colors.Red, "A page demonstrating how to bind to various AvatarView properties."),
+	SectionModel.Create<AvatarViewBordersViewModel>("AvatarView Borders Page", Colors.Red, "A page demonstrating AvatarView borders."),
+	SectionModel.Create<AvatarViewColorsViewModel>("AvatarView Colors Page", Colors.Red, "A page demonstrating AvatarViews with different color options."),
+	SectionModel.Create<AvatarViewDayOfWeekViewModel>("AvatarView Day of Week Page", Colors.Red, "A page demonstrating AvatarViews as a Day of the Week."),
+	SectionModel.Create<AvatarViewGesturesViewModel>("AvatarView Gestures Page", Colors.Red, "A page demonstrating AvatarViews with different gesture options."),
+	SectionModel.Create<AvatarViewImagesViewModel>("AvatarView Images Page", Colors.Red, "A page demonstrating AvatarViews with different image options."),
+	SectionModel.Create<AvatarViewKeyboardViewModel>("AvatarView Keyboard Page", Colors.Red, "A page demonstrating AvatarViews aligned as a Keyboard."),
+	SectionModel.Create<AvatarViewRatingViewModel>("AvatarView Rating Page", Colors.Red, "A page demonstrating AvatarViews as a star rating."),
+	SectionModel.Create<AvatarViewShadowsViewModel>("AvatarView Shadows Page", Colors.Red, "A page demonstrating AvatarViews with various shadow options."),
+	SectionModel.Create<AvatarViewShapesViewModel>("AvatarView Shapes Page", Colors.Red, "A page demonstrating AvatarViews with various shape options."),
+	SectionModel.Create<AvatarViewSizesViewModel>("AvatarView Sizes Page", Colors.Red, "A page demonstrating AvatarViews with various size options."),
+	SectionModel.Create<CustomSizeAndPositionPopupViewModel>("Custom Size and Positioning Popup", Colors.Red, "Displays a basic popup anywhere on the screen with a custom size using VerticalOptions and HorizontalOptions."),
+	SectionModel.Create<DrawingViewViewModel>("DrawingView", Colors.Red, "DrawingView provides a canvas for users to \"paint\" on the screen. The drawing can also be captured and displayed as an Image."),
+	SectionModel.Create<ExpanderViewModel>("Expander Page", Colors.Red, "Expander allows collapse and expand content."),
+	SectionModel.Create<BasicMapsViewModel>("Windows Maps Basic Page", Colors.Red, "A page demonstrating a basic example of .NET MAUI Maps for Windows."),
+	SectionModel.Create<MapsPinsViewModel>("Windows Maps Pins Page", Colors.Red, "A page demonstrating .NET MAUI Maps for Windows with Pins."),
+	SectionModel.Create<LazyViewViewModel>("LazyView", Colors.Red, "LazyView is a view that allows you to load its children in a delayed manner."),
+	SectionModel.Create<MediaElementViewModel>("MediaElement", Colors.Red, "MediaElement is a view for playing video and audio"),
+	SectionModel.Create<MultiplePopupViewModel>("Multiple Popups Page", Colors.Red, "A page demonstrating multiple different Popups"),
+	SectionModel.Create<PopupPositionViewModel>("Custom Positioning Popup", Colors.Red, "Displays a basic popup anywhere on the screen using VerticalOptions and HorizontalOptions"),
+	SectionModel.Create<PopupAnchorViewModel>("Anchor Popup", Colors.Red, "Popups can be anchored to other view's on the screen"),
+	SectionModel.Create<PopupLayoutAlignmentViewModel>("Popup Layout Page", Colors.Red, "Popup.Content demonstrated using different layouts"),
+	SectionModel.Create<PopupSizingIssuesViewModel>("Popup Sizing Issues Page", Colors.Red, "A page demonstrating how Popups can be styled in a .NET MAUI application."),
+	SectionModel.Create<ShowPopupInOnAppearingPageViewModel>("Show Popup in OnAppearing", Colors.Red, "Proves that we now support showing a popup before the platform is even ready."),
+	SectionModel.Create<SemanticOrderViewPageViewModel>("Semantic Order View", Colors.Red, "SemanticOrderView allows developers to indicate the focus order of visible controls when a user is navigating via TalkBack (Android), VoiceOver (iOS) or Narrator (Windows)."),
+	SectionModel.Create<StylePopupViewModel>("Popup Style Page", Colors.Red, "A page demonstrating how Popups can be styled in a .NET MAUI application.")
+]);


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->

This PR doesn't aim to fix anything, its purpose is to provide a more comprehensive set of `Popup` based samples to make verification of change/fixes easier.

The current approach relies on a bit of magic:

```csharp
void OnShowPopup(Page page)
{
    var popup = new Popup();

    if (SelectedContainer?.ControlTemplate.LoadTemplate() is not View container)
    {
        return;
    }

    container.GetType().GetProperty(nameof(IPaddingElement.Padding))?.SetValue(container, new Thickness(Padding));

    const string longText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";

    container.GetType().GetProperty(nameof(IContentView.Content))?.SetValue(container, GetContentLabel(longText));

    if (container is Layout layout)
    {
        layout.Children.Add(GetContentLabel(longText));
    }
    else if (container is ItemsView itemsView)
    {
        itemsView.ItemsSource = Enumerable.Repeat(longText, 10);
        itemsView.ItemTemplate = new DataTemplate(() => GetContentLabel(longText));
    }

    popup.Content = container;

    page.ShowPopup(popup);
}
```

And it is driven from a list of `Containers`:

```csharp
public IList<ContainerViewModel> Containers { get; } =
[
    new ("HorizontalStackLayout", new ControlTemplate(() => new HorizontalStackLayout())),
    new ("VerticalStackLayout", new ControlTemplate(() => new VerticalStackLayout())),
    new ("Border", new ControlTemplate(() => new Border())),
    new ("Grid", new ControlTemplate(() => new Grid())),
    new ("CollectionView", new ControlTemplate(() => new CollectionView()))
];
```

I couldn't decide whether this saved on effort over a single clearly defined scenario e.g.

```csharp
public IList<ContainerViewModel> Scenarios { get; } =
[
    new ("HorizontalStackLayout with Label", new ControlTemplate(() => new HorizontalStackLayout { Children = [new Label()] }))
];
```

The part I really like is the effort we save by not having to create a popup xaml/c# for each scenario.

Thoughts?

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

n/a

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [ ] Rebased on top of `main` at time of PR
 - [ ] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
