### PR TITLE
Add subtitle support

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml
@@ -29,7 +29,9 @@
             </Grid.RowDefinitions>
             <toolkit:MediaElement
                 x:Name="MediaElement"
+                WidthRequest="{OnIdiom Tablet=410, Default=380}"
                 ShouldAutoPlay="True"
+                SubtitleUrl=""
                 Source="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
                 MediaEnded="OnMediaEnded"
                 MediaFailed="OnMediaFailed"

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml
@@ -29,7 +29,6 @@
             </Grid.RowDefinitions>
             <toolkit:MediaElement
                 x:Name="MediaElement"
-                WidthRequest="{OnIdiom Tablet=410, Default=380}"
                 ShouldAutoPlay="True"
                 SubtitleUrl=""
                 Source="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml.cs
@@ -197,6 +197,8 @@ public partial class MediaElementPage : BasePage<MediaElementViewModel>
 				}
 				return;
 			case loadSubTitles:
+				MediaElement.SubtitleFont = "monospace";
+				MediaElement.SubtitleFontSize = 16;
 				MediaElement.SubtitleUrl = "https://raw.githubusercontent.com/ne0rrmatrix/SampleVideo/main/SRT/WindowsVideo.srt";
 				MediaElement.Source = MediaSource.FromResource("WindowsVideo.mp4");
 				return;

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml.cs
@@ -197,7 +197,14 @@ public partial class MediaElementPage : BasePage<MediaElementViewModel>
 				}
 				return;
 			case loadSubTitles:
-				MediaElement.SubtitleFont = "monospace";
+				if(OperatingSystem.IsIOS() || OperatingSystem.IsMacCatalyst())
+				{
+					MediaElement.SubtitleFont = "Avenir-Book";
+				}
+				else
+				{
+					MediaElement.SubtitleFont = "monospace";
+				}
 				MediaElement.SubtitleFontSize = 16;
 				MediaElement.SubtitleUrl = "https://raw.githubusercontent.com/ne0rrmatrix/SampleVideo/main/SRT/WindowsVideo.srt";
 				MediaElement.Source = MediaSource.FromResource("WindowsVideo.mp4");

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml.cs
@@ -14,6 +14,7 @@ public partial class MediaElementPage : BasePage<MediaElementViewModel>
 	const string loadHls = "Load HTTP Live Stream (HLS)";
 	const string loadLocalResource = "Load Local Resource";
 	const string resetSource = "Reset Source to null";
+	const string loadSubTitles = "Load Subtitles";
 
 	public MediaElementPage(MediaElementViewModel viewModel, ILogger<MediaElementPage> logger) : base(viewModel)
 	{
@@ -154,23 +155,26 @@ public partial class MediaElementPage : BasePage<MediaElementViewModel>
 	async void ChangeSourceClicked(Object sender, EventArgs e)
 	{
 		var result = await DisplayActionSheet("Choose a source", "Cancel", null,
-			loadOnlineMp4, loadHls, loadLocalResource, resetSource);
+			loadOnlineMp4, loadHls, loadLocalResource, resetSource, loadSubTitles);
 
 		switch (result)
 		{
 			case loadOnlineMp4:
+				MediaElement.SubtitleUrl = string.Empty;
 				MediaElement.Source =
 					MediaSource.FromUri(
 						"https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4");
 				return;
 
 			case loadHls:
+				MediaElement.SubtitleUrl = string.Empty;
 				MediaElement.Source
 					= MediaSource.FromUri(
 						"https://mtoczko.github.io/hls-test-streams/test-gap/playlist.m3u8");
 				return;
 
 			case resetSource:
+				MediaElement.SubtitleUrl = string.Empty;
 				MediaElement.Source = null;
 				return;
 
@@ -178,16 +182,23 @@ public partial class MediaElementPage : BasePage<MediaElementViewModel>
 				if (DeviceInfo.Platform == DevicePlatform.MacCatalyst
 					|| DeviceInfo.Platform == DevicePlatform.iOS)
 				{
+					MediaElement.SubtitleUrl = string.Empty;
 					MediaElement.Source = MediaSource.FromResource("AppleVideo.mp4");
 				}
 				else if (DeviceInfo.Platform == DevicePlatform.Android)
 				{
+					MediaElement.SubtitleUrl = string.Empty;
 					MediaElement.Source = MediaSource.FromResource("AndroidVideo.mp4");
 				}
 				else if (DeviceInfo.Platform == DevicePlatform.WinUI)
 				{
+					MediaElement.SubtitleUrl = string.Empty;
 					MediaElement.Source = MediaSource.FromResource("WindowsVideo.mp4");
 				}
+				return;
+			case loadSubTitles:
+				MediaElement.SubtitleUrl = "https://raw.githubusercontent.com/ne0rrmatrix/SampleVideo/main/SRT/WindowsVideo.srt";
+				MediaElement.Source = MediaSource.FromResource("WindowsVideo.mp4");
 				return;
 		}
 	}
@@ -214,7 +225,6 @@ public partial class MediaElementPage : BasePage<MediaElementViewModel>
 
 		MediaElement.Aspect = (Aspect)aspectEnum;
 	}
-
 	void DisplayPopup(object sender, EventArgs e)
 	{
 		MediaElement.Pause();

--- a/src/CommunityToolkit.Maui.MediaElement/Extensions/SrtParser.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Extensions/SrtParser.cs
@@ -1,0 +1,72 @@
+﻿using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace CommunityToolkit.Maui.Extensions;
+/// <summary>
+/// a class that provides subtitle parser for SRT files.
+/// </summary>
+public static partial class SrtParser
+{
+	static readonly string[] separator = ["\r\n", "\n"];
+
+	/// <summary>
+	/// a method that parses the SRT content and returns a list of SubtitleCue objects.
+	/// </summary>
+	/// <param name="srtContent"></param>
+	/// <returns></returns>
+	public static List<SubtitleCue> ParseSrtContent(string srtContent)
+	{
+		List<SubtitleCue> cues = [];
+		string[] lines = srtContent.Split(separator, StringSplitOptions.None);
+
+		Regex timecodePattern = MyRegex();
+
+		SubtitleCue? currentCue = null;
+		foreach (var line in lines)
+		{
+			if (int.TryParse(line, out _)) // Skip lines that contain only numbers
+			{
+				continue;
+			}
+			var match = timecodePattern.Match(line);
+			if (match.Success)
+			{
+				if (currentCue != null)
+				{
+					cues.Add(currentCue);
+				}
+
+				currentCue = new SubtitleCue
+				{
+					StartTime = ParseTimecode(match.Groups[1].Value),
+					EndTime = ParseTimecode(match.Groups[2].Value),
+					Text = ""
+				};
+			}
+			else if (currentCue is not null && !string.IsNullOrWhiteSpace(line))
+			{
+				if (!string.IsNullOrEmpty(currentCue.Text))
+				{
+					currentCue.Text += Environment.NewLine;
+				}
+				currentCue.Text += line.Trim(); // Trim leading/trailing spaces
+			}
+		}
+
+		if (currentCue is not null)
+		{
+			cues.Add(currentCue);
+		}
+
+		return cues;
+	}
+
+	static TimeSpan ParseTimecode(string timecode)
+	{
+		return TimeSpan.ParseExact(timecode, @"hh\:mm\:ss\,fff", CultureInfo.InvariantCulture);
+	}
+
+	[GeneratedRegex(@"(\d{2}\:\d{2}\:\d{2}\,\d{3}) --> (\d{2}\:\d{2}\:\d{2}\,\d{3})")]
+	private static partial Regex MyRegex();
+}
+

--- a/src/CommunityToolkit.Maui.MediaElement/Extensions/SrtParser.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Extensions/SrtParser.cs
@@ -31,7 +31,7 @@ public static partial class SrtParser
 			var match = timecodePattern.Match(line);
 			if (match.Success)
 			{
-				if (currentCue != null)
+				if (currentCue is not null)
 				{
 					cues.Add(currentCue);
 				}

--- a/src/CommunityToolkit.Maui.MediaElement/Extensions/SubtitleCue.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Extensions/SubtitleCue.cs
@@ -1,0 +1,26 @@
+﻿namespace CommunityToolkit.Maui.Extensions;
+
+/// <summary>
+/// The SubtitleCue class represents a single cue in a subtitle file.
+/// </summary>
+public class SubtitleCue
+{
+	/// <summary>
+	/// The number of the cue.
+	/// </summary>
+	public int Number { get; set; }
+	/// <summary>
+	/// The start time of the cue.
+	/// </summary>
+	public TimeSpan? StartTime { get; set; }
+
+	/// <summary>
+	/// The end time of the cue.
+	/// </summary>
+	public TimeSpan? EndTime { get; set; }
+
+	/// <summary>
+	/// The text of the cue.
+	/// </summary>
+	public string? Text { get; set; }
+}

--- a/src/CommunityToolkit.Maui.MediaElement/Extensions/SubtitleExtensions.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Extensions/SubtitleExtensions.android.cs
@@ -38,7 +38,7 @@ public partial class SubtitleExtensions : CoordinatorLayout
 		this.dispatcher = dispatcher;
 		this.styledPlayerView = styledPlayerView;
 		cues = [];
-		
+
 		textBlockLayout = new RelativeLayout.LayoutParams(LayoutParams.WrapContent, LayoutParams.WrapContent);
 		textBlockLayout.AddRule(LayoutRules.AlignParentBottom);
 		textBlockLayout.AddRule(LayoutRules.CenterHorizontal);
@@ -52,7 +52,7 @@ public partial class SubtitleExtensions : CoordinatorLayout
 			LayoutParameters = textBlockLayout
 		};
 		textBlock.SetBackgroundColor(Android.Graphics.Color.Argb(150, 0, 0, 0));
-		textBlock.SetPadding(10, 10, 10, 10);
+		textBlock.SetPaddingRelative(10, 10, 10, 10);
 		textBlock.SetTextColor(Android.Graphics.Color.White);
 		
 		MauiMediaElement.WindowsChanged += MauiMediaElement_WindowsChanged;

--- a/src/CommunityToolkit.Maui.MediaElement/Extensions/SubtitleExtensions.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Extensions/SubtitleExtensions.android.cs
@@ -45,7 +45,6 @@ public partial class SubtitleExtensions : CoordinatorLayout
 			Text = string.Empty,
 			HorizontalScrollBarEnabled = false,
 			VerticalScrollBarEnabled = false,
-			TextSize = 16,
 			TextAlignment = Android.Views.TextAlignment.Center,
 			Visibility = Android.Views.ViewStates.Gone,
 		};
