### PR TITLE
Update Touch Behavior Sample

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/TouchBehaviorPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/TouchBehaviorPage.xaml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" ?>
 
 <pages:BasePage
     x:Class="CommunityToolkit.Maui.Sample.Pages.Behaviors.TouchBehaviorPage"
@@ -24,9 +24,11 @@
     <ScrollView>
         <VerticalStackLayout>
 
-            <Label HorizontalOptions="Center" HorizontalTextAlignment="Center"
-                   FontSize="Body"
-                   Text="{Binding TouchCount, StringFormat='Touches: {0}'}" />
+            <Label
+                FontSize="Body"
+                HorizontalOptions="Center"
+                HorizontalTextAlignment="Center"
+                Text="{Binding TouchCount, StringFormat='Touches: {0}'}" />
 
             <Label Style="{StaticResource SectionHeader}" Text="Image | Toggle" />
             <Image HeightRequest="100" WidthRequest="100">
@@ -42,6 +44,8 @@
             <HorizontalStackLayout HorizontalOptions="CenterAndExpand" VerticalOptions="Center">
                 <HorizontalStackLayout.Behaviors>
                     <mct:TouchBehavior
+                        BindingContext="{Binding Source={x:Reference Page}, Path=BindingContext}"
+                        Command="{Binding IncreaseTouchCountCommand}"
                         DefaultAnimationDuration="250"
                         DefaultAnimationEasing="{x:Static Easing.CubicInOut}"
                         Command="{Binding IncreaseTouchCountCommand}"
@@ -50,23 +54,26 @@
                 </HorizontalStackLayout.Behaviors>
 
                 <ContentView
+                    BackgroundColor="Gold"
                     HeightRequest="100"
-                    WidthRequest="10"
-                    BackgroundColor="Gold" />
-                <Label Text="The entire layout receives touches" VerticalOptions="Center" LineBreakMode="TailTruncation"/>
+                    WidthRequest="10" />
+                <Label
+                    LineBreakMode="TailTruncation"
+                    Text="The entire layout receives touches"
+                    VerticalOptions="Center" />
                 <ContentView
+                    BackgroundColor="Gold"
                     HeightRequest="100"
-                    WidthRequest="10"
-                    BackgroundColor="Gold" />
+                    WidthRequest="10" />
             </HorizontalStackLayout>
 
             <Label Style="{StaticResource SectionHeader}" Text="Long Press | Hover" />
 
             <Label
+                Margin="0,0,0,6"
                 FontSize="Body"
                 HorizontalOptions="CenterAndExpand"
-                Text="{Binding LongPressCount, StringFormat='Long press count: {0}'}"
-                Margin="0,0,0,6" />
+                Text="{Binding LongPressCount, StringFormat='Long press count: {0}'}" />
             <HorizontalStackLayout
                 Padding="20"
                 Background="Black"
@@ -94,6 +101,8 @@
 
                 <HorizontalStackLayout.Behaviors>
                     <mct:TouchBehavior
+                        BindingContext="{Binding Source={x:Reference Page}, Path=BindingContext}"
+                        Command="{Binding IncreaseTouchCountCommand}"
                         DefaultAnimationDuration="500"
                         Command="{Binding IncreaseTouchCountCommand}"
                         DefaultBackgroundColor="Gold"
@@ -157,6 +166,8 @@
                 StrokeThickness="0">
                 <Border.Behaviors>
                     <mct:TouchBehavior
+                        BindingContext="{Binding Source={x:Reference Page}, Path=BindingContext}"
+                        Command="{Binding IncreaseTouchCountCommand}"
                         DefaultAnimationDuration="150"
                         DefaultAnimationEasing="{x:Static Easing.CubicInOut}"
                         Command="{Binding IncreaseTouchCountCommand}"
@@ -175,8 +186,7 @@
                         WidthRequest="40" />
                     <VerticalStackLayout Grid.Column="1" VerticalOptions="Center">
                         <Label FontSize="20" Text="Lorem Ipsum" />
