### PR TITLE
Update Media Element to fix code compliance

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/CommunityToolkit.Maui.Sample.csproj
+++ b/samples/CommunityToolkit.Maui.Sample/CommunityToolkit.Maui.Sample.csproj
@@ -51,8 +51,8 @@
     <!-- Custom Fonts -->
     <MauiFont Include="Resources\Fonts\*" />
 
-    <PackageReference Include="Microsoft.Maui.Controls" Version="*"/>
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="*"/>
+    <PackageReference Include="Microsoft.Maui.Controls" Version="*" />
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="*" />
     <PackageReference Include="CommunityToolkit.Maui.Markup" Version="4.0.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.3.0" />
@@ -85,5 +85,10 @@
 
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('windows'))=='false' and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))=='maccatalyst' and $(Configuration) == 'Debug'">
     <RuntimeIdentifiers>maccatalyst-arm64;maccatalyst-x64</RuntimeIdentifiers>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net8.0-ios'">
+    <CodesignKey>Apple Development: Created via API (7U62A7MVA4)</CodesignKey>
+    <CodesignProvision>VS: WildCard Development</CodesignProvision>
   </PropertyGroup>
 </Project>

--- a/samples/CommunityToolkit.Maui.Sample/CommunityToolkit.Maui.Sample.csproj
+++ b/samples/CommunityToolkit.Maui.Sample/CommunityToolkit.Maui.Sample.csproj
@@ -51,8 +51,8 @@
     <!-- Custom Fonts -->
     <MauiFont Include="Resources\Fonts\*" />
 
-    <PackageReference Include="Microsoft.Maui.Controls" Version="*" />
-    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="*" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="*"/>
+    <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="*"/>
     <PackageReference Include="CommunityToolkit.Maui.Markup" Version="4.0.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.3.0" />
@@ -85,10 +85,5 @@
 
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('windows'))=='false' and $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)'))=='maccatalyst' and $(Configuration) == 'Debug'">
     <RuntimeIdentifiers>maccatalyst-arm64;maccatalyst-x64</RuntimeIdentifiers>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)'=='net8.0-ios'">
-    <CodesignKey>Apple Development: Created via API (7U62A7MVA4)</CodesignKey>
-    <CodesignProvision>VS: WildCard Development</CodesignProvision>
   </PropertyGroup>
 </Project>