@@ -156,7 +155,9 @@ public partial class SubtitleExtensions : CoordinatorLayout
 		{
 			if (cue is not null)
 			{
+				textBlock.FontFeatureSettings = !string.IsNullOrEmpty(mediaElement.SubtitleFont) ? mediaElement.SubtitleFont : default;
 				textBlock.Text = cue.Text;
+				textBlock.TextSize = (float)mediaElement.SubtitleFontSize;
 				textBlock.Visibility = Android.Views.ViewStates.Visible;
 			}
 			else

--- a/src/CommunityToolkit.Maui.MediaElement/Extensions/SubtitleExtensions.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Extensions/SubtitleExtensions.android.cs
@@ -1,0 +1,209 @@
+﻿using Android.Content;
+using Android.Views;
+using Android.Widget;
+using AndroidX.CoordinatorLayout.Widget;
+using Com.Google.Android.Exoplayer2.UI;
+using CommunityToolkit.Maui.Core;
+using CommunityToolkit.Maui.Core.Views;
+using CommunityToolkit.Maui.Primitives;
+
+namespace CommunityToolkit.Maui.Extensions;
+/// <summary>
+/// A class that provides subtitle support for a video player.
+/// </summary>
+public partial class SubtitleExtensions : CoordinatorLayout
+{
+	readonly HttpClient httpClient;
+	System.Timers.Timer? timer;
+	List<SubtitleCue> cues;
+	bool disposedValue;
+	bool isFullScreen = false;
+	IMediaElement? mediaElement;
+	TextView? textBlock;
+	readonly StyledPlayerView styledPlayerView;
+	readonly IDispatcher dispatcher;
+	RelativeLayout? relativeLayout;
+	RelativeLayout? fullScreenLayout;
+
+	/// <summary>
+	/// The SubtitleExtensions class provides a way to display subtitles on a video player.
+	/// </summary>
+	/// <param name="context"></param>
+	/// <param name="styledPlayerView"></param>
+	public SubtitleExtensions(Context context, StyledPlayerView styledPlayerView, IDispatcher dispatcher) : base(context)
+	{
+		httpClient = new HttpClient();
+		this.dispatcher = dispatcher;
+		this.styledPlayerView = styledPlayerView;
+		cues = [];
+		MauiMediaElement.WindowsChanged += MauiMediaElement_WindowsChanged;
+	}
+
+	void MauiMediaElement_WindowsChanged(object? sender, WindowsEventArgs e)
+	{
+		if (e.data is not ViewGroup viewGroup || styledPlayerView.Parent is not ViewGroup parent || string.IsNullOrEmpty(mediaElement?.SubtitleUrl))
+		{
+			return;
+		}
+		if(isFullScreen)
+		{
+			relativeLayout = new(Platform.AppContext)
+			{
+				LayoutParameters = new CoordinatorLayout.LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent)
+				{
+					Gravity = (int)GravityFlags.Bottom
+				}
+			};
+			dispatcher.Dispatch(() =>
+			{
+				viewGroup.RemoveView(fullScreenLayout);
+				fullScreenLayout?.RemoveView(textBlock);
+				relativeLayout?.AddView(textBlock);
+				parent.AddView(relativeLayout);
+			});
+			isFullScreen = false;
+			return;
+		}
+
+		dispatcher.Dispatch(() =>
+		{
+			parent.RemoveView(relativeLayout);
+			relativeLayout?.RemoveView(textBlock);
+			fullScreenLayout = new(Platform.AppContext)
+			{
+				LayoutParameters = new CoordinatorLayout.LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent)
+				{
+					Gravity = (int)GravityFlags.Bottom
+				}
+			};
+			fullScreenLayout.AddView(textBlock);
+			viewGroup.AddView(fullScreenLayout);
+		});
+		isFullScreen = true;
+	}
+
+	/// <summary>
+	/// Loads the subtitles from the provided URL.
+	/// </summary>
+	/// <param name="mediaElement"></param>
+	public async Task LoadSubtitles(IMediaElement mediaElement)
+	{
+		this.mediaElement = mediaElement;
+		string? vttContent;
+		try
+		{
+			vttContent = await httpClient.GetStringAsync(mediaElement.SubtitleUrl);
+		}
+		catch (Exception ex)
+		{
+			System.Diagnostics.Trace.TraceError(ex.Message);
+			return;
+		}
+		cues = mediaElement.SubtitleUrl switch
+		{
+			var url when url.EndsWith("srt") => SrtParser.ParseSrtContent(vttContent),
+			var url when url.EndsWith("vtt") => VttParser.ParseVttContent(vttContent),
+			_ => throw new NotSupportedException("Unsupported subtitle format"),
+		};
+	}
+
+	/// <summary>
+	/// Starts the subtitle display.
+	/// </summary>
+	public void StartSubtitleDisplay()
+	{
+		textBlock = new(Platform.AppContext)
+		{
+			Text = string.Empty,
+			HorizontalScrollBarEnabled = false,
+			VerticalScrollBarEnabled = false,
+			TextSize = 16,
+			TextAlignment = Android.Views.TextAlignment.Center,
+			Visibility = Android.Views.ViewStates.Gone,
+		};
+
+		textBlock.SetBackgroundColor(Android.Graphics.Color.Argb(150, 0, 0, 0));
+		textBlock.SetPadding(10, 10, 10, 10);
+		textBlock.SetTextColor(Android.Graphics.Color.White);
+		if (styledPlayerView.Parent is not ViewGroup parent)
+		{
+			return;
+		}
+		relativeLayout = new(Platform.AppContext)
+		{
+			LayoutParameters = new CoordinatorLayout.LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent)
+			{
+				Gravity = (int)GravityFlags.Bottom
+			}
+		};
+		relativeLayout.AddView(textBlock);
+		dispatcher.Dispatch(() => parent.AddView(relativeLayout));
+		timer = new System.Timers.Timer(1000);
+		timer.Elapsed += Timer_Elapsed;
+		timer.Start();
+	}
+
+	void Timer_Elapsed(object? sender, System.Timers.ElapsedEventArgs e)
+	{
+		if (mediaElement?.Position is null || textBlock is null || cues.Count == 0)
+		{
+			return;
+		}
+
+		var cue = cues.Find(c => c.StartTime <= mediaElement.Position && c.EndTime >= mediaElement.Position);
+		dispatcher.Dispatch(() =>
+		{
+			if (cue is not null)
+			{
+				textBlock.Text = cue.Text;
+				textBlock.Visibility = Android.Views.ViewStates.Visible;
+			}
+			else
+			{
+				textBlock.Text = string.Empty;
+				textBlock.Visibility = Android.Views.ViewStates.Gone;
+			}
+		});
+	}
+
+	/// <summary>
+	/// Stops the subtitle timer.
+	/// </summary>
+	public void StopSubtitleDisplay()
+	{
+		if (timer is null)
+		{
+			return;
+		}
+		if(styledPlayerView.Parent is ViewGroup parent)
+		{
+			dispatcher.Dispatch(() =>
+			{
+				parent.RemoveView(relativeLayout);
+				relativeLayout?.RemoveView(textBlock);
+			});
+		}
+		timer.Stop();
+		timer.Elapsed -= Timer_Elapsed;
+	}
+
+	protected override void Dispose(bool disposing)
+	{
+		base.Dispose(disposing);
+		if (!disposedValue)
+		{
+			if (disposing)
+			{
+				timer?.Stop();
+				if(timer is not null)
+				{
+					timer.Elapsed -= Timer_Elapsed;
+				}
+				httpClient?.Dispose();
+				timer?.Dispose();
+			}
+			timer = null;
+			disposedValue = true;
+		}
+	}
+}