-                        <Label FontSize="12"
-                               Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam gravida, sapien in volutpat ornare, magna dui condimentum dui, quis egestas tellus leo non nulla. Quisque sit amet neque dapibus, congue justo non, dapibus dolor." />
+                        <Label FontSize="12" Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam gravida, sapien in volutpat ornare, magna dui condimentum dui, quis egestas tellus leo non nulla. Quisque sit amet neque dapibus, congue justo non, dapibus dolor." />
                     </VerticalStackLayout>
                 </Grid>
             </Border>

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/TouchBehaviorPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/TouchBehaviorPage.xaml
@@ -12,6 +12,8 @@
 
     <ContentPage.Resources>
         <ResourceDictionary>
+            <x:Double x:Key="SectionSpacing">10</x:Double>
+
             <Style x:Key="SectionHeader" TargetType="Label">
                 <Setter Property="Margin" Value="0,16,0,6" />
                 <Setter Property="FontAttributes" Value="Bold" />
@@ -22,13 +24,14 @@
     </ContentPage.Resources>
 
     <ScrollView>
-        <VerticalStackLayout>
+        <VerticalStackLayout Spacing="20">
 
-            <Label
-                FontSize="Body"
-                HorizontalOptions="Center"
-                HorizontalTextAlignment="Center"
-                Text="{Binding TouchCount, StringFormat='Touches: {0}'}" />
+            <VerticalStackLayout Spacing="{StaticResource SectionSpacing}">
+                <Label
+                    FontSize="Body"
+                    HorizontalOptions="Center"
+                    HorizontalTextAlignment="Center"
+                    Text="{Binding TouchCount, StringFormat='Touches: {0}'}" />
 
             <Label Style="{StaticResource SectionHeader}" Text="Image | Toggle" />
             <Image HeightRequest="100" WidthRequest="100">
@@ -53,21 +56,23 @@
                         PressedScale="0.8" />
                 </HorizontalStackLayout.Behaviors>
 
-                <ContentView
-                    BackgroundColor="Gold"
-                    HeightRequest="100"
-                    WidthRequest="10" />
-                <Label
-                    LineBreakMode="TailTruncation"
-                    Text="The entire layout receives touches"
-                    VerticalOptions="Center" />
-                <ContentView
-                    BackgroundColor="Gold"
-                    HeightRequest="100"
-                    WidthRequest="10" />
-            </HorizontalStackLayout>
+                    <ContentView
+                        BackgroundColor="Gold"
+                        HeightRequest="100"
+                        WidthRequest="10" />
+                    <Label
+                        LineBreakMode="TailTruncation"
+                        Text="The entire layout receives touches"
+                        VerticalOptions="Center" />
+                    <ContentView
+                        BackgroundColor="Gold"
+                        HeightRequest="100"
+                        WidthRequest="10" />
+                </HorizontalStackLayout>
+            </VerticalStackLayout>
 
-            <Label Style="{StaticResource SectionHeader}" Text="Long Press | Hover" />
+            <VerticalStackLayout Spacing="{StaticResource SectionSpacing}">
+                <Label Style="{StaticResource SectionHeader}" Text="Long Press | Hover" />
 
             <Label
                 Margin="0,0,0,6"
@@ -86,18 +91,37 @@
                         LongPressCommand="{Binding IncreaseLongPressCountCommand}" />
                 </HorizontalStackLayout.Behaviors>
                 <Label
