### PR TITLE
issue-1884-fix-snackbar-anchoring-ios: Attach snackbar to top anchor …

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Views/Alert/AlertView.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Alert/AlertView.macios.cs
@@ -67,7 +67,7 @@ public class AlertView : UIView
 		}
 		else
 		{
-			this.SafeBottomAnchor().ConstraintEqualTo(AnchorView.SafeBottomAnchor(), -defaultSpacing).Active = true;
+			this.SafeBottomAnchor().ConstraintEqualTo(AnchorView.SafeTopAnchor(), -defaultSpacing).Active = true;
 		}
 
 		this.SafeLeadingAnchor().ConstraintGreaterThanOrEqualTo(ParentView.SafeLeadingAnchor(), defaultSpacing).Active = true;


### PR DESCRIPTION
…of `AnchorView`. Would attach to bottom anchor and overlap the `AnchorView`.

 ### Description of Change ###

Fixes the vertical snackbar position on iOS if the snackbar is anchored at a view instead of the key window.

Has no tests because the snackbar position on the platform is not tested. No samples because it fixes existing behavior.

 ### Linked Issues ###

 - Fixes #1884

 ### PR Checklist ###
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated

 ### Additional information ###

Affects iOS only. Tested on iOS 17.2 simulators, both before and after the change.

Before (the `AnchorView` is the magenta "Hello world" label):
<img src="https://github.com/CommunityToolkit/Maui/assets/1574034/1a74abd6-c8e0-4fde-8f47-38c315db2705" width="256">

After:
<img src="https://github.com/CommunityToolkit/Maui/assets/1574034/7d867f4b-8f41-4497-9fb5-6e79a944fdbc" width="256">
