### PR TITLE
Add Platform-Specific Option to Enable Snackbar on Windows

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/MauiProgram.cs
+++ b/samples/CommunityToolkit.Maui.Sample/MauiProgram.cs
@@ -41,10 +41,14 @@ public static class MauiProgram
 	{
 		var builder = MauiApp.CreateBuilder()
 #if DEBUG
-								.UseMauiCommunityToolkit()
+								.UseMauiCommunityToolkit(options =>
+								{
+									options.SetShouldEnableSnackbarOnWindows(true);
+								})
 #else
 								.UseMauiCommunityToolkit(options =>
 								{
+									options.SetShouldEnableSnackbarOnWindows(true);
 									options.SetShouldSuppressExceptionsInConverters(true);
 									options.SetShouldSuppressExceptionsInBehaviors(true);
 									options.SetShouldSuppressExceptionsInAnimations(true);

--- a/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
@@ -18,7 +18,7 @@ public partial class Snackbar : ISnackbar
 	{
 		if (OperatingSystem.IsWindows() && !Options.ShouldEnableSnackbarOnWindows)
 		{
-			throw new InvalidOperationException($"Additional setup is required in the Package.appxmanifest file to enable {nameof(Snackbar)} on Windows. Additonally, `{nameof(AppBuilderExtensions.UseMauiCommunityToolkit)}(options => options.{nameof(Options.SetShouldEnableSnackbarOnWindows)}({true.ToString().ToLower()});` must be called to enable Snackbar on Windows. Additonally, Platform Specific Initialization section of the {nameof(Snackbar)} documentaion for more information: https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar")
+			throw new InvalidOperationException($"Additional setup is required in the Package.appxmanifest file to enable {nameof(Snackbar)} on Windows. Additonally, `{nameof(AppBuilderExtensions.UseMauiCommunityToolkit)}(options => options.{nameof(Options.SetShouldEnableSnackbarOnWindows)}({true.ToString().ToLower()});` must be called to enable Snackbar on Windows. See the Platform Specific Initialization section of the {nameof(Snackbar)} documentaion for more information: https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar")
 			{
 				HelpLink = "https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar"
 			};

--- a/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
@@ -18,7 +18,7 @@ public partial class Snackbar : ISnackbar
 	{
 		if (OperatingSystem.IsWindows() && !Options.ShouldEnableSnackbarOnWindows)
 		{
-			throw new InvalidOperationException($"Additional setup is required in the Package.appxmanifest file to enable {nameof(Snackbar)} on Windows. Additonally, `{nameof(AppBuilderExtensions.UseMauiCommunityToolkit)}(options => options.{nameof(Options.SetShouldEnableSnackbarOnWindows)}({true.ToString().ToLower()});` must be called to enable Snackbar on Windows. See the Platform Specific Initialization section of the {nameof(Snackbar)} documentaion for more information: https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar")
+			throw new InvalidOperationException($"Additional setup is required in the Package.appxmanifest file to enable {nameof(Snackbar)} on Windows. Additonally, `{nameof(AppBuilderExtensions.UseMauiCommunityToolkit)}(options => options.{nameof(Options.SetShouldEnableSnackbarOnWindows)}({bool.TrueString});` must be called to enable Snackbar on Windows. See the Platform Specific Initialization section of the {nameof(Snackbar)} documentaion for more information: https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar")
 			{
 				HelpLink = "https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar"
 			};

--- a/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
@@ -16,13 +16,15 @@ public partial class Snackbar : ISnackbar
 	/// </summary>
 	public Snackbar()
 	{
-		if (OperatingSystem.IsWindows() && !Options.ShouldEnableSnackbarOnWindows)
+#if WINDOWS
+		if (!Options.ShouldEnableSnackbarOnWindows)
 		{
 			throw new InvalidOperationException($"Additional setup is required in the Package.appxmanifest file to enable {nameof(Snackbar)} on Windows. Additonally, `{nameof(AppBuilderExtensions.UseMauiCommunityToolkit)}(options => options.{nameof(Options.SetShouldEnableSnackbarOnWindows)}({bool.TrueString.ToLower()});` must be called to enable Snackbar on Windows. See the Platform Specific Initialization section of the {nameof(Snackbar)} documentaion for more information: https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar")
 			{
 				HelpLink = "https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar"
 			};
 		}
+#endif
 
 		Duration = GetDefaultTimeSpan();
 		VisualOptions = new SnackbarOptions();

--- a/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
@@ -16,6 +16,14 @@ public partial class Snackbar : ISnackbar
 	/// </summary>
 	public Snackbar()
 	{
+		if (OperatingSystem.IsWindows() && !Options.ShouldEnableSnackbarOnWindows)
+		{
+			throw new InvalidOperationException($"Additional setup is required in the Package.appxmanifest file to enable {nameof(Snackbar)} on Windows. Additonally, `{nameof(AppBuilderExtensions.UseMauiCommunityToolkit)}(options => options.{nameof(Options.SetShouldEnableSnackbarOnWindows)}({true.ToString().ToLower()});` must be called to enable Snackbar on Windows. Additonally, Platform Specific Initialization section of the {nameof(Snackbar)} documentaion for more information: https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar")
+			{
+				HelpLink = "https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar"
+			};
+		}
+
 		Duration = GetDefaultTimeSpan();
 		VisualOptions = new SnackbarOptions();
 	}

--- a/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
@@ -18,7 +18,7 @@ public partial class Snackbar : ISnackbar
 	{
 		if (OperatingSystem.IsWindows() && !Options.ShouldEnableSnackbarOnWindows)
 		{
-			throw new InvalidOperationException($"Additional setup is required in the Package.appxmanifest file to enable {nameof(Snackbar)} on Windows. Additonally, `{nameof(AppBuilderExtensions.UseMauiCommunityToolkit)}(options => options.{nameof(Options.SetShouldEnableSnackbarOnWindows)}({bool.TrueString});` must be called to enable Snackbar on Windows. See the Platform Specific Initialization section of the {nameof(Snackbar)} documentaion for more information: https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar")
+			throw new InvalidOperationException($"Additional setup is required in the Package.appxmanifest file to enable {nameof(Snackbar)} on Windows. Additonally, `{nameof(AppBuilderExtensions.UseMauiCommunityToolkit)}(options => options.{nameof(Options.SetShouldEnableSnackbarOnWindows)}({bool.TrueString.ToLower()});` must be called to enable Snackbar on Windows. See the Platform Specific Initialization section of the {nameof(Snackbar)} documentaion for more information: https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar")
 			{
 				HelpLink = "https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar"
 			};

--- a/src/CommunityToolkit.Maui/AppBuilderExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui/AppBuilderExtensions.shared.cs
@@ -23,27 +23,10 @@ public static class AppBuilderExtensions
 		// Pass `null` because `options?.Invoke()` will set options on both `CommunityToolkit.Maui` and `CommunityToolkit.Maui.Core`
 		builder.UseMauiCommunityToolkitCore(null);
 
-#if WINDOWS
-		builder.ConfigureLifecycleEvents(events =>
-		{
-			events.AddWindows(windows => windows
-				.OnLaunched((_, _) =>
-				{
-					Microsoft.Windows.AppNotifications.AppNotificationManager.Default.NotificationInvoked += OnSnackbarNotificationInvoked;
-					Microsoft.Windows.AppNotifications.AppNotificationManager.Default.Register();
-				})
-				.OnClosed((_, _) =>
-				{
-					Microsoft.Windows.AppNotifications.AppNotificationManager.Default.NotificationInvoked -= OnSnackbarNotificationInvoked;
-					Microsoft.Windows.AppNotifications.AppNotificationManager.Default.Unregister();
-				}));
-		});
-#endif
-
 		builder.Services.AddSingleton<IPopupService, PopupService>();
 
 		// Invokes options for both `CommunityToolkit.Maui` and `CommunityToolkit.Maui.Core`
-		options?.Invoke(new Options());
+		options?.Invoke(new Options(builder));
 
 		builder.ConfigureMauiHandlers(h =>
 		{
@@ -56,12 +39,4 @@ public static class AppBuilderExtensions
 		NavigationBar.RemapForControls();
 		return builder;
 	}
-#if WINDOWS
-	static void OnSnackbarNotificationInvoked(
-		Microsoft.Windows.AppNotifications.AppNotificationManager sender,
-		Microsoft.Windows.AppNotifications.AppNotificationActivatedEventArgs args)
-	{
-		Snackbar.HandleSnackbarAction(args);
-	}
-#endif
 }

--- a/src/CommunityToolkit.Maui/Options.cs
+++ b/src/CommunityToolkit.Maui/Options.cs
@@ -49,7 +49,7 @@ public class Options() : Core.Options
 	/// Enables <see cref="Alerts.Snackbar"/> for Windows
 	/// </summary>
 	/// <remarks>
-	/// Additional setup is required in the Package.appxmanifest file to enable Snackbar on Windows. See the <see cref="Alerts.Snackbar"/> <a href="https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar">Platform Specific Initialization Documentation</a> for more information. Default value is false.
+	/// Additional setup is required in the Package.appxmanifest file to enable <see cref="Alerts.Snackbar"/> on Windows. See the <a href="https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar">Snackbar Platform Specific Initialization Documentation</a> for more information. Default value is false.
 	/// </remarks>
 	public void SetShouldEnableSnackbarOnWindows(bool value)
 	{

--- a/src/CommunityToolkit.Maui/Options.cs
+++ b/src/CommunityToolkit.Maui/Options.cs
@@ -49,7 +49,7 @@ public class Options() : Core.Options
 	/// Enables <see cref="Alerts.Snackbar"/> for Windows
 	/// </summary>
 	/// <remarks>
-	/// Additonal setup in Package.appxmanifest to enable Snackbar for Windows. See the <see cref="Alerts.Snackbar"/> Platform Specific Initialization Documentation for more information. Default value is false.
+	/// Additional setup is required in the Package.appxmanifest file to enable Snackbar on Windows. See the <see cref="Alerts.Snackbar"/> <a href="https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar">Platform Specific Initialization Documentation</a> for more information. Default value is false.
 	/// </remarks>
 	public void SetShouldEnableSnackbarOnWindows(bool value)
 	{

--- a/src/CommunityToolkit.Maui/Options.cs
+++ b/src/CommunityToolkit.Maui/Options.cs
@@ -78,6 +78,6 @@ public class Options() : Core.Options
 #endif
 
 
-		ShouldEnableSnackbarOnWindows = true;
+		ShouldEnableSnackbarOnWindows = value;
 	}
 }

--- a/src/CommunityToolkit.Maui/Options.cs
+++ b/src/CommunityToolkit.Maui/Options.cs
@@ -56,7 +56,10 @@ public class Options() : Core.Options
 #if WINDOWS
 		if (value is true && builder is null)
 		{
-			throw new InvalidOperationException($"{nameof(SetShouldEnableSnackbarOnWindows)} must be called using the {nameof(AppBuilderExtensions.UseMauiCommunityToolkit)} extension method. See the Platform Specific Initialization section of the {nameof(Alerts.Snackbar)} documentaion for more inforamtion: https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar)");
+			throw new InvalidOperationException($"{nameof(SetShouldEnableSnackbarOnWindows)} must be called using the {nameof(AppBuilderExtensions.UseMauiCommunityToolkit)} extension method. See the Platform Specific Initialization section of the {nameof(Alerts.Snackbar)} documentaion for more inforamtion: https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar)")
+			{
+ 				HelpLink = "https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar"
+ 			};
 		}
 		else if (value is true && builder is not null)
 		{

--- a/src/CommunityToolkit.Maui/Options.cs
+++ b/src/CommunityToolkit.Maui/Options.cs
@@ -1,32 +1,83 @@
 using CommunityToolkit.Maui.Behaviors;
 using CommunityToolkit.Maui.Converters;
+using Microsoft.Maui.LifecycleEvents;
 
 namespace CommunityToolkit.Maui;
 
 /// <summary>
 /// .NET MAUI Community Toolkit Options.
 /// </summary>
-public class Options : Core.Options
+public class Options() : Core.Options
 {
+	readonly MauiAppBuilder? builder;
+
+	internal Options(MauiAppBuilder builder) : this()
+	{
+		this.builder = builder;
+	}
+
 	internal static bool ShouldSuppressExceptionsInAnimations { get; private set; }
 	internal static bool ShouldSuppressExceptionsInConverters { get; private set; }
 	internal static bool ShouldSuppressExceptionsInBehaviors { get; private set; }
+	internal static bool ShouldEnableSnackbarOnWindows { get; private set; }
 
 	/// <summary>
 	/// Allows to return default value instead of throwing an exception when using <see cref="BaseConverter{TFrom,TTo}"/>.
-	/// Default value is false.
 	/// </summary>
+	/// <remarks>
+	/// Default value is false.
+	/// </remarks>
 	public void SetShouldSuppressExceptionsInConverters(bool value) => ShouldSuppressExceptionsInConverters = value;
 
 	/// <summary>
 	/// Allows to return default value instead of throwing an exception when using <see cref="AnimationBehavior"/>.
-	/// Default value is false.
 	/// </summary>
+	/// <remarks>
+	/// Default value is false.
+	/// </remarks>
 	public void SetShouldSuppressExceptionsInAnimations(bool value) => ShouldSuppressExceptionsInAnimations = value;
 
 	/// <summary>
 	/// Allows to return default value instead of throwing an exception when using <see cref="BaseBehavior{TView}"/>.
-	/// Default value is false.
 	/// </summary>
+	/// <remarks>
+	/// Default value is false.
+	/// </remarks>
 	public void SetShouldSuppressExceptionsInBehaviors(bool value) => ShouldSuppressExceptionsInBehaviors = value;
+
+	/// <summary>
+	/// Enables <see cref="Alerts.Snackbar"/> for Windows
+	/// </summary>
+	/// <remarks>
+	/// Additonal setup in Package.appxmanifest to enable Snackbar for Windows. See the <see cref="Alerts.Snackbar"/> Platform Specific Initialization Documentation for more information. Default value is false.
+	/// </remarks>
+	public void SetShouldEnableSnackbarOnWindows(bool value)
+	{
+
+#if WINDOWS
+		builder?.ConfigureLifecycleEvents(events =>
+		{
+			events.AddWindows(windows => windows
+				.OnLaunched((_, _) =>
+				{
+					Microsoft.Windows.AppNotifications.AppNotificationManager.Default.NotificationInvoked += OnSnackbarNotificationInvoked;
+					Microsoft.Windows.AppNotifications.AppNotificationManager.Default.Register();
+				})
+				.OnClosed((_, _) =>
+				{
+					Microsoft.Windows.AppNotifications.AppNotificationManager.Default.NotificationInvoked -= OnSnackbarNotificationInvoked;
+					Microsoft.Windows.AppNotifications.AppNotificationManager.Default.Unregister();
+				}));
+		});
+
+		static void OnSnackbarNotificationInvoked(Microsoft.Windows.AppNotifications.AppNotificationManager sender,
+													Microsoft.Windows.AppNotifications.AppNotificationActivatedEventArgs args)
+		{
+			Alerts.Snackbar.HandleSnackbarAction(args);
+		}
+#endif
+
+
+		ShouldEnableSnackbarOnWindows = true;
+	}
 }


### PR DESCRIPTION
Snackbar now requires additional code to be added on Windows to the Package.appxmanifest file: https://github.com/MicrosoftDocs/CommunityToolkit/pull/374

Currently, without adding this additional code to `Package.appxmanifest`, `CommunityToolkit.Maui` causes all Windows apps to crash on launch. 

This PR adds `Options.ShouldEnableSnackbarOnWidows` to allow users to opt-in to enabling Snackbar on Windows, ensuring that they have added the additional required code to `Package.appxmanifest`.

```cs
var builder = MauiApp.CreateBuilder()
  .UseMauiCommunityToolkit(options =>
  {
    options.SetShouldEnableSnackbarOnWindows(true);
  })
```