### PR TITLE
Don't copy Core & main package to artifacts for Camera package build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -337,7 +337,8 @@ jobs:
         condition: and(eq(variables['Agent.OS'], 'Windows_NT'),
           startsWith(variables['Build.SourceBranch'], 'refs/tags/'),
           not(endsWith(variables['Build.SourceBranch'], '-mediaelement')), 
-          not(endsWith(variables['Build.SourceBranch'], '-maps'))) # Only run this step on Windows and when it's a tagged build and the tag does NOT end with -mediaelement and does NOT end with -maps
+          not(endsWith(variables['Build.SourceBranch'], '-maps')),
+          not(endsWith(variables['Build.SourceBranch'], '-camera'))) # Only run this step on Windows and when it's a tagged build and the tag does NOT end with -mediaelement and does NOT end with -maps and does NOT end with -camera
         displayName: 'Copy CommunityToolkit.Maui & CommunityToolkit.Maui.Core NuGet Packages to Staging Directory'
         inputs:
           targetType: 'inline'


### PR DESCRIPTION
In the build pipeline we were missing a bit where `CommunityToolkit.Maui` and `CommunityToolkit.Maui.Core` were excluded when we do a tagged build for `CommunityToolkit.Maui.Camera`.

 ### Description of Change ###

Adds a condition to our build pipeline to NOT copy `CommunityToolkit.Maui` & `CommunityToolkit.Maui.Core` NuGet packages to staging directory when building `CommunityToolkit.Maui.Camera`.

 ### Linked Issues ###

N/A
