### PR TITLE
Set unloaded event to make sure popup is shown on Windows.

### DIFF
--- a/src/CommunityToolkit.Maui/Views/Popup/PopupExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/PopupExtensions.shared.cs
@@ -63,6 +63,7 @@ public static partial class PopupExtensions
 
 		async void handler(object? sender, EventArgs args)
 		{
+			page.GetCurrentPage().Unloaded -= (_, _) => { };
 			page.GetCurrentPage().Loaded -= handler;
 
 			try
@@ -76,6 +77,8 @@ public static partial class PopupExtensions
 				taskCompletionSource.TrySetException(ex);
 			}
 		}
+
+		page.GetCurrentPage().Unloaded += (_, _) => { };
 		page.GetCurrentPage().Loaded += handler;
 
 		return taskCompletionSource.Task.WaitAsync(token);


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->
This fixes an issue with MAUI 8.0.60 and later where the `Page.Loaded` event isn't triggering resulting in a hanging Task.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #1931 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [X] Rebased on top of `main` at time of PR
 - [X] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
The question is should this be added to the CommunityToolkit or be fixed in MAUI itself. At the moment Popups don't work as expected when used with 8.0.60 and higher on Windows. This fixes that issue. The code is already a workaround so adding the Unloaded events is probably not that exciting and could possibly be removed if issue https://github.com/dotnet/maui/issues/12970 is fixed.
 