-                    FontSize="Large"
-                    Text="TITLE"
-                    TextColor="White"
-                    VerticalOptions="Start" />
-            </HorizontalStackLayout>
+                    Margin="0,0,0,6"
+                    FontSize="Body"
+                    HorizontalOptions="CenterAndExpand"
+                    Text="{Binding LongPressCount, StringFormat='Long press count: {0}'}" />
+                <HorizontalStackLayout
+                    Padding="20"
+                    Background="Black"
+                    HorizontalOptions="CenterAndExpand">
+                    <HorizontalStackLayout.Behaviors>
+                        <mct:TouchBehavior
+                            BindingContext="{Binding Source={x:Reference Page}, Path=BindingContext}"
+                            Command="{Binding IncreaseTouchCountCommand}"
+                            HoveredBackgroundColor="{StaticResource Gray900}"
+                            HoveredScale="1.2"
+                            LongPressCommand="{Binding Source={x:Reference Page}, Path=BindingContext.IncreaseLongPressCountCommand}" />
+                    </HorizontalStackLayout.Behaviors>
+                    <Label
+                        FontSize="Large"
+                        Text="TITLE"
+                        TextColor="White"
+                        VerticalOptions="Start" />
+                </HorizontalStackLayout>
+            </VerticalStackLayout>
 
-            <Label Style="{StaticResource SectionHeader}" Text="Color | Rotation | Animated" />
+            <VerticalStackLayout Spacing="{StaticResource SectionSpacing}">
+                <Label Style="{StaticResource SectionHeader}" Text="Color | Rotation | Animated" />
 
-            <HorizontalStackLayout
-                Padding="20"
-                BackgroundColor="Gold"
-                HorizontalOptions="CenterAndExpand">
+                <HorizontalStackLayout
+                    Padding="20"
+                    BackgroundColor="Gold"
+                    HorizontalOptions="CenterAndExpand">
 
                 <HorizontalStackLayout.Behaviors>
                     <mct:TouchBehavior
@@ -109,13 +133,14 @@
                         PressedBackgroundColor="Orange"
                         PressedRotation="15" />
 
-                </HorizontalStackLayout.Behaviors>
+                    </HorizontalStackLayout.Behaviors>
 
-                <Label
-                    FontSize="Large"
-                    Text="TITLE"
-                    TextColor="White" />
-            </HorizontalStackLayout>
+                    <Label
+                        FontSize="Large"
+                        Text="TITLE"
+                        TextColor="White" />
+                </HorizontalStackLayout>
+            </VerticalStackLayout>
 
             <Label Style="{StaticResource SectionHeader}" Text="Image | Native" />
             <Border StrokeThickness="1">
@@ -130,7 +155,8 @@
                 </Image>
             </Border>
 
-            <Label Style="{StaticResource SectionHeader}" Text="Nested effect" />
+            <VerticalStackLayout Spacing="{StaticResource SectionSpacing}">
+                <Label Style="{StaticResource SectionHeader}" Text="Nested effect" />
 
             <ContentView
                 Padding="50"
@@ -144,19 +170,30 @@
                 </ContentView.Behaviors>
 
                 <ContentView
-                    BackgroundColor="Red"
-                    HeightRequest="100"
+                    Padding="50"
+                    Background="Yellow"
+                    HeightRequest="200"
                     HorizontalOptions="Center"
-                    VerticalOptions="Center"
-                    WidthRequest="100">
+                    WidthRequest="200">
                     <ContentView.Behaviors>
                         <mct:TouchBehavior
                             Command="{Binding ChildClickedCommand}" />
                     </ContentView.Behaviors>
-                </ContentView>
-            </ContentView>
 
-            <VerticalStackLayout Spacing="10">
+                    <ContentView
+                        BackgroundColor="Red"
+                        HeightRequest="100"
+                        HorizontalOptions="Center"
+                        VerticalOptions="Center"
+                        WidthRequest="100">
+                        <ContentView.Behaviors>
+                            <mct:TouchBehavior BindingContext="{Binding Source={x:Reference Page}, Path=BindingContext}" Command="{Binding ChildClickedCommand}" />
+                        </ContentView.Behaviors>
+                    </ContentView>
+                </ContentView>
+            </VerticalStackLayout>
+
+            <VerticalStackLayout Spacing="{StaticResource SectionSpacing}">
                 <Label Style="{StaticResource SectionHeader}" Text="Command with parameter example" />
 
                 <Picker x:Name="MonkeyPicker" Title="Pick a monkey">
@@ -196,7 +233,8 @@
                 </Border>
             </VerticalStackLayout>
 