--- a/src/CommunityToolkit.Maui.MediaElement/Extensions/SubtitleExtensions.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Extensions/SubtitleExtensions.macios.cs
@@ -1,6 +1,4 @@
 ﻿using CommunityToolkit.Maui.Core;
-using CommunityToolkit.Maui.Core.Views;
-using CommunityToolkit.Maui.Primitives;
 using CoreFoundation;
 using CoreGraphics;
 using CoreMedia;
@@ -20,6 +18,7 @@ public partial class SubtitleExtensions : UIViewController
 	readonly UILabel subtitleLabel;
 	List<SubtitleCue> cues;
 	NSObject? playerObserver;
+	IMediaElement? mediaElement;
 
 	/// <summary>
 	/// The SubtitleExtensions class provides a way to display subtitles on a video player.
@@ -52,6 +51,7 @@ public partial class SubtitleExtensions : UIViewController
 	/// <param name="mediaElement"></param>
 	public async Task LoadSubtitles(IMediaElement mediaElement)
 	{
+		this.mediaElement = mediaElement;
 		string? vttContent;
 		try
 		{
@@ -104,11 +104,13 @@ public partial class SubtitleExtensions : UIViewController
 	{
 		ArgumentNullException.ThrowIfNull(subtitleLabel);
 		ArgumentNullException.ThrowIfNull(playerViewController.View);
+		ArgumentNullException.ThrowIfNull(mediaElement);
 		foreach (var cue in cues)
 		{
 			if (currentPlaybackTime >= cue.StartTime && currentPlaybackTime <= cue.EndTime)
 			{
 				subtitleLabel.Text = cue.Text;
+				subtitleLabel.Font = !string.IsNullOrEmpty(mediaElement.SubtitleFont) ? UIFont.FromName(mediaElement.SubtitleFont, (int)mediaElement.SubtitleFontSize) : UIFont.SystemFontOfSize((int)mediaElement.SubtitleFontSize);
 				subtitleLabel.BackgroundColor = UIColor.FromRGBA(0, 0, 0, 128);
 				break;
 			}

--- a/src/CommunityToolkit.Maui.MediaElement/Extensions/SubtitleExtensions.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Extensions/SubtitleExtensions.macios.cs
@@ -1,0 +1,144 @@
+﻿using CommunityToolkit.Maui.Core;
+using CoreFoundation;
+using CoreGraphics;
+using CoreMedia;
+using Foundation;
+using UIKit;
+
+namespace CommunityToolkit.Maui.Extensions;
+
+/// <summary>
+/// A class that provides subtitle support for a video player.
+/// </summary>
+public partial class SubtitleExtensions : UIViewController
+{
+	readonly HttpClient httpClient;
+	readonly UIViewController playerViewController;
+	readonly PlatformMediaElement? player;
+	readonly UILabel subtitleLabel;
+	List<SubtitleCue> cues;
+	NSObject? playerObserver;
+
+	/// <summary>
+	/// The SubtitleExtensions class provides a way to display subtitles on a video player.
+	/// </summary>
+	/// <param name="player"></param>
+	/// <param name="playerViewController"></param>
+	public SubtitleExtensions(PlatformMediaElement? player, UIViewController? playerViewController)
+	{
+		ArgumentNullException.ThrowIfNull(player);
+		ArgumentNullException.ThrowIfNull(playerViewController?.View?.Bounds);
+		this.playerViewController = playerViewController;
+		this.player = player;
+		cues = [];
+		httpClient = new HttpClient();
+		subtitleLabel = new UILabel
+		{
+			Frame = CalculateSubtitleFrame(),
+			TextColor = UIColor.White,
+			TextAlignment = UITextAlignment.Center,
+			Font = UIFont.SystemFontOfSize(16),
+			Text = "",
+			Lines = 0,
+			AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleTopMargin | UIViewAutoresizing.FlexibleHeight | UIViewAutoresizing.FlexibleBottomMargin
+		};
+		playerViewController.View.AddSubview(subtitleLabel);
+	}
+
+	/// <summary>
+	/// Loads the subtitles from the provided URL.
+	/// </summary>
+	/// <param name="mediaElement"></param>
+	public async Task LoadSubtitles(IMediaElement mediaElement)
+	{
+		string vttContent = string.Empty;
+		try
+		{
+			vttContent = await httpClient.GetStringAsync(mediaElement.SubtitleUrl).ConfigureAwait(true) ?? string.Empty;
+		}
+		catch (Exception ex)
+		{
+			System.Diagnostics.Trace.TraceError(ex.Message);
+		}
+
+		if (string.IsNullOrEmpty(vttContent))
+		{
+			System.Diagnostics.Trace.TraceError("VTT Subtitle Content is Empty");
+			return;
+		}
+		if (mediaElement.SubtitleUrl.EndsWith("srt"))
+		{
+			cues = SrtParser.ParseSrtContent(vttContent);
+		}
+		else if (mediaElement.SubtitleUrl.EndsWith("vtt"))
+		{
+			cues = VttParser.ParseVttContent(vttContent);
+		}
+	}
+
+	/// <summary>
+	/// Starts the subtitle display.
+	/// </summary>
+	public void StartSubtitleDisplay()
+	{
+		ArgumentNullException.ThrowIfNull(player);
+		if(cues?.Count == 0)
+		{
+			return;
+		}
+		if (playerObserver is not null)
+		{
+			StopSubtitleDisplay();
+		}
+		playerObserver = player.AddPeriodicTimeObserver(CMTime.FromSeconds(1, 1), null, (time) =>
+		{
+			TimeSpan currentPlaybackTime = TimeSpan.FromSeconds(time.Seconds);
+			ArgumentNullException.ThrowIfNull(subtitleLabel);
+			DispatchQueue.MainQueue.DispatchAsync(() => UpdateSubtitle(currentPlaybackTime));
+		});
+	}
+
+	/// <summary>
+	/// Stops the subtitle display.
+	/// </summary>
+	public void StopSubtitleDisplay()
+	{
+		ArgumentNullException.ThrowIfNull(player);
+		if (playerObserver is not null)
+		{
+			player.RemoveTimeObserver(playerObserver);
+			playerObserver.Dispose();
+			playerObserver = null;
+			subtitleLabel.RemoveFromSuperview();
+		}
+	}
+	void UpdateSubtitle(TimeSpan currentPlaybackTime)
+	{
+		ArgumentNullException.ThrowIfNull(subtitleLabel);
+		ArgumentNullException.ThrowIfNull(playerViewController.View);
+		subtitleLabel.RemoveFromSuperview();
+		foreach (var cue in cues)
+		{
+			if (currentPlaybackTime >= cue.StartTime && currentPlaybackTime <= cue.EndTime)
+			{
+				subtitleLabel.Text = cue.Text;
+				subtitleLabel.BackgroundColor = UIColor.FromRGBA(0, 0, 0, 128);
+				break;
+			}
+			else
+			{
+				subtitleLabel.Text = "";
+				subtitleLabel.BackgroundColor = UIColor.FromRGBA(0, 0, 0, 0);
+			}
+		}
+		subtitleLabel.Frame = CalculateSubtitleFrame();
+		playerViewController.View.AddSubview(subtitleLabel);
+	}
+	CGRect CalculateSubtitleFrame()
+	{
+		ArgumentNullException.ThrowIfNull(playerViewController?.View?.Bounds);
+		return new CGRect(0, playerViewController.View.Bounds.Height - 60, playerViewController.View.Bounds.Width, 50);
+	}
+	
+}
+

--- a/src/CommunityToolkit.Maui.MediaElement/Extensions/SubtitleExtensions.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Extensions/SubtitleExtensions.macios.cs
@@ -82,7 +82,6 @@ public partial class SubtitleExtensions : UIViewController
 			TimeSpan currentPlaybackTime = TimeSpan.FromSeconds(time.Seconds);
 			ArgumentNullException.ThrowIfNull(subtitleLabel);
 			subtitleLabel.Frame = CalculateSubtitleFrame(playerViewController);
-			playerViewController.View?.AddSubview(subtitleLabel);
 			DispatchQueue.MainQueue.DispatchAsync(() => UpdateSubtitle(currentPlaybackTime));
 		});
 	}

--- a/src/CommunityToolkit.Maui.MediaElement/Extensions/SubtitleExtensions.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Extensions/SubtitleExtensions.windows.cs
@@ -1,0 +1,202 @@
+﻿using CommunityToolkit.Maui.Core;
+using CommunityToolkit.Maui.Core.Views;
+using CommunityToolkit.Maui.Primitives;
+
+namespace CommunityToolkit.Maui.Extensions;
+
+/// <summary>
+/// A class that provides subtitle support for a video player.
+/// </summary>
+public partial class SubtitleExtensions : Grid, IDisposable
+{
+	readonly HttpClient httpClient;
+	Microsoft.UI.Xaml.Controls.Grid? item;
+	System.Timers.Timer? timer;
+	List<SubtitleCue> cues;
+	bool disposedValue;
+	IMediaElement? mediaElement;
+	readonly Label textBlock;
+	Microsoft.UI.Xaml.Controls.TextBlock? xamlTextBlock;
+
+	/// <summary>
+	/// The SubtitleExtensions class provides a way to display subtitles on a video player.
+	/// </summary>
+	public SubtitleExtensions()
+	{
+		httpClient = new HttpClient();
+		cues = [];
+		MauiMediaElement.WindowsChanged += MauiMediaElement_WindowsChanged;
+		textBlock = new()
+		{
+			Text = string.Empty,
+			IsVisible = false,
+			HorizontalOptions = LayoutOptions.Center,
+			VerticalOptions = LayoutOptions.End,
+			TextColor = Microsoft.Maui.Graphics.Colors.White,
+			FontSize = 16,
+			LineBreakMode = LineBreakMode.WordWrap,
+		};
+	}
+	void MauiMediaElement_WindowsChanged(object? sender, WindowsEventArgs e)
+	{
+		System.Diagnostics.Trace.TraceInformation("Windows Changed");
+		if (mediaElement?.Parent is not Grid mediaElementParent || e.data is not Microsoft.UI.Xaml.Controls.Grid gridItem || string.IsNullOrEmpty(mediaElement.SubtitleUrl))
+		{
+			return;
+		}
+		this.item = gridItem;
+		if (mediaElementParent.Children.Contains(textBlock))
+		{
+			Dispatcher.Dispatch(() => mediaElementParent.Children.Remove(textBlock));
+		}
+		if (item.Children.Contains(xamlTextBlock))
+		{
+			Dispatcher.Dispatch(() => item.Children.Remove(xamlTextBlock));
+			Dispatcher.Dispatch(() => mediaElementParent.Children.Add(textBlock));
+			xamlTextBlock = null;
+			return;
+		}
+		Dispatcher.Dispatch(() => item.Children.Add(xamlTextBlock));
+	}
+
+	/// <summary>
+	/// Loads the subtitles from the provided URL.
+	/// </summary>
+	/// <param name="mediaElement"></param>
+	public async Task LoadSubtitles(IMediaElement mediaElement)
+	{
+		this.mediaElement = mediaElement;
+		string? vttContent;
+		try
+		{
+			vttContent = await httpClient.GetStringAsync(mediaElement.SubtitleUrl);
+		}
+		catch (Exception ex)
+		{
+			System.Diagnostics.Trace.TraceError(ex.Message);
+			return;
+		}
+		xamlTextBlock ??= new()
+		{
+			Text = string.Empty,
+			Visibility = Microsoft.UI.Xaml.Visibility.Collapsed,
+			HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Center,
+			VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Bottom,
+			Foreground = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.White),
+			FontSize = 16,
+			TextWrapping = Microsoft.UI.Xaml.TextWrapping.Wrap,
+		};
+		cues = mediaElement.SubtitleUrl switch
+		{
+			var url when url.EndsWith("srt") => SrtParser.ParseSrtContent(vttContent),
+			var url when url.EndsWith("vtt") => VttParser.ParseVttContent(vttContent),
+			_ => throw new NotSupportedException("Unsupported subtitle format"),
+		};
+	}
+
+	/// <summary>
+	/// Starts the subtitle display.
+	/// </summary>
+	public void StartSubtitleDisplay()
+	{
+		if(mediaElement?.Parent is not Grid parent)
+		{
+			return;
+		}
+		
+		Dispatcher.Dispatch(() => parent.Children.Add(textBlock));
+		timer = new System.Timers.Timer(1000);
+		timer.Elapsed += Timer_Elapsed;
+		timer.Start();
+	}
+
+	void Timer_Elapsed(object? sender, System.Timers.ElapsedEventArgs e)
+	{
+		if (mediaElement?.Position is null || cues.Count == 0 || string.IsNullOrEmpty(mediaElement.SubtitleUrl))
+		{
+			return;
+		}
+		var cue = cues.Find(c => c.StartTime <= mediaElement.Position && c.EndTime >= mediaElement.Position);
+		Dispatcher.Dispatch(() =>
+		{
+			if (cue is not null)
+			{
+				if (xamlTextBlock is not null)
+				{
+					xamlTextBlock.Text = cue.Text;
+					xamlTextBlock.Visibility = Microsoft.UI.Xaml.Visibility.Visible;
+				}
+				textBlock.Text = cue.Text;
+				textBlock.IsVisible = true;
+			}
+			else
+			{
+				if (xamlTextBlock is not null)
+				{
+					xamlTextBlock.Text = string.Empty;
+					xamlTextBlock.Visibility = Microsoft.UI.Xaml.Visibility.Collapsed;
+				}
+				textBlock.Text = string.Empty;
+				textBlock.IsVisible = false;
+			}
+		});
+	}
+
+	/// <summary>
+	/// Stops the subtitle timer.
+	/// </summary>
+	public void StopSubtitleDisplay()
+	{
+		if (timer is null)
+		{
+			return;
+		}
+		timer.Stop();
+		timer.Elapsed -= Timer_Elapsed;
+		if (mediaElement?.Parent is not Grid parent)
+		{
+			return;
+		}
+		Dispatcher.Dispatch(() => parent.Children.Remove(textBlock));
+	}
+
+	/// <summary>
+	/// The Dispose method. For the <see cref="SubtitleExtensions"/> class."/>
+	/// </summary>
+	/// <param name="disposing"></param>
+	protected virtual void Dispose(bool disposing)
+	{
+		if (!disposedValue)
+		{
+			if (timer is not null)
+			{
+				timer.Stop();
+				timer.Elapsed -= Timer_Elapsed;
+			}
+			if (disposing)
+			{
+				httpClient?.Dispose();
+				timer?.Dispose();
+			}
+			timer = null;
+			disposedValue = true;
+		}
+	}
+
+	/// <summary>
+	/// A finalizer for the <see cref="SubtitleExtensions"/>.
+	/// </summary>
+	~SubtitleExtensions()
+	{
+	     Dispose(disposing: false);
+	}
+
+	/// <summary>
+	/// 
+	/// </summary>
+	public void Dispose()
+	{
+		Dispose(disposing: true);
+		GC.SuppressFinalize(this);
+	}
+}

