### PR TITLE
Add PresentationStyle

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
@@ -219,6 +219,9 @@ public class MauiPopup : UIViewController
 		public override UIModalPresentationStyle GetAdaptivePresentationStyle(UIPresentationController forPresentationController) =>
 			UIModalPresentationStyle.None;
 
+		public override UIModalPresentationStyle GetAdaptivePresentationStyle(UIPresentationController controller, UITraitCollection traitCollection) =>
+			UIModalPresentationStyle.None;
+
 		public override void DidDismiss(UIPresentationController presentationController) =>
 			popoverDismissedEventManager.HandleEvent(this, presentationController, nameof(PopoverDismissedEvent));
 	}


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

This PR resolves the following issue that occurs when displaying Popup on iPhone 11 or lower, iPhone Plus, and iPhone Pro Max.

1. An issue that caused a crash when displaying a Popup when the device was in landscape orientation.
2. An issue where rotating the device while viewing a popup would cause a crash.

The exception is occurring at the location below, but it is not caused by the SetShadowView method.

[src\CommunityToolkit.Maui.Core\Views\Popup\MauiPopup.macios.cs]

	static void SetShadowView(in UIView target)
	{
		if (target.Class.Name is "_UICutoutShadowView")
		{
			target.RemoveFromSuperview();
		}

		if (target.Class.Name is "_UIPopoverDimmingView")
		{
			target.BackgroundColor = UIColor.Black.ColorWithAlpha(0.4f);
		}

		foreach (var view in target.Subviews)
		{
			SetShadowView(view);
		}
	}

 ### Description of Change ###

Below is the solution.

	sealed class PopoverDelegate : UIPopoverPresentationControllerDelegate
	{
		... omit 

		public override UIModalPresentationStyle GetAdaptivePresentationStyle(UIPresentationController forPresentationController) =>
			UIModalPresentationStyle.None;

		// ADD-START
		public override UIModalPresentationStyle GetAdaptivePresentationStyle(UIPresentationController controller, UITraitCollection traitCollection) =>
			UIModalPresentationStyle.None;
		// ADD-END

		... omit                
	}

The newly added code is the two lines above.

Resolving the Null reference exception in the SetSahdowView method causes the popup to display in modal form sheet style when the device orientation is landscape. To solve the problem, I focused on its behavior.

When I investigated the behavior for each device, we found that iPhone 11 or lower, iPhone Plue, and iPhone Pro Max exhibit this behavior. On devices other than those listed above, the Popup was displayed as intended, and on the devices listed above, the Popup was not displayed.

I was looking for a case where it is displayed in a modal form sheet format when the device is in landscape orientation.
I found the post below.
https://developer.apple.com/forums/thread/71350
https://stackoverflow.com/questions/30378249/uimodalpresentationpopover-for-iphone-6-plus-in-landscape-doesnt-display-popove

According to the above post, you need to override the method below and explicitly return UIModalPresentationStyle.none as the return value.

	func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle 
	{
		return UIModalPresentationStyle.none
	}

The same method as above is shown below.

	public override UIModalPresentationStyle GetAdaptivePresentationStyle(UIPresentationController controller, UITraitCollection traitCollection) =>
		UIModalPresentationStyle.None;

On the device where the problem occurs, you need to override the above method and return UIModalPresentationStyle.None as the return value.

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #1844

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->

Below are the verification results.

[iPhone 11]

|Case 1|Case 2|
|:-:|:-:|
|<video src="https://github.com/CommunityToolkit/Maui/assets/125236133/1a3b953a-0630-4932-ba91-a0a33b39dd16">|<video src="https://github.com/CommunityToolkit/Maui/assets/125236133/ef479fa0-6875-4957-83be-9b58a705927d">|

[iPhone 15 Plus]

|Case 1|Case 2|
|:-:|:-:|
|<video src="https://github.com/CommunityToolkit/Maui/assets/125236133/17f1d42e-695d-41b9-830b-38f55d3afa88">|<video src="https://github.com/CommunityToolkit/Maui/assets/125236133/afb877b6-499d-43f1-a475-78a0c63fa3e3">|

[iPhone 15 Pro Max]

|Case 1|Case 2|
|:-:|:-:|
|<video src="https://github.com/CommunityToolkit/Maui/assets/125236133/daeaae21-0d33-4509-bffa-3492217422e7">|<video src="https://github.com/CommunityToolkit/Maui/assets/125236133/577d739f-9d0d-48c5-97e2-45d5be00fb06">|

[iPhone 15]

|Case 1|Case 2|
|:-:|:-:|
|<video src="https://github.com/CommunityToolkit/Maui/assets/125236133/612257e5-744a-4c08-9afc-e6474c05a09c">|<video src="https://github.com/CommunityToolkit/Maui/assets/125236133/9960adca-ddea-4ed8-b69c-5e8127121778">|

You can see that the crash does not occur even if you rotate the orientation of the device while viewing the Popup.
You'll notice that if your device is in landscape orientation, it won't crash when you display the popup.