-            <Label Style="{StaticResource SectionHeader}" Text="Input transparency for nested layouts" />
+            <VerticalStackLayout Spacing="{StaticResource SectionSpacing}">
+                <Label Style="{StaticResource SectionHeader}" Text="Input transparency for nested layouts" />
 
             <Border
                 Margin="20"
@@ -218,18 +256,34 @@
                 </Border.Behaviors>
                 <Grid
                     BackgroundColor="Transparent"
-                    ColumnDefinitions="Auto, *"
-                    ColumnSpacing="10">
-                    <Ellipse
-                        BackgroundColor="#A4CF5B"
-                        HeightRequest="40"
-                        WidthRequest="40" />
-                    <VerticalStackLayout Grid.Column="1" VerticalOptions="Center">
-                        <Label FontSize="20" Text="Lorem Ipsum" />
-                        <Label FontSize="12" Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam gravida, sapien in volutpat ornare, magna dui condimentum dui, quis egestas tellus leo non nulla. Quisque sit amet neque dapibus, congue justo non, dapibus dolor." />
-                    </VerticalStackLayout>
-                </Grid>
-            </Border>
+                    StrokeShape="RoundRectangle, 10"
+                    StrokeThickness="0">
+                    <Border.Behaviors>
+                        <mct:TouchBehavior
+                            BindingContext="{Binding Source={x:Reference Page}, Path=BindingContext}"
+                            Command="{Binding IncreaseTouchCountCommand}"
+                            DefaultAnimationDuration="150"
+                            DefaultAnimationEasing="{x:Static Easing.CubicInOut}"
+                            PressedBackgroundColor="LightGray"
+                            PressedOpacity="0.8"
+                            PressedScale="0.9"
+                            ShouldMakeChildrenInputTransparent="True" />
+                    </Border.Behaviors>
+                    <Grid
+                        BackgroundColor="Transparent"
+                        ColumnDefinitions="Auto, *"
+                        ColumnSpacing="10">
+                        <Ellipse
+                            BackgroundColor="#A4CF5B"
+                            HeightRequest="40"
+                            WidthRequest="40" />
+                        <VerticalStackLayout Grid.Column="1" VerticalOptions="Center">
+                            <Label FontSize="20" Text="Lorem Ipsum" />
+                            <Label FontSize="12" Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam gravida, sapien in volutpat ornare, magna dui condimentum dui, quis egestas tellus leo non nulla. Quisque sit amet neque dapibus, congue justo non, dapibus dolor." />
+                        </VerticalStackLayout>
+                    </Grid>
+                </Border>
+            </VerticalStackLayout>
         </VerticalStackLayout>
     </ScrollView>
 </pages:BasePage>

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/TouchBehaviorPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/TouchBehaviorPage.xaml
@@ -156,6 +156,46 @@
                 </ContentView>
             </ContentView>
 
+            <VerticalStackLayout Spacing="10">
+                <Label Style="{StaticResource SectionHeader}" Text="Command with parameter example" />
+
+                <Picker x:Name="MonkeyPicker" Title="Pick a monkey">
+                    <Picker.ItemsSource>
+                        <x:Array Type="{x:Type x:String}">
+                            <x:String>Baboon</x:String>
+                            <x:String>Capuchin Monkey</x:String>
+                            <x:String>Blue Monkey</x:String>
+                            <x:String>Squirrel Monkey</x:String>
+                            <x:String>Golden Lion Tamarin</x:String>
+                            <x:String>Howler Monkey</x:String>
+                            <x:String>Japanese Macaque</x:String>
+                        </x:Array>
+                    </Picker.ItemsSource>
+                </Picker>
+
+                <Border
+                    Padding="20"
+                    BackgroundColor="Orange"
+                    HeightRequest="200"
+                    HorizontalOptions="Fill"
+                    StrokeShape="RoundRectangle, 20"
+                    StrokeThickness="0">
+                    <ContentView.Behaviors>
+                        <mct:TouchBehavior
+                            BindingContext="{Binding Source={x:Reference Page}, Path=BindingContext}"
+                            Command="{Binding MonkeySelectedCommand}"
+                            CommandParameter="{Binding Source={x:Reference MonkeyPicker}, Path=SelectedItem}" />
+                    </ContentView.Behaviors>
+                    <Label
+                        FontAttributes="Bold"
+                        FontSize="18"
+                        HorizontalTextAlignment="Center"
+                        Text="Press me to announce the selected monkey!"
+                        TextColor="White"
+                        VerticalTextAlignment="Center" />
+                </Border>
+            </VerticalStackLayout>
+
             <Label Style="{StaticResource SectionHeader}" Text="Input transparency for nested layouts" />
 
             <Border

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/TouchBehaviorPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/TouchBehaviorPage.xaml
@@ -33,28 +33,26 @@
                     HorizontalTextAlignment="Center"
                     Text="{Binding TouchCount, StringFormat='Touches: {0}'}" />
 