--- a/src/CommunityToolkit.Maui.MediaElement/Extensions/SubtitleExtensions.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Extensions/SubtitleExtensions.windows.cs
@@ -16,7 +16,7 @@ public partial class SubtitleExtensions : Grid, IDisposable
 	List<SubtitleCue> cues;
 	bool disposedValue;
 	IMediaElement? mediaElement;
-	Microsoft.UI.Xaml.Controls.TextBlock? xamlTextBlock;
+	readonly Microsoft.UI.Xaml.Controls.TextBlock? xamlTextBlock;
 	MauiMediaElement? mauiMediaElement;
 
 	/// <summary>
@@ -27,6 +27,17 @@ public partial class SubtitleExtensions : Grid, IDisposable
 		httpClient = new();
 		cues = [];
 		MauiMediaElement.WindowsChanged += MauiMediaElement_WindowsChanged;
+		xamlTextBlock = new()
+		{
+			Text = string.Empty,
+			Margin = new Microsoft.UI.Xaml.Thickness(0, 0, 0, 10),
+			Visibility = Microsoft.UI.Xaml.Visibility.Collapsed,
+			HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Center,
+			VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Bottom,
+			Foreground = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.White),
+			FontSize = 16,
+			TextWrapping = Microsoft.UI.Xaml.TextWrapping.Wrap,
+		};
 	}
 	void MauiMediaElement_WindowsChanged(object? sender, WindowsEventArgs e)
 	{
@@ -67,17 +78,7 @@ public partial class SubtitleExtensions : Grid, IDisposable
 			System.Diagnostics.Trace.TraceError(ex.Message);
 			return;
 		}
