### PR TITLE
Fixing crash in IconTintColorBehavior

### DIFF
--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.android.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.android.cs
@@ -11,17 +11,15 @@ namespace CommunityToolkit.Maui.Behaviors;
 
 public partial class IconTintColorBehavior
 {
-	View? mauiView;
 	AView? nativeView;
 	
 	/// <inheritdoc/>
 	protected override void OnAttachedTo(View bindable, AView platformView)
 	{
 		base.OnAttachedTo(bindable, platformView);
-		mauiView = bindable;
 		nativeView = platformView;
 
-		ApplyTintColor(platformView);
+		ApplyTintColor();
 
 		bindable.PropertyChanged += OnElementPropertyChanged;
 		PropertyChanged += OnTintedImagePropertyChanged;
@@ -29,9 +27,9 @@ public partial class IconTintColorBehavior
 	
 	void OnTintedImagePropertyChanged(object? sender, PropertyChangedEventArgs e)
 	{
-		if (e.PropertyName == TintColorProperty.PropertyName && mauiView is not null && nativeView is not null)
+		if (e.PropertyName == TintColorProperty.PropertyName)
 		{
-			ApplyTintColor(nativeView);
+			ApplyTintColor();
 		}
 	}
 
@@ -45,11 +43,16 @@ public partial class IconTintColorBehavior
 		PropertyChanged -= OnTintedImagePropertyChanged;
 	}
 
-	void ApplyTintColor(AView control)
+	void ApplyTintColor()
 	{
 		var color = TintColor;
 
-		switch (control)
+		if (nativeView is null)
+		{
+			return;
+		}
+
+		switch (nativeView)
 		{
 			case ImageView image:
 				SetImageViewTintColor(image, color);
@@ -108,7 +111,7 @@ public partial class IconTintColorBehavior
 			return;
 		}
 
-		ApplyTintColor(platformView);
+		ApplyTintColor();
 	}
 
 	void ClearTintColor(View element, AView control)

--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.android.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.android.cs
@@ -11,21 +11,28 @@ namespace CommunityToolkit.Maui.Behaviors;
 
 public partial class IconTintColorBehavior
 {
+	View? mauiView;
+	AView? nativeView;
+	
 	/// <inheritdoc/>
 	protected override void OnAttachedTo(View bindable, AView platformView)
 	{
 		base.OnAttachedTo(bindable, platformView);
+		mauiView = bindable;
+		nativeView = platformView;
 
-		ApplyTintColor(bindable, platformView);
+		ApplyTintColor(platformView);
 
 		bindable.PropertyChanged += OnElementPropertyChanged;
-		this.PropertyChanged += (s, e) =>
+		PropertyChanged += OnTintedImagePropertyChanged;
+	}
+	
+	void OnTintedImagePropertyChanged(object? sender, PropertyChangedEventArgs e)
+	{
+		if (e.PropertyName == TintColorProperty.PropertyName && mauiView is not null && nativeView is not null)
 		{
-			if (e.PropertyName == TintColorProperty.PropertyName)
-			{
-				ApplyTintColor(bindable, platformView);
-			}
-		};
+			ApplyTintColor(nativeView);
+		}
 	}
 
 	/// <inheritdoc/>
@@ -35,9 +42,10 @@ public partial class IconTintColorBehavior
 
 		ClearTintColor(bindable, platformView);
 		bindable.PropertyChanged -= OnElementPropertyChanged;
+		PropertyChanged -= OnTintedImagePropertyChanged;
 	}
 
-	void ApplyTintColor(View element, AView control)
+	void ApplyTintColor(AView control)
 	{
 		var color = TintColor;
 
@@ -100,7 +108,7 @@ public partial class IconTintColorBehavior
 			return;
 		}
 
-		ApplyTintColor(bindable, platformView);
+		ApplyTintColor(platformView);
 	}
 
 	void ClearTintColor(View element, AView control)


### PR DESCRIPTION
 ### Description of Change ###

Event handler was not disposed. That led to crash System.DisposedObject

 ### Linked Issues ###
#1819
#1710

 - Fixes #

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [ ] Rebased on top of `main` at time of PR
 - [ ] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

Android only
 