-            <Label Style="{StaticResource SectionHeader}" Text="Image | Toggle" />
-            <Image HeightRequest="100" WidthRequest="100">
-                <Image.Behaviors>
-                    <mct:ImageTouchBehavior
-                        Command="{Binding IncreaseTouchCountCommand}"
-                        DefaultImageSource="button.png"
-                        PressedImageSource="button_pressed.png" />
-                </Image.Behaviors>
-            </Image>
+                <Label Style="{StaticResource SectionHeader}" Text="Image | Toggle" />
+                <Image HeightRequest="100" WidthRequest="100">
+                    <Image.Behaviors>
+                        <mct:ImageTouchBehavior
+                            Command="{Binding IncreaseTouchCountCommand}"
+                            DefaultImageSource="button.png"
+                            PressedImageSource="button_pressed.png" />
+                    </Image.Behaviors>
+                </Image>
 
-            <Label Style="{StaticResource SectionHeader}" Text="Scale | Fade | Animated" />
-            <HorizontalStackLayout HorizontalOptions="CenterAndExpand" VerticalOptions="Center">
-                <HorizontalStackLayout.Behaviors>
-                    <mct:TouchBehavior
-                        BindingContext="{Binding Source={x:Reference Page}, Path=BindingContext}"
-                        Command="{Binding IncreaseTouchCountCommand}"
-                        DefaultAnimationDuration="250"
-                        DefaultAnimationEasing="{x:Static Easing.CubicInOut}"
-                        Command="{Binding IncreaseTouchCountCommand}"
-                        PressedOpacity="0.6"
-                        PressedScale="0.8" />
-                </HorizontalStackLayout.Behaviors>
+                <Label Style="{StaticResource SectionHeader}" Text="Scale | Fade | Animated" />
+                <HorizontalStackLayout HorizontalOptions="CenterAndExpand" VerticalOptions="Center">
+                    <HorizontalStackLayout.Behaviors>
+                        <mct:TouchBehavior
+                            Command="{Binding IncreaseTouchCountCommand}"
+                            DefaultAnimationDuration="250"
+                            DefaultAnimationEasing="{x:Static Easing.CubicInOut}"
+                            PressedOpacity="0.6"
+                            PressedScale="0.8" />
+                    </HorizontalStackLayout.Behaviors>
 
                     <ContentView
                         BackgroundColor="Gold"
@@ -74,44 +72,33 @@
             <VerticalStackLayout Spacing="{StaticResource SectionSpacing}">
                 <Label Style="{StaticResource SectionHeader}" Text="Long Press | Hover" />
 
-            <Label
-                Margin="0,0,0,6"
-                FontSize="Body"
-                HorizontalOptions="CenterAndExpand"
-                Text="{Binding LongPressCount, StringFormat='Long press count: {0}'}" />
-            <HorizontalStackLayout
-                Padding="20"
-                Background="Black"
-                HorizontalOptions="CenterAndExpand">
-                <HorizontalStackLayout.Behaviors>
-                    <mct:TouchBehavior
-                        Command="{Binding IncreaseTouchCountCommand}"
-                        HoveredBackgroundColor="{StaticResource Gray900}"
-                        HoveredScale="1.2"
-                        LongPressCommand="{Binding IncreaseLongPressCountCommand}" />
-                </HorizontalStackLayout.Behaviors>
                 <Label
                     Margin="0,0,0,6"
                     FontSize="Body"
                     HorizontalOptions="CenterAndExpand"
                     Text="{Binding LongPressCount, StringFormat='Long press count: {0}'}" />
