### PR TITLE
Fix IconTintColorBehavior not tinting UriImageSource and TintColor binding not working on Windows

### DIFF
--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.windows.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.windows.cs
@@ -136,6 +136,10 @@ public partial class IconTintColorBehavior
 
 		void OnImageOpened(object sender, RoutedEventArgs e)
 		{
+			ArgumentNullException.ThrowIfNull(sender);
+
+			var image = (WImage)sender;
+
 			image.ImageOpened -= OnImageOpened;
 
 			ApplyTintColor();

--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.windows.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.windows.cs
@@ -125,7 +125,14 @@ public partial class IconTintColorBehavior
 
 	void LoadAndApplyImageTintColor(View element, WImage image, Color color)
 	{
-		image.ImageOpened += OnImageOpened;
+		if (image.IsLoaded)
+		{
+			ApplyTintColor();
+		}
+		else
+		{
+			image.ImageOpened += OnImageOpened;
+		}
 
 		void OnImageOpened(object sender, RoutedEventArgs e)
 		{


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

 On Windows, the IconTintColorBehavior did not tint images with a URL source and in the CommunityToolkit sample, the ImageButton with the TintColor binding was not changing color when pressed. These issues did not happen on Mac or iOS. The issue was with the `OnImageOpened()` function not getting called with for URL images. There was a change made in a previous pull request #1370 that fixed an issue described in #1333 on Windows where applying the IconTintColorBehavior caused the image to not show up, but when reverting this change, the URL image was tinted correctly and the ImageButton worked. Reverting the change did not cause the issue in #1333 to reappear.

Below is an image of the tests I wrote in the sample solution to see the change:
![image](https://github.com/CommunityToolkit/Maui/assets/80227988/939054dc-33fc-4ddb-94e9-209578ea9ca0)

This is what it looks like without the change:
![image](https://github.com/CommunityToolkit/Maui/assets/80227988/ecc9b3e3-e778-4188-b6a2-542f5a13ecc0)

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #1906 
 - Fixes #1734 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls

### Additional Information ###

Tested on Windows 10