### PR TITLE
Bug fix for MediaElement File Duplication

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/CommunityToolkit.Maui.MediaElement.csproj
+++ b/src/CommunityToolkit.Maui.MediaElement/CommunityToolkit.Maui.MediaElement.csproj
@@ -47,16 +47,10 @@
     <WarningsAsErrors>$(WarningsAsErrors);CS1591</WarningsAsErrors>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <MauiImage Include="Resources\Images\fullscreen.svg" Pack="True" PackagePath="buildTransitive\Images\" />
-  </ItemGroup>
   
   <ItemGroup>
     <None Include="..\..\build\nuget.png" PackagePath="icon.png" Pack="true"/>
     <None Include="ReadMe.txt" pack="true" PackagePath="."/>
-    <None Include="Resources\Images\fullscreen.svg" Pack="True" PackagePath="buildTransitive\Images\" />
-    <None Include="CommunityToolkit.Maui.MediaElement.targets" Pack="True" PackagePath="buildTransitive\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CommunityToolkit.Maui.MediaElement/CommunityToolkit.Maui.MediaElement.targets
+++ b/src/CommunityToolkit.Maui.MediaElement/CommunityToolkit.Maui.MediaElement.targets
@@ -1,5 +1,0 @@
-<Project>
-  <ItemGroup>
-    <MauiImage Include="$(MSBuildThisFileDirectory)\Images\fullscreen.svg" />
-  </ItemGroup>
-</Project>

--- a/src/CommunityToolkit.Maui.MediaElement/Resources/Images/fullscreen.svg
+++ b/src/CommunityToolkit.Maui.MediaElement/Resources/Images/fullscreen.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24" fill="#FFFFFF" viewBox="0 -960 960 960" width="24"><path d="M120-120v-200h80v120h120v80H120Zm520 0v-80h120v-120h80v200H640ZM120-640v-200h200v80H200v120h-80Zm640 0v-120H640v-80h200v200h-80Z"/></svg> 

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.windows.cs
@@ -121,6 +121,17 @@ public class MauiMediaElement : Grid, IDisposable
 			return;
 		}
 