-                <HorizontalStackLayout
-                    Padding="20"
-                    Background="Black"
-                    HorizontalOptions="CenterAndExpand">
+                <HorizontalStackLayout HorizontalOptions="CenterAndExpand" VerticalOptions="Center">
                     <HorizontalStackLayout.Behaviors>
                         <mct:TouchBehavior
-                            BindingContext="{Binding Source={x:Reference Page}, Path=BindingContext}"
                             Command="{Binding IncreaseTouchCountCommand}"
-                            HoveredBackgroundColor="{StaticResource Gray900}"
-                            HoveredScale="1.2"
-                            LongPressCommand="{Binding Source={x:Reference Page}, Path=BindingContext.IncreaseLongPressCountCommand}" />
+                            DefaultAnimationDuration="250"
+                            DefaultAnimationEasing="{x:Static Easing.CubicInOut}"
+                            PressedOpacity="0.6"
+                            PressedScale="0.8" />
                     </HorizontalStackLayout.Behaviors>
+
+                    <ContentView
+                        BackgroundColor="Gold"
+                        HeightRequest="100"
+                        WidthRequest="10" />
                     <Label
-                        FontSize="Large"
-                        Text="TITLE"
-                        TextColor="White"
-                        VerticalOptions="Start" />
+                        LineBreakMode="TailTruncation"
+                        Text="The entire layout receives touches"
+                        VerticalOptions="Center" />
+                    <ContentView
+                        BackgroundColor="Gold"
+                        HeightRequest="100"
+                        WidthRequest="10" />
                 </HorizontalStackLayout>
             </VerticalStackLayout>
 
@@ -123,15 +110,13 @@
                     BackgroundColor="Gold"
                     HorizontalOptions="CenterAndExpand">
 
-                <HorizontalStackLayout.Behaviors>
-                    <mct:TouchBehavior
-                        BindingContext="{Binding Source={x:Reference Page}, Path=BindingContext}"
-                        Command="{Binding IncreaseTouchCountCommand}"
-                        DefaultAnimationDuration="500"
-                        Command="{Binding IncreaseTouchCountCommand}"
-                        DefaultBackgroundColor="Gold"
-                        PressedBackgroundColor="Orange"
-                        PressedRotation="15" />
+                    <HorizontalStackLayout.Behaviors>
+                        <mct:TouchBehavior
+                            Command="{Binding IncreaseTouchCountCommand}"
+                            DefaultAnimationDuration="500"
+                            DefaultBackgroundColor="Gold"
+                            PressedBackgroundColor="Orange"
+                            PressedRotation="15" />
 
                     </HorizontalStackLayout.Behaviors>
 
@@ -149,25 +134,13 @@
                     Source="button.png"
                     WidthRequest="100">
                     <Image.Behaviors>
-                        <mct:TouchBehavior
-                            Command="{Binding IncreaseTouchCountCommand}" />
+                        <mct:TouchBehavior Command="{Binding IncreaseTouchCountCommand}" />
                     </Image.Behaviors>
                 </Image>
             </Border>
 
             <VerticalStackLayout Spacing="{StaticResource SectionSpacing}">
                 <Label Style="{StaticResource SectionHeader}" Text="Nested effect" />
-
-            <ContentView
-                Padding="50"
-                Background="Yellow"
-                HeightRequest="200"
-                HorizontalOptions="Center"
-                WidthRequest="200">
-                <ContentView.Behaviors>
-                    <mct:TouchBehavior
-                        Command="{Binding ParentClickedCommand}"/>
-                </ContentView.Behaviors>
 
                 <ContentView
                     Padding="50"
