### PR TITLE
Not use UseMauiMaps

### DIFF
--- a/src/CommunityToolkit.Maui.Maps/AppHostBuilderExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui.Maps/AppHostBuilderExtensions.shared.cs
@@ -13,12 +13,13 @@ public static class AppHostBuilderExtensions
 	/// <returns><see cref="MauiAppBuilder"/></returns>
 	public static MauiAppBuilder UseMauiCommunityToolkitMaps(this MauiAppBuilder builder, string key)
 	{
-		builder.UseMauiMaps();
 		builder.ConfigureMauiHandlers(handlers =>
 		{
 #if WINDOWS
 			CommunityToolkit.Maui.Maps.Handlers.MapHandlerWindows.MapsKey = key;
 			handlers.AddHandler<Microsoft.Maui.Controls.Maps.Map, CommunityToolkit.Maui.Maps.Handlers.MapHandlerWindows>();
+			handlersCollection.AddHandler<Pin, MapPinHandler>();
+			handlersCollection.AddHandler<MapElement, MapElementHandler>();
 #endif
 		});
 

--- a/src/CommunityToolkit.Maui.Maps/AppHostBuilderExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui.Maps/AppHostBuilderExtensions.shared.cs
@@ -18,8 +18,6 @@ public static class AppHostBuilderExtensions
 #if WINDOWS
 			CommunityToolkit.Maui.Maps.Handlers.MapHandlerWindows.MapsKey = key;
 			handlers.AddHandler<Microsoft.Maui.Controls.Maps.Map, CommunityToolkit.Maui.Maps.Handlers.MapHandlerWindows>();
-			handlersCollection.AddHandler<Pin, MapPinHandler>();
-			handlersCollection.AddHandler<MapElement, MapElementHandler>();
 #endif
 		});
 


### PR DESCRIPTION
As part of enabling the .NET MAUI Maps for Windows we call `UseMauiMaps` in the .NET MAUI SDK.

While this worked before, it was unnecessary to do so. Due to a recent change in .NET MAUI, which now throws a exception with a clear error message, this now became problematic. Because of this change in .NET MAUI, now an exception is always thrown, also through our library when you're actually trying to enable Windows.

This change removes the call to .NET MAUI Maps `UseMauiMaps`, users will have to call this themselves, which would then look something like:

```csharp
  var builder = MauiApp.CreateBuilder();
  builder
	  .UseMauiApp<App>()
	  .ConfigureFonts(fonts =>
	  {
		  fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
		  fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
	  });

    #if IOS || ANDROID
    builder.UseMauiMaps();
    #endif
    
    #if WINDOWS
    // Initialize the .NET MAUI Community Toolkit Maps by adding the below line of code
    builder.UseMauiCommunityToolkitMaps("key")
    #endif

   return builder.Build();
```

Fixes https://github.com/dotnet/maui/issues/21360