-		xamlTextBlock ??= new()
-		{
-			Text = string.Empty,
-			Margin = new Microsoft.UI.Xaml.Thickness(0, 0, 0, 10),
-			Visibility = Microsoft.UI.Xaml.Visibility.Collapsed,
-			HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Center,
-			VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Bottom,
-			Foreground = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.White),
-			FontSize = 16,
-			TextWrapping = Microsoft.UI.Xaml.TextWrapping.Wrap,
-		};
+		
 		cues = mediaElement.SubtitleUrl switch
 		{
 			var url when url.EndsWith("srt") => SrtParser.ParseSrtContent(vttContent),

--- a/src/CommunityToolkit.Maui.MediaElement/Extensions/SubtitleExtensions.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Extensions/SubtitleExtensions.windows.cs
@@ -109,6 +109,7 @@ public partial class SubtitleExtensions : Grid, IDisposable
 		{
 			if (cue is not null)
 			{
+				xamlTextBlock.FontSize = isFullScreen ? 24 : 16;
 				xamlTextBlock.Text = cue.Text;
 				xamlTextBlock.Visibility = Microsoft.UI.Xaml.Visibility.Visible;
 			}

--- a/src/CommunityToolkit.Maui.MediaElement/Extensions/SubtitleExtensions.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Extensions/SubtitleExtensions.windows.cs
@@ -24,36 +24,27 @@ public partial class SubtitleExtensions : Grid, IDisposable
 	/// </summary>
 	public SubtitleExtensions()
 	{
-		httpClient = new HttpClient();
+		httpClient = new();
 		cues = [];
 		MauiMediaElement.WindowsChanged += MauiMediaElement_WindowsChanged;
 	}
 	void MauiMediaElement_WindowsChanged(object? sender, WindowsEventArgs e)
 	{
-		System.Diagnostics.Trace.TraceInformation("Windows Changed");
 		if (mauiMediaElement is null || e.data is not Microsoft.UI.Xaml.Controls.Grid gridItem || string.IsNullOrEmpty(mediaElement?.SubtitleUrl))
 		{
 			return;
 		}
 		this.item = gridItem;
-
-		if (!isFullScreen)
+		switch(isFullScreen)
 		{
-			if (mauiMediaElement.Children.Contains(xamlTextBlock))
-			{
-				Dispatcher.Dispatch(() => mauiMediaElement.Children.Remove(xamlTextBlock));
-			}
-			Dispatcher.Dispatch(() => item.Children.Add(xamlTextBlock));
-			isFullScreen = true;
-		}
-		else
-		{
-			if (item.Children.Contains(xamlTextBlock))
-			{
-				Dispatcher.Dispatch(() => item.Children.Remove(xamlTextBlock));
-			}
-			Dispatcher.Dispatch(() => mauiMediaElement.Children.Add(xamlTextBlock));
-			isFullScreen = false;
+			case true:
+				Dispatcher.Dispatch(() => { item.Children.Remove(xamlTextBlock); mauiMediaElement.Children.Add(xamlTextBlock); });
+				isFullScreen = false;
+				break;
+			case false:
+				Dispatcher.Dispatch(() => { mauiMediaElement.Children.Remove(xamlTextBlock); item.Children.Add(xamlTextBlock); });
+				isFullScreen = true;
+				break;
 		}
 	}
 
@@ -108,7 +99,7 @@ public partial class SubtitleExtensions : Grid, IDisposable
 
 	void Timer_Elapsed(object? sender, System.Timers.ElapsedEventArgs e)
 	{
-		if (mediaElement?.Position is null || cues.Count == 0 || string.IsNullOrEmpty(mediaElement.SubtitleUrl))
+		if (mediaElement?.Position is null || cues.Count == 0 || string.IsNullOrEmpty(mediaElement.SubtitleUrl) || xamlTextBlock is null)
 		{
 			return;
 		}
@@ -117,20 +108,14 @@ public partial class SubtitleExtensions : Grid, IDisposable
 		{
 			if (cue is not null)
 			{
-				if (xamlTextBlock is not null)
-				{
-					xamlTextBlock.Text = cue.Text;
-					System.Diagnostics.Trace.TraceInformation("Cue Text: {0}", cue.Text);
-					xamlTextBlock.Visibility = Microsoft.UI.Xaml.Visibility.Visible;
-				}
+				xamlTextBlock.Text = cue.Text;
+				System.Diagnostics.Trace.TraceInformation("Cue Text: {0}", cue.Text);
+				xamlTextBlock.Visibility = Microsoft.UI.Xaml.Visibility.Visible;
 			}
 			else
 			{
-				if (xamlTextBlock is not null)
-				{
-					xamlTextBlock.Text = string.Empty;
-					xamlTextBlock.Visibility = Microsoft.UI.Xaml.Visibility.Collapsed;
-				}
+				xamlTextBlock.Text = string.Empty;
+				xamlTextBlock.Visibility = Microsoft.UI.Xaml.Visibility.Collapsed;
 			}
 		});
 	}
@@ -151,7 +136,6 @@ public partial class SubtitleExtensions : Grid, IDisposable
 			return;
 		}
 		Dispatcher.Dispatch(() => mauiMediaElement.Children.Remove(xamlTextBlock));