@@ -176,8 +149,7 @@
                     HorizontalOptions="Center"
                     WidthRequest="200">
                     <ContentView.Behaviors>
-                        <mct:TouchBehavior
-                            Command="{Binding ChildClickedCommand}" />
+                        <mct:TouchBehavior Command="{Binding ParentClickedCommand}" />
                     </ContentView.Behaviors>
 
                     <ContentView
@@ -187,7 +159,7 @@
                         VerticalOptions="Center"
                         WidthRequest="100">
                         <ContentView.Behaviors>
-                            <mct:TouchBehavior BindingContext="{Binding Source={x:Reference Page}, Path=BindingContext}" Command="{Binding ChildClickedCommand}" />
+                            <mct:TouchBehavior Command="{Binding ChildClickedCommand}" />
                         </ContentView.Behaviors>
                     </ContentView>
                 </ContentView>
@@ -218,10 +190,7 @@
                     StrokeShape="RoundRectangle, 20"
                     StrokeThickness="0">
                     <ContentView.Behaviors>
-                        <mct:TouchBehavior
-                            BindingContext="{Binding Source={x:Reference Page}, Path=BindingContext}"
-                            Command="{Binding MonkeySelectedCommand}"
-                            CommandParameter="{Binding Source={x:Reference MonkeyPicker}, Path=SelectedItem}" />
+                        <mct:TouchBehavior Command="{Binding MonkeySelectedCommand}" CommandParameter="{Binding Source={x:Reference MonkeyPicker}, Path=SelectedItem}" />
                     </ContentView.Behaviors>
                     <Label
                         FontAttributes="Bold"
@@ -236,38 +205,20 @@
             <VerticalStackLayout Spacing="{StaticResource SectionSpacing}">
                 <Label Style="{StaticResource SectionHeader}" Text="Input transparency for nested layouts" />
 
-            <Border
-                Margin="20"
-                Padding="20,10"
-                BackgroundColor="Transparent"
-                StrokeShape="RoundRectangle, 10"
-                StrokeThickness="0">
-                <Border.Behaviors>
-                    <mct:TouchBehavior
-                        BindingContext="{Binding Source={x:Reference Page}, Path=BindingContext}"
-                        Command="{Binding IncreaseTouchCountCommand}"
-                        DefaultAnimationDuration="150"
-                        DefaultAnimationEasing="{x:Static Easing.CubicInOut}"
-                        Command="{Binding IncreaseTouchCountCommand}"
-                        PressedBackgroundColor="LightGray"
-                        PressedOpacity="0.8"
-                        PressedScale="0.9"
-                        ShouldMakeChildrenInputTransparent="True" />
-                </Border.Behaviors>
-                <Grid
+                <Border
+                    Margin="20"
+                    Padding="20,10"
                     BackgroundColor="Transparent"
                     StrokeShape="RoundRectangle, 10"
                     StrokeThickness="0">
                     <Border.Behaviors>
                         <mct:TouchBehavior
-                            BindingContext="{Binding Source={x:Reference Page}, Path=BindingContext}"
                             Command="{Binding IncreaseTouchCountCommand}"
                             DefaultAnimationDuration="150"
                             DefaultAnimationEasing="{x:Static Easing.CubicInOut}"
                             PressedBackgroundColor="LightGray"
                             PressedOpacity="0.8"
-                            PressedScale="0.9"
-                            ShouldMakeChildrenInputTransparent="True" />
+                            PressedScale="0.9" />
                     </Border.Behaviors>
                     <Grid
                         BackgroundColor="Transparent"

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/TouchBehaviorPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/TouchBehaviorPage.xaml
@@ -77,28 +77,22 @@
                     FontSize="Body"
                     HorizontalOptions="CenterAndExpand"
                     Text="{Binding LongPressCount, StringFormat='Long press count: {0}'}" />
