### PR TITLE
Fix IOS crash on invalid or missing file extension on Resource Media Source

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
@@ -225,8 +225,8 @@ public partial class MediaManager : IDisposable
 		else if (MediaElement.Source is ResourceMediaSource resourceMediaSource)
 		{
 			var path = resourceMediaSource.Path;
-
-			if (!string.IsNullOrWhiteSpace(path))
+		
+			if (!string.IsNullOrWhiteSpace(path) && Path.HasExtension(path))
 			{
 				string directory = Path.GetDirectoryName(path) ?? "";
 				string filename = Path.GetFileNameWithoutExtension(path);

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
@@ -225,7 +225,7 @@ public partial class MediaManager : IDisposable
 		else if (MediaElement.Source is ResourceMediaSource resourceMediaSource)
 		{
 			var path = resourceMediaSource.Path;
-		
+
 			if (!string.IsNullOrWhiteSpace(path) && Path.HasExtension(path))
 			{
 				string directory = Path.GetDirectoryName(path) ?? "";
@@ -235,6 +235,10 @@ public partial class MediaManager : IDisposable
 					extension, directory);
 
 				asset = AVAsset.FromUrl(url);
+			}
+			else
+			{
+				Logger.LogWarning("Invalid file path for ResourceMediaSource.");
 			}
 		}
 


### PR DESCRIPTION
 - Bug fix

 ### Description of Change ###
The primary change made to the code involves enhancing the validation of the `path` variable. Previously, the code checked if the `path` was neither null nor consisted solely of whitespace. The update extends this validation by also verifying that the `path` includes an extension. This adjustment is crucial for ensuring that operations such as retrieving the directory name, the filename without its extension, and the file extension itself are only executed on valid file paths. This modification aims to mitigate potential errors or unexpected outcomes when the code encounters paths that do not correspond to actual files, which would characteristically include extensions.

### Summary of Changes:
- Enhanced validation of the `path` variable to include a check for the presence of a file extension, in addition to the existing checks for null or whitespace content. This ensures that operations reliant on the path being a file (with an extension) are only performed on suitable paths, thereby improving the robustness of the code against invalid path inputs.

_Reference to Code Changes:_
- The condition for checking the `path` variable has been updated to include a check for a file extension.
 
### Linked Issues ###

 - Fixes #1856

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

Fixes issue with invalid or missing file extension for video source that caused BSOD on IOS when trying to set source without a file extension.
 
