### PR TITLE
Also update Maps NuGet version number for PR builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -169,6 +169,7 @@ jobs:
           Write-Host("GitHub PR = $prNumber, Commit = $commitId");
           Write-Host ("##vso[task.setvariable variable=NugetPackageVersion;]$fullVersionString")
           Write-Host ("##vso[task.setvariable variable=NugetPackageVersionMediaElement;]$fullVersionString")
+          Write-Host ("##vso[task.setvariable variable=NugetPackageVersionMaps;]$fullVersionString")
           Write-Host "##vso[build.updatebuildnumber]$fullVersionString"
         displayName: Set NuGet Version to PR Version
         condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['build.reason'], 'PullRequest')) # Only run this step on Windows when a Pull Request has triggered the CI Pipeline


### PR DESCRIPTION
The Maps package was not included in the step to set the right version number for the PR artifacts