-                <HorizontalStackLayout HorizontalOptions="CenterAndExpand" VerticalOptions="Center">
+                <HorizontalStackLayout
+                    Padding="20"
+                    Background="Black"
+                    HorizontalOptions="CenterAndExpand">
                     <HorizontalStackLayout.Behaviors>
                         <mct:TouchBehavior
                             Command="{Binding IncreaseTouchCountCommand}"
-                            DefaultAnimationDuration="250"
-                            DefaultAnimationEasing="{x:Static Easing.CubicInOut}"
-                            PressedOpacity="0.6"
-                            PressedScale="0.8" />
+                            HoveredBackgroundColor="{StaticResource Gray900}"
+                            HoveredScale="1.2"
+                            LongPressCommand="{Binding IncreaseLongPressCountCommand}" />
                     </HorizontalStackLayout.Behaviors>
-
-                    <ContentView
-                        BackgroundColor="Gold"
-                        HeightRequest="100"
-                        WidthRequest="10" />
                     <Label
-                        LineBreakMode="TailTruncation"
-                        Text="The entire layout receives touches"
-                        VerticalOptions="Center" />
-                    <ContentView
-                        BackgroundColor="Gold"
-                        HeightRequest="100"
-                        WidthRequest="10" />
+                        FontSize="Large"
+                        Text="TITLE"
+                        TextColor="White"
+                        VerticalOptions="Start" />
                 </HorizontalStackLayout>
             </VerticalStackLayout>
 

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/TouchBehaviorPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/TouchBehaviorPage.xaml.cs
@@ -1,5 +1,4 @@
 using CommunityToolkit.Maui.Sample.ViewModels.Behaviors;
-
 namespace CommunityToolkit.Maui.Sample.Pages.Behaviors;
 
 public partial class TouchBehaviorPage : BasePage<TouchBehaviorViewModel>

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Behaviors/TouchBehaviorViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Behaviors/TouchBehaviorViewModel.cs
@@ -20,6 +20,18 @@ public partial class TouchBehaviorViewModel : BaseViewModel
 		=> DisplayAlert("Child Clicked", token);
 
 	[RelayCommand]
+	async Task MonkeySelected(string? monkey, CancellationToken token)
+	{
+		if (string.IsNullOrEmpty(monkey))
+		{
+			await DisplayAlert("No monkey selected", token);
+			return;
+		}
+
+		await DisplayAlert($"Selected monkey: {monkey}", token);
+	}
+	
+	[RelayCommand]
 	void IncreaseTouchCount()
 	{
 		TouchCount++;

--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/Touch/TouchBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/Touch/TouchBehavior.shared.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Windows.Input;
 using CommunityToolkit.Maui.Core;
 using CommunityToolkit.Maui.Extensions;


### PR DESCRIPTION
 ### Description of Change ###

Update the `TouchBehavior` sample gallery to show the recommended method of setting of setting the binding context for the `TouchBehavior`.

I have included a new usage with the `CommandParameter` to help clearup some confusion we've been seeing for people consuming this `Behavior` upon release.

 ### Linked Issues ###
 N/A

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [X] Has samples (if omitted, state reason in description)
 - [X] Rebased on top of `main` at time of PR
 - [X] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [X] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->

[Docs PR](https://github.com/MicrosoftDocs/CommunityToolkit/pull/399)

 ### Additional information ###

I've run `dotnet format` and checked that in, some minor changes all in the `TouchBehavior` area.

Screenshots of changes to the sample:
<img src="https://github.com/CommunityToolkit/Maui/assets/33064621/a3d43f7b-8c8c-4562-aaa3-80f4e658fcab" alt="Command parameter sample with no picker selection" width="400px">
<img src="https://github.com/CommunityToolkit/Maui/assets/33064621/923c50d7-7e65-487a-8720-3e39734e1c3e" alt="Command parameter sample after command executed with no picker selection" width="400px">
<img src="https://github.com/CommunityToolkit/Maui/assets/33064621/4c144b03-1b07-4fd3-809c-e3a46bff435a" alt="Command parameter sample after command executed with no picker selection" width="400px">