-		System.Diagnostics.Trace.TraceInformation("Removed text block from player parent");
 	}
 
 	/// <summary>

--- a/src/CommunityToolkit.Maui.MediaElement/Extensions/SubtitleExtensions.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Extensions/SubtitleExtensions.windows.cs
@@ -109,7 +109,6 @@ public partial class SubtitleExtensions : Grid, IDisposable
 			if (cue is not null)
 			{
 				xamlTextBlock.Text = cue.Text;
-				System.Diagnostics.Trace.TraceInformation("Cue Text: {0}", cue.Text);
 				xamlTextBlock.Visibility = Microsoft.UI.Xaml.Visibility.Visible;
 			}
 			else

--- a/src/CommunityToolkit.Maui.MediaElement/Extensions/SubtitleExtensions.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Extensions/SubtitleExtensions.windows.cs
@@ -35,7 +35,6 @@ public partial class SubtitleExtensions : Grid, IDisposable
 			HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Center,
 			VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Bottom,
 			Foreground = new Microsoft.UI.Xaml.Media.SolidColorBrush(Microsoft.UI.Colors.White),
-			FontSize = 16,
 			TextWrapping = Microsoft.UI.Xaml.TextWrapping.Wrap,
 		};
 	}
@@ -109,7 +108,8 @@ public partial class SubtitleExtensions : Grid, IDisposable
 		{
 			if (cue is not null)
 			{
-				xamlTextBlock.FontSize = isFullScreen ? 24 : 16;
+				xamlTextBlock.FontFamily = !string.IsNullOrEmpty(mediaElement.SubtitleFont) ? new Microsoft.UI.Xaml.Media.FontFamily(mediaElement.SubtitleFont) : default;
+				xamlTextBlock.FontSize = isFullScreen ? (mediaElement.SubtitleFontSize + 8.0) : mediaElement.SubtitleFontSize;
 				xamlTextBlock.Text = cue.Text;
 				xamlTextBlock.Visibility = Microsoft.UI.Xaml.Visibility.Visible;
 			}

--- a/src/CommunityToolkit.Maui.MediaElement/Extensions/VttParser.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Extensions/VttParser.cs
@@ -1,0 +1,63 @@
+﻿using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace CommunityToolkit.Maui.Extensions;
+
+/// <summary>
+/// A class that provides subtitle parser for VTT files.
+/// </summary>
+public static partial class VttParser
+{
+	static readonly string[] separator = ["\r\n", "\n"];
+
+	/// <summary>
+	/// The ParseVttContent method parses the VTT content and returns a list of SubtitleCue objects.
+	/// </summary>
+	/// <param name="vttContent"></param>
+	/// <returns></returns>
+	public static List<SubtitleCue> ParseVttContent(string vttContent)
+	{
+		List<SubtitleCue> cues = [];
+		string[] lines = vttContent.Split(separator, StringSplitOptions.None);
+
+		Regex timecodePattern = MyRegex();
+
+		SubtitleCue? currentCue = null;
+		foreach (var line in lines)
+		{
+			var match = timecodePattern.Match(line);
+			if (match.Success)
+			{
+				if (currentCue is not null)
+				{
+					cues.Add(currentCue);
+				}
+
+				currentCue = new SubtitleCue
+				{
+					StartTime = TimeSpan.Parse(match.Groups[1].Value, new CultureInfo("en-US")),
+					EndTime = TimeSpan.Parse(match.Groups[2].Value, new CultureInfo("en-US")),
+					Text = ""
+				};
+			}
+			else if (currentCue is not null && !string.IsNullOrWhiteSpace(line))
+			{
+				if (!string.IsNullOrEmpty(currentCue.Text))
+				{
+					currentCue.Text += " ";
+				}
+				currentCue.Text += line.Trim('-').Trim(); // Trim hyphens and spaces
+			}
+		}
+
+		if (currentCue is not null)
+		{
+			cues.Add(currentCue);
+		}
+
+		return cues;
+	}
+
+	[GeneratedRegex(@"(\d{2}:\d{2}:\d{2}\.\d{3}) --> (\d{2}:\d{2}:\d{2}\.\d{3})")]
+	private static partial Regex MyRegex();
+}

--- a/src/CommunityToolkit.Maui.MediaElement/Interfaces/IMediaElement.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Interfaces/IMediaElement.cs
@@ -69,6 +69,15 @@ public interface IMediaElement : IView, IAsynchronousMediaElementHandler
 	bool ShouldShowPlaybackControls { get; set; }
 
 	/// <summary>
+	/// Gets or sets the font to use for the subtitle text.
+	/// </summary>
+	string SubtitleFont { get; set; }
+	/// <summary>
+	/// Gets or sets the URL of the subtitle file to display.
+	/// </summary>
+	string SubtitleUrl { get; set; }
+
+	/// <summary>
 	/// Gets or sets the source of the media to play.
 	/// </summary>
 	MediaSource? Source { get; set; }
@@ -81,15 +90,14 @@ public interface IMediaElement : IView, IAsynchronousMediaElementHandler
 	double Speed { get; set; }
 
 	/// <summary>
+	/// Gets or sets the font size of the subtitle text.
+	/// </summary>
+	double SubtitleFontSize { get; set; }
+	/// <summary>
 	/// Gets or sets the volume of the audio for the media.
 	/// </summary>
 	/// <remarks>A value of 1 means full volume, 0 is silence.</remarks>
 	double Volume { get; set; }
-
-	/// <summary>
-	/// Gets or sets the URL of the subtitle file to display.
-	/// </summary>
-	string SubtitleUrl { get; set; }
 
 	/// <summary>
 	/// Occurs when <see cref="CurrentState"/> changed.

--- a/src/CommunityToolkit.Maui.MediaElement/Interfaces/IMediaElement.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Interfaces/IMediaElement.cs
@@ -87,6 +87,11 @@ public interface IMediaElement : IView, IAsynchronousMediaElementHandler
 	double Volume { get; set; }
 
 	/// <summary>
+	/// Gets or sets the URL of the subtitle file to display.
+	/// </summary>
+	string SubtitleUrl { get; set; }
+
+	/// <summary>
 	/// Occurs when <see cref="CurrentState"/> changed.
 	/// </summary>
 	event EventHandler<MediaStateChangedEventArgs> StateChanged;

--- a/src/CommunityToolkit.Maui.MediaElement/MediaElement.shared.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/MediaElement.shared.cs
@@ -75,6 +75,10 @@ public class MediaElement : View, IMediaElement, IDisposable
 			propertyChanging: OnSourcePropertyChanging, propertyChanged: OnSourcePropertyChanged);
 
 	/// <summary>
+	/// Backing store for the <see cref="SubtitleUrl"/> property.
+	/// </summary>
+	public static readonly BindableProperty SubtitleProperty = BindableProperty.Create(nameof(SubtitleUrl), typeof(string), typeof(MediaElement), string.Empty);
+	/// <summary>
 	/// Backing store for the <see cref="Speed"/> property.
 	/// </summary>
 	public static readonly BindableProperty SpeedProperty =
@@ -264,6 +268,15 @@ public class MediaElement : View, IMediaElement, IDisposable
 	{
 		get => (MediaSource)GetValue(SourceProperty);
 		set => SetValue(SourceProperty, value);
+	}
+
+	/// <summary>
+	/// Gets or sets the URL of the subtitle file to display.
+	/// </summary>
+	public string SubtitleUrl
+	{
+		get => (string)GetValue(SubtitleProperty);
+		set => SetValue(SubtitleProperty, value);
 	}
 
 	/// <summary>

