### PR TITLE
Queue up the Text update when running on Android

### DIFF
--- a/src/CommunityToolkit.Maui/Behaviors/MaskedBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/MaskedBehavior.shared.cs
@@ -102,7 +102,17 @@ public class MaskedBehavior : BaseBehavior<InputView>, IDisposable
 		await maskedBehavior.OnMaskChanged(maskedBehavior.Mask, CancellationToken.None).ConfigureAwait(false);
 	}
 
-	Task OnTextPropertyChanged(CancellationToken token) => ApplyMask(View?.Text, token);
+	Task OnTextPropertyChanged(CancellationToken token)
+	{
+#if ANDROID
+		// Android does not play well when we update the Text inside the TextChanged event. Therefore if we dispatch 
+		// the mechanism of updating the Text property it solves the issue of the caret position being updated incorrectly.
+		Application.Current?.Dispatcher.Dispatch(async () => await ApplyMask(View?.Text, token));
+		return Task.CompletedTask;
+#else
+		return ApplyMask(View?.Text, token);
+#endif
+	}
 
 	void SetMaskPositions(in string? mask)
 	{


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->

This PR aims at working around an issue on Android when the `Text` property is updated programmatically during the `TextChanged` event then the `CurrentPosition` property is overridden once completed.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #1913
 - Fixes #460

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [x] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