--- a/src/CommunityToolkit.Maui.MediaElement/Primitives/Metadata.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Primitives/Metadata.macios.cs
@@ -9,7 +9,6 @@ namespace CommunityToolkit.Maui.Core.Primitives;
 class Metadata
 {
 	static readonly UIImage defaultUIImage = new();
-	static readonly MPMediaItemArtwork defaultImage = new(boundsSize: new(0, 0), requestHandler: _ => defaultUIImage);
 	static readonly MPNowPlayingInfo nowPlayingInfoDefault = new()
 	{
 		AlbumTitle = string.Empty,
@@ -19,7 +18,7 @@ class Metadata
 		IsLiveStream = false,
 		PlaybackRate = 0,
 		ElapsedPlaybackTime = 0,
-		Artwork = defaultImage
+		Artwork = new(boundsSize: new(0, 0), requestHandler: _ => defaultUIImage)
 	};
 
 	readonly PlatformMediaElement player;
@@ -31,7 +30,7 @@ class Metadata
 	public Metadata(PlatformMediaElement player)
 	{
 		this.player = player;
-		MPNowPlayingInfoCenter.DefaultCenter.NowPlaying = NowPlayingInfo;
+		MPNowPlayingInfoCenter.DefaultCenter.NowPlaying = nowPlayingInfoDefault;
 
 		var commandCenter = MPRemoteCommandCenter.Shared;
 
@@ -90,12 +89,18 @@ class Metadata
 
 	static UIImage GetImage(string imageUri)
 	{
-		if (imageUri.StartsWith(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
+		try
 		{
-			return UIImage.LoadFromData(NSData.FromUrl(new NSUrl(imageUri))) ?? defaultUIImage;
+			if (imageUri.StartsWith(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
+			{
+				return UIImage.LoadFromData(NSData.FromUrl(new NSUrl(imageUri))) ?? defaultUIImage;
+			}
+			return defaultUIImage;
 		}
-
-		return defaultUIImage;
+		catch
+		{
+			return defaultUIImage;
+		}
 	}
 
 	MPRemoteCommandHandlerStatus SeekCommand(MPRemoteCommandEvent? commandEvent)

--- a/src/CommunityToolkit.Maui.MediaElement/Primitives/Metadata.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Primitives/Metadata.macios.cs
@@ -6,6 +6,7 @@ using MediaPlayer;
 using UIKit;
 
 namespace CommunityToolkit.Maui.Core.Primitives;
+
 class Metadata
 {
 	static readonly UIImage defaultUIImage = new();

--- a/src/CommunityToolkit.Maui.MediaElement/Primitives/Metadata.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Primitives/Metadata.windows.cs
@@ -1,6 +1,7 @@
 ﻿using Windows.Media;
 
 namespace CommunityToolkit.Maui.Core.Primitives;
+
 class Metadata
 {
 	readonly IMediaElement? mediaElement;

--- a/src/CommunityToolkit.Maui.MediaElement/Primitives/Metadata.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Primitives/Metadata.windows.cs
@@ -1,11 +1,7 @@
 ﻿using Windows.Media;
 
 namespace CommunityToolkit.Maui.Core.Primitives;
-
-/// <summary>
-/// A class that provides methods to update the system UI for media transport controls to display media metadata.
-/// </summary>
-public class Metadata
+class Metadata
 {
 	readonly IMediaElement? mediaElement;
 	readonly SystemMediaTransportControls? systemMediaControls;

--- a/src/CommunityToolkit.Maui.MediaElement/Services/MediaControlsService.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Services/MediaControlsService.android.cs
@@ -18,7 +18,7 @@ using Resource = Microsoft.Maui.Resource;
 namespace CommunityToolkit.Maui.Media.Services;
 
 [Service(Exported = false, Enabled = true, Name = "CommunityToolkit.Maui.Media.Services", ForegroundServiceType = ForegroundService.TypeMediaPlayback)]
-public class MediaControlsService : Service
+class MediaControlsService : Service
 {
 	public const string ACTION_PLAY = "MediaAction.play";
 	public const string ACTION_PAUSE = "MediaAction.pause";

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
@@ -223,7 +223,7 @@ public partial class MediaManager : IDisposable
 		}
 
 		metaData ??= new(Player);
-		metaData.ClearNowPlaying();
+		Metadata.ClearNowPlaying();
 
 		if (MediaElement.Source is UriMediaSource uriMediaSource)
 		{
@@ -383,8 +383,7 @@ public partial class MediaManager : IDisposable
 		{
 			return;
 		}
-
-		Player.PreventsDisplaySleepDuringVideoPlayback = MediaElement.ShouldKeepScreenOn;
+		UIApplication.SharedApplication.IdleTimerDisabled = MediaElement.ShouldKeepScreenOn;
 	}
 
 	protected virtual partial void PlatformUpdateShouldMute()
@@ -417,7 +416,8 @@ public partial class MediaManager : IDisposable
 				{
 					UIApplication.SharedApplication.EndReceivingRemoteControlEvents();
 				});
-
+				// disable the idle timer so screen turns off when media is not playing
+				UIApplication.SharedApplication.IdleTimerDisabled = false;
 				var audioSession = AVAudioSession.SharedInstance();
 				audioSession.SetActive(false);
 


### PR DESCRIPTION
- Bug fix
 
 ### Description of Change ###

Add static keyword to a few methods
Replace deprecated IOS API's

Deprecated API's
- `MPMediaItemArtwork`
- `Player.PreventsDisplaySleepDuringVideoPlayback`

 ### Linked Issues ###
 - Fixes #1954

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###
As brought up earlier there are a few issues with existing code that need to be fixed. Code compliance with dotnet standards and repository best practices.
 