--- a/src/CommunityToolkit.Maui.MediaElement/MediaElement.shared.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/MediaElement.shared.cs
@@ -88,6 +88,7 @@ public class MediaElement : View, IMediaElement, IDisposable
 	/// Backing store for the <see cref="SubtitleUrl"/> property.
 	/// </summary>
 	public static readonly BindableProperty SubtitleProperty = BindableProperty.Create(nameof(SubtitleUrl), typeof(string), typeof(MediaElement), string.Empty);
+
 	/// <summary>
 	/// Backing store for the <see cref="Speed"/> property.
 	/// </summary>

--- a/src/CommunityToolkit.Maui.MediaElement/MediaElement.shared.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/MediaElement.shared.cs
@@ -75,6 +75,16 @@ public class MediaElement : View, IMediaElement, IDisposable
 			propertyChanging: OnSourcePropertyChanging, propertyChanged: OnSourcePropertyChanged);
 
 	/// <summary>
+	/// Backing store for the <see cref="SubtitleFont"/> property.
+	/// </summary>
+	public static readonly BindableProperty SubtitleFontProperty = BindableProperty.Create(nameof(SubtitleFont), typeof(string), typeof(MediaElement), string.Empty);
+	
+	/// <summary>
+	/// Backing store for the <see cref="SubtitleFontSize"/> property.
+	/// </summary>
+	public static readonly BindableProperty SubtitleFontSizeProperty = BindableProperty.Create(nameof(SubtitleFontSize), typeof(double), typeof(MediaElement), 16.0);
+
+	/// <summary>
 	/// Backing store for the <see cref="SubtitleUrl"/> property.
 	/// </summary>
 	public static readonly BindableProperty SubtitleProperty = BindableProperty.Create(nameof(SubtitleUrl), typeof(string), typeof(MediaElement), string.Empty);
@@ -277,6 +287,24 @@ public class MediaElement : View, IMediaElement, IDisposable
 	{
 		get => (string)GetValue(SubtitleProperty);
 		set => SetValue(SubtitleProperty, value);
+	}
+
+	/// <summary>
+	/// Gets or sets the font to use for the subtitle text.
+	/// </summary>
+	public string SubtitleFont
+	{
+		get => (string)GetValue(SubtitleFontProperty);
+		set => SetValue(SubtitleFontProperty, value);
+	}
+
+	/// <summary>
+	/// Gets or sets the font size of the subtitle text.
+	/// </summary>
+	public double SubtitleFontSize
+	{
+		get => (double)GetValue(SubtitleFontSizeProperty);
+		set => SetValue(SubtitleFontSizeProperty, value);
 	}
 
 	/// <summary>

--- a/src/CommunityToolkit.Maui.MediaElement/Primitives/WindowsEventArgs.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Primitives/WindowsEventArgs.cs
@@ -1,0 +1,20 @@
+﻿
+namespace CommunityToolkit.Maui.Primitives;
+/// <summary>
+/// 
+/// </summary>
+public class WindowsEventArgs : EventArgs
+{
+	/// <summary>
+	/// 
+	/// </summary>
+	public object? data { get; }
+	/// <summary>
+	/// 
+	/// </summary>
+	/// <param name="data"></param>
+	public WindowsEventArgs(object? data)
+	{
+		this.data = data;
+	}
+}

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.android.cs
@@ -8,6 +8,7 @@ using Android.Widget;
 using AndroidX.CoordinatorLayout.Widget;
 using AndroidX.Core.View;
 using Com.Google.Android.Exoplayer2.UI;
+using CommunityToolkit.Maui.Primitives;
 using CommunityToolkit.Maui.Views;
 
 namespace CommunityToolkit.Maui.Core.Views;
@@ -17,6 +18,10 @@ namespace CommunityToolkit.Maui.Core.Views;
 /// </summary>
 public class MauiMediaElement : CoordinatorLayout
 {
+	/// <summary>
+	/// Handles the event when the windows change.
+	/// </summary>
+	public static event EventHandler<WindowsEventArgs>? WindowsChanged;
 	readonly StyledPlayerView playerView;
 	int defaultSystemUiVisibility;
 	bool isSystemBarVisible;
@@ -48,6 +53,13 @@ public class MauiMediaElement : CoordinatorLayout
 		AddView(playerView);
 	}
 
+	/// <summary>
+	/// A method that raises the WindowsChanged event.
+	/// </summary>
+	protected virtual void OnWindowsChanged(WindowsEventArgs e)
+	{
+		WindowsChanged?.Invoke(null, e);
+	}
 	public override void OnDetachedFromWindow()
 	{
 		if (isFullScreen)
@@ -146,6 +158,7 @@ public class MauiMediaElement : CoordinatorLayout
 			item.Height = displayMetrics.HeightPixels;
 			layout?.AddView(playerView, item);
 			SetSystemBarsVisibility();
+			OnWindowsChanged(new Maui.Primitives.WindowsEventArgs(layout));
 		}
 		else
 		{
@@ -158,6 +171,7 @@ public class MauiMediaElement : CoordinatorLayout
 			layout?.RemoveView(playerView);
 			AddView(playerView, item);
 			SetSystemBarsVisibility();
+			OnWindowsChanged(new Maui.Primitives.WindowsEventArgs(layout));
 		}
 	}
 

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.windows.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.Maui.Extensions;
+using CommunityToolkit.Maui.Primitives;
 using CommunityToolkit.Maui.Views;
 using Microsoft.UI;
 using Microsoft.UI.Windowing;
@@ -22,6 +23,10 @@ namespace CommunityToolkit.Maui.Core.Views;
 /// </summary>
 public class MauiMediaElement : Grid, IDisposable
 {
+	/// <summary>
+	/// Handles the event when the windows change.
+	/// </summary>
+	public static event EventHandler<WindowsEventArgs>? WindowsChanged;
 	static readonly AppWindow appWindow = GetAppWindowForCurrentWindow();
 	static readonly ImageSource source = new BitmapImage(new Uri("ms-appx:///fullscreen.png"));
 
@@ -81,6 +86,14 @@ public class MauiMediaElement : Grid, IDisposable
 	/// Finalizer
 	/// </summary>
 	~MauiMediaElement() => Dispose(false);
+
+	/// <summary>
+	/// A method that raises the WindowsChanged event.
+	/// </summary>
+	protected virtual void OnWindowsChanged(WindowsEventArgs e)
+	{
+		WindowsChanged?.Invoke(null, e);
+	}
 
 	/// <summary>
 	/// Releases the managed and unmanaged resources used by the <see cref="MauiMediaElement"/>.
@@ -160,6 +173,7 @@ public class MauiMediaElement : Grid, IDisposable
 			appWindow.SetPresenter(AppWindowPresenterKind.Default);
 			Shell.SetNavBarIsVisible(CurrentPage, doesNavigationBarExistBeforeFullScreen);
 
+			OnWindowsChanged(new Maui.Primitives.WindowsEventArgs(fullScreenGrid));
 			if (popup.IsOpen)
 			{
 				popup.IsOpen = false;
@@ -169,7 +183,6 @@ public class MauiMediaElement : Grid, IDisposable
 
 			Children.Add(mediaPlayerElement);
 			Children.Add(buttonContainer);
-
 			var parent = mediaPlayerElement.Parent as FrameworkElement;
 			mediaPlayerElement.Width = parent?.Width ?? mediaPlayerElement.Width;
 			mediaPlayerElement.Height = parent?.Height ?? mediaPlayerElement.Height;
@@ -187,7 +200,7 @@ public class MauiMediaElement : Grid, IDisposable
 			Children.Clear();
 			fullScreenGrid.Children.Add(mediaPlayerElement);
 			fullScreenGrid.Children.Add(buttonContainer);
-
+			
 			popup.XamlRoot = mediaPlayerElement.XamlRoot;
 			popup.HorizontalOffset = 0;
 			popup.VerticalOffset = 0;
@@ -200,6 +213,7 @@ public class MauiMediaElement : Grid, IDisposable
 			{
 				popup.IsOpen = true;
 			}
+			OnWindowsChanged(new Maui.Primitives.WindowsEventArgs(fullScreenGrid));
 		}
 	}
 }

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.android.cs
@@ -17,6 +17,7 @@ using Com.Google.Android.Exoplayer2.UI;
 using Com.Google.Android.Exoplayer2.Video;
 using CommunityToolkit.Maui.ApplicationModel.Permissions;
 using CommunityToolkit.Maui.Core.Primitives;