+		switch (appWindow.Presenter.Kind)
+		{
+			case AppWindowPresenterKind.FullScreen:
+				fullScreenButton.Click -= OnFullScreenButtonClick;
+				break;
+			case AppWindowPresenterKind.Default:
+				exitFullScreenButton.Click -= OnFullScreenButtonClick;
+				break;
+		}
+		mediaPlayerElement.PointerMoved -= OnMediaPlayerElementPointerMoved;
+		
 		if (disposing)
 		{
 			mediaPlayerElement.MediaPlayer.Dispose();

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.windows.cs
@@ -38,58 +38,56 @@ public class MauiMediaElement : Grid, IDisposable
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="MauiMediaElement"/> class.
-	/// </summary>
-	/// <param name="mediaPlayerElement"></param>
-	public MauiMediaElement(MediaPlayerElement mediaPlayerElement)
-	{
-		this.mediaPlayerElement = mediaPlayerElement;
+    /// </summary>
+    /// <param name="mediaPlayerElement"></param>
+    public MauiMediaElement(MediaPlayerElement mediaPlayerElement)
+    {
+        this.mediaPlayerElement = mediaPlayerElement;
 
-		var fullScreenIcon = new FontIcon
-		{
-			Glyph = "\uE740",
-			Foreground = new SolidColorBrush(Colors.White),
-			FontFamily = new FontFamily("Segoe MDL2 Assets")
-		};
-		var exitFullScreenIcon = new FontIcon
-		{
-			Glyph = "\uE73F",
-			Foreground = new SolidColorBrush(Colors.White),
-			FontFamily = new FontFamily("Segoe MDL2 Assets")
-		};
+        var fullScreenIcon = new FontIcon
+        {
+            Glyph = "\uE740",
+            FontFamily = new FontFamily("Segoe Fluent Icons")
+        };
+        var exitFullScreenIcon = new FontIcon
+        {
+            Glyph = "\uE73F",
+            FontFamily = new FontFamily("Segoe Fluent Icons")
+        };
 
-		fullScreenButton = new Button
-		{
-			Content = fullScreenIcon,
-			Background = new SolidColorBrush(Colors.Transparent),
-			Width = 45,
-			Height = 45
-		};
-		exitFullScreenButton = new Button
-		{
-			Content = exitFullScreenIcon,
-			Background = new SolidColorBrush(Colors.Transparent),
-			Width = 45,
-			Height = 45
-		};
+        fullScreenButton = new Button
+        {
+            Content = fullScreenIcon,
+            Background = new SolidColorBrush(Colors.Transparent),
+            Width = 45,
+            Height = 45
+        };
+        exitFullScreenButton = new Button
+        {
+            Content = exitFullScreenIcon,
+            Background = new SolidColorBrush(Colors.Transparent),
+            Width = 45,
+            Height = 45
+        };
 
-		buttonContainer = new Grid
-		{
-			HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Right,
-			VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Top,
-			Visibility = mediaPlayerElement.TransportControls.Visibility,
-			Width = 45,
-			Height = 45,
-			Margin = new Thickness(0, 20, 30, 0)
-		};
+        buttonContainer = new Grid
+        {
+            HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Right,
+            VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Top,
+            Visibility = mediaPlayerElement.TransportControls.Visibility,
+            Width = 45,
+            Height = 45,
+            Margin = new Thickness(0, 20, 30, 0)
+        };
 
-		fullScreenButton.Click += OnFullScreenButtonClick;
-		buttonContainer.Children.Add(fullScreenButton);
+        fullScreenButton.Click += OnFullScreenButtonClick;
+        buttonContainer.Children.Add(fullScreenButton);
 
-		Children.Add(this.mediaPlayerElement);
-		Children.Add(buttonContainer);
+        Children.Add(this.mediaPlayerElement);
+        Children.Add(buttonContainer);
 
-		mediaPlayerElement.PointerMoved += OnMediaPlayerElementPointerMoved;
-	}
+        mediaPlayerElement.PointerMoved += OnMediaPlayerElementPointerMoved;
+    }
 
 	/// <summary>
 	/// Finalizer

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.windows.cs
@@ -32,7 +32,8 @@ public class MauiMediaElement : Grid, IDisposable
 	readonly Button fullScreenButton;
 	readonly Button exitFullScreenButton;
 	readonly MediaPlayerElement mediaPlayerElement;
-
+	static readonly FontIcon fullScreenIcon = new() { Glyph = "\uE740", FontFamily = new FontFamily("Segoe Fluent Icons")};
+	static readonly FontIcon exitFullScreenIcon = new() { Glyph = "\uE73F", FontFamily = new FontFamily("Segoe Fluent Icons") };
 	bool doesNavigationBarExistBeforeFullScreen;
 	bool isDisposed;
 
@@ -43,17 +44,6 @@ public class MauiMediaElement : Grid, IDisposable
     public MauiMediaElement(MediaPlayerElement mediaPlayerElement)
     {
         this.mediaPlayerElement = mediaPlayerElement;
-
-        var fullScreenIcon = new FontIcon
-        {
-            Glyph = "\uE740",
-            FontFamily = new FontFamily("Segoe Fluent Icons")
-        };
-        var exitFullScreenIcon = new FontIcon
-        {
-            Glyph = "\uE73F",
-            FontFamily = new FontFamily("Segoe Fluent Icons")
-        };
 
         fullScreenButton = new Button
         {

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.windows.cs
@@ -30,7 +30,6 @@ public class MauiMediaElement : Grid, IDisposable
 	readonly Grid fullScreenGrid = new();
 	readonly Grid buttonContainer;
 	readonly Button fullScreenButton;
-	readonly Button exitFullScreenButton;
 	readonly MediaPlayerElement mediaPlayerElement;
 	static readonly FontIcon fullScreenIcon = new() { Glyph = "\uE740", FontFamily = new FontFamily("Segoe Fluent Icons")};
 	static readonly FontIcon exitFullScreenIcon = new() { Glyph = "\uE73F", FontFamily = new FontFamily("Segoe Fluent Icons") };
@@ -52,15 +51,8 @@ public class MauiMediaElement : Grid, IDisposable
             Width = 45,
             Height = 45
         };
-        exitFullScreenButton = new Button
-        {
-            Content = exitFullScreenIcon,
-            Background = new SolidColorBrush(Colors.Transparent),
-            Width = 45,
-            Height = 45
-        };
-
-        buttonContainer = new Grid
+        
+		buttonContainer = new Grid
         {
             HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Right,
             VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Top,
@@ -109,15 +101,7 @@ public class MauiMediaElement : Grid, IDisposable
 			return;
 		}
 
-		switch (appWindow.Presenter.Kind)
-		{
-			case AppWindowPresenterKind.FullScreen:
-				fullScreenButton.Click -= OnFullScreenButtonClick;
-				break;
-			case AppWindowPresenterKind.Default:
-				exitFullScreenButton.Click -= OnFullScreenButtonClick;
-				break;
-		}
+		fullScreenButton.Click -= OnFullScreenButtonClick;
 		mediaPlayerElement.PointerMoved -= OnMediaPlayerElementPointerMoved;
 		
 		if (disposing)
@@ -179,10 +163,7 @@ public class MauiMediaElement : Grid, IDisposable
 				popup.Child = null;
 				fullScreenGrid.Children.Clear();
 			}
-			exitFullScreenButton.Click -= OnFullScreenButtonClick;
-			fullScreenButton.Click += OnFullScreenButtonClick;
-			buttonContainer.Children.Remove(exitFullScreenButton);
-			buttonContainer.Children.Add(fullScreenButton);
+			fullScreenButton.Content = exitFullScreenIcon;
 			Children.Add(mediaPlayerElement);
 			Children.Add(buttonContainer);
 
@@ -201,10 +182,7 @@ public class MauiMediaElement : Grid, IDisposable
 			mediaPlayerElement.Height = displayInfo.Height / displayInfo.Density;
 
 			Children.Clear();
-			fullScreenButton.Click -= OnFullScreenButtonClick;
-			exitFullScreenButton.Click += OnFullScreenButtonClick;
-			buttonContainer.Children.Remove(fullScreenButton);
-			buttonContainer.Children.Add(exitFullScreenButton);
+			fullScreenButton.Content = fullScreenIcon;
 			fullScreenGrid.Children.Add(mediaPlayerElement);
 			fullScreenGrid.Children.Add(buttonContainer);
 


### PR DESCRIPTION
## Bug fix ##

### Sample ###

https://github.com/CommunityToolkit/Maui/assets/4167863/1f481dc4-5f6e-40d3-aefe-3595cfce58a1

 ### Description of Change ###

The most significant changes to the `MauiMediaElement` involve modernizing the fullscreen controls by transitioning from using static SVG images to adopting `FontIcon` elements for better flexibility and visual consistency. This shift enhances the user interface and interaction model for entering and exiting fullscreen mode. The key changes include:

1. **Removal of fullscreen.svg Resource**: The static `fullscreen.svg` image resource was removed, indicating a move away from static images for the fullscreen button.
2. **Introduction of Font Icons for Fullscreen Controls**: Replacing the `Image` with `FontIcon` elements for fullscreen controls, utilizing glyphs from the "Segoe MDL2 Assets" font for a more flexible and accessible approach.
3. **Adjustments to Fullscreen Button Logic**: The logic for toggling between the fullscreen and exit fullscreen buttons was refined, including the dynamic addition and removal of buttons and event handlers based on the fullscreen state.
4. **UI and Styling Adjustments**: Several UI and styling adjustments were made to improve the appearance and positioning of the fullscreen controls, such as setting the buttons' background to transparent and adjusting their size and margin.
5. **Removal of Static Image Source for Fullscreen Button**: The static image source for the fullscreen button was removed, aligning with the shift towards a font icon-based approach for controls.
6. **Event Handling Adjustments**: Minor adjustments were made to event handling, particularly in managing the visibility of the button container in response to pointer movements, ensuring intuitive user interactions.

These changes collectively enhance the `MauiMediaElement` by making the fullscreen controls more adaptable, visually consistent, and user-friendly.

 ### Linked Issues ###
 - Fixes #1862

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###
Fixes an issue where if you create a visual studio project and add a second project to it and then add media element to both projects will result in a file duplication error when attempting to build the project. This bug is fixed by not using a file image source and switching to using a `FontIcon`.
 