+using CommunityToolkit.Maui.Extensions;
 using CommunityToolkit.Maui.Media.Services;
 using CommunityToolkit.Maui.Views;
 using Microsoft.Extensions.Logging;

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.android.cs
@@ -202,6 +202,7 @@ public partial class MediaManager : Java.Lang.Object, IPlayer.IListener
 			LayoutParameters = new RelativeLayout.LayoutParams(ViewGroup.LayoutParams.MatchParent, ViewGroup.LayoutParams.MatchParent)
 		};
 
+		subtitleExtensions = new(Platform.AppContext, PlayerView, Dispatcher);
 		checkPermissionsTask = CheckAndRequestForegroundPermission(checkPermissionSourceToken.Token);
 		return (Player, PlayerView);
 	}

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
@@ -13,7 +13,7 @@ namespace CommunityToolkit.Maui.Core.Views;
 public partial class MediaManager : IDisposable
 {
 	SubtitleExtensions? subtitleExtensions;
-	CancellationTokenSource subTitles = new();
+	readonly CancellationTokenSource subTitles = new();
 	Task? startSubtitles;
 
 	// Media would still start playing when Speed was set although ShouldAutoPlay=False

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
@@ -224,6 +224,7 @@ public partial class MediaManager : IDisposable
 		MediaElement.CurrentStateChanged(MediaElementState.Opening);
 		
 		AVAsset? asset = null;
+		subtitleExtensions?.StopSubtitleDisplay();
 		if (Player is null)
 		{
 			return;
@@ -231,7 +232,7 @@ public partial class MediaManager : IDisposable
 
 		metaData ??= new(Player);
 		metaData.ClearNowPlaying();
-
+		
 		if (MediaElement.Source is UriMediaSource uriMediaSource)
 		{
 			var uri = uriMediaSource.Uri;
@@ -277,8 +278,6 @@ public partial class MediaManager : IDisposable
 		CurrentItemErrorObserver?.Dispose();
 
 		Player.ReplaceCurrentItemWithPlayerItem(PlayerItem);
-
-		Player?.ReplaceCurrentItemWithPlayerItem(PlayerItem);
 		subtitleExtensions ??= new(Player, PlayerViewController);
 		CurrentItemErrorObserver = PlayerItem?.AddObserver("error",
 			valueObserverOptions, (NSObservedChange change) =>

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
@@ -2,11 +2,13 @@
 using AVKit;
 using CommunityToolkit.Maui.Core.Primitives;
 using CommunityToolkit.Maui.Extensions;
+using CommunityToolkit.Maui.Primitives;
 using CommunityToolkit.Maui.Views;
 using CoreFoundation;
 using CoreMedia;
 using Foundation;
 using Microsoft.Extensions.Logging;
+using UIKit;
 
 namespace CommunityToolkit.Maui.Core.Views;
 
@@ -95,7 +97,8 @@ public partial class MediaManager : IDisposable
 		Player = new();
 		PlayerViewController = new()
 		{
-			Player = Player
+			Player = Player,
+			Delegate = new MediaManagerDelegate()
 		};
 
 		// Pre-initialize Volume and Muted properties to the player object
@@ -109,7 +112,7 @@ public partial class MediaManager : IDisposable
 		AddStatusObservers();
 		AddPlayedToEndObserver();
 		AddErrorObservers();
-
+		
 		return (Player, PlayerViewController);
 	}
 
@@ -608,5 +611,27 @@ public partial class MediaManager : IDisposable
 		{
 			MediaElement.Speed = Player.Rate;
 		}
+	}
+}
+sealed class MediaManagerDelegate : AVPlayerViewControllerDelegate
+{
+	/// <summary>
+	/// Handles the event when the windows change.
+	/// </summary>
+	public static event EventHandler<WindowsEventArgs>? WindowsChanged;
+	public override void WillBeginFullScreenPresentation(AVPlayerViewController playerViewController, IUIViewControllerTransitionCoordinator coordinator)
+	{
+		OnWindowsChanged(new WindowsEventArgs(true));
+	}
+	public override void WillEndFullScreenPresentation(AVPlayerViewController playerViewController, IUIViewControllerTransitionCoordinator coordinator)
+	{
+		OnWindowsChanged(new WindowsEventArgs(false));
+	}
+	/// <summary>
+	/// A method that raises the WindowsChanged event.
+	/// </summary>
+	void OnWindowsChanged(WindowsEventArgs e)
+	{
+		WindowsChanged?.Invoke(null, e);
 	}
 }

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.windows.cs
@@ -295,11 +295,12 @@ partial class MediaManager : IDisposable
 	async Task LoadSubtitles(CancellationToken cancellationToken = default)
 	{
 		subtitleExtensions?.StopSubtitleDisplay();
-		if (subtitleExtensions is null || string.IsNullOrEmpty(MediaElement.SubtitleUrl))
+		if (subtitleExtensions is null || string.IsNullOrEmpty(MediaElement.SubtitleUrl) || Player is null)
 		{
+			System.Diagnostics.Trace.TraceError("SubtitleExtensions is null or SubtitleUrl is null or Player is null");
 			return;
 		}
-		await subtitleExtensions.LoadSubtitles(MediaElement).WaitAsync(cancellationToken).ConfigureAwait(false);
+		await subtitleExtensions.LoadSubtitles(MediaElement, Player).WaitAsync(cancellationToken).ConfigureAwait(false);
 		subtitleExtensions.StartSubtitleDisplay();
 	}
 	protected virtual partial void PlatformUpdateShouldLoopPlayback()


### PR DESCRIPTION
 - ## Feature/Proposal ##
####  Add Support for Subtitles to Media Element.

 ### Description of Change ###

Adds subtitle support to Windows, Android, iOS, and Mac Catalyst.

 ### Linked Issues ###

 - Fixes #1899

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###
Input on API, naming, and design is appreciated. Nothing is final yet. There were a few people that had ideas from the June meeting. If the people who were at the meeting or are just seeing this now can elaborate on their ideas I will look at them and talk with the other team members about them.

At this time this is a draft PR and is not ready for review. I will be doing multiple reviews to fix and make changes. Please wait to suggest fixes until this comes out of draft. I am looking for design, API, and input on naming so we can move this further.

### Current issues on Android: ###
- The layout when switching to full screen does not stay relative to the bottom. Input on how to fix this would be helpful.

### Current issues all platforms: ###
- Input on how to apply Maui fonts to device specific fonts to each platform. I can figure this out but if someone has an easy way to implement this I would love the input.
 
I wrote file type specific parsers for VTT and SRT subtitle files. They currently are using try - catch and this either requires having error checking added and/or the classes/methods may be rewritten. Input is desired.

I am using device specific text blocks to add subtitles to media element. At this time it works great in Windows and iOS/Mac. Android layout issues are the only current issues I have been working on. Font sizing is done and ready. I did set font size to be larger in Windows when switching to full screen as they appear to be too small when switching to full screen. Users can select font size, font family, etc. 

### API: ### 
```csharp
/// <summary>
/// Backing store for the <see cref="SubtitleFont"/> property.
/// </summary>
public static readonly BindableProperty SubtitleFontProperty = BindableProperty.Create(nameof(SubtitleFont), typeof(string), typeof(MediaElement), string.Empty);

/// <summary>
/// Backing store for the <see cref="SubtitleFontSize"/> property.
/// </summary>
public static readonly BindableProperty SubtitleFontSizeProperty = BindableProperty.Create(nameof(SubtitleFontSize), typeof(double), typeof(MediaElement), 16.0);

/// <summary>
/// Backing store for the <see cref="SubtitleUrl"/> property.
/// </summary>
public static readonly BindableProperty SubtitleProperty = BindableProperty.Create(nameof(SubtitleUrl), typeof(string), typeof(MediaElement), string.Empty);
```