### PR TITLE
Prevent volume bar from popping up on Android

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Services/MediaControlsService.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Services/MediaControlsService.android.cs
@@ -176,7 +176,7 @@ class MediaControlsService : Service
 		ArgumentNullException.ThrowIfNull(audioManager);
 		audioManager.RequestAudioFocus(null, AndroidStream.Music, AudioFocus.Gain);
 		audioManager.SetParameters("Ducking=true");
-		audioManager.SetStreamVolume(AndroidStream.Music, audioManager.GetStreamVolume(AndroidStream.Music), VolumeNotificationFlags.ShowUi);
+		audioManager.SetStreamVolume(AndroidStream.Music, audioManager.GetStreamVolume(AndroidStream.Music), 0);
 	}
 
 	async Task OnSetContent(Intent mediaManagerIntent, CancellationToken cancellationToken)


### PR DESCRIPTION
 ### Description of Change ###

Currently the volume bar keeps popping up on Android whenever you interact with `MediaElement`, this change will stop that as it look a bit funny to me.

 ### Linked Issues ###
N/A, just a Gerald annoyance 😜 

 ### PR Checklist ###
 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal), no, I'm a badass
 - [ ] Has tests (if omitted, state reason in description), also not 😱 
 - [x] Has samples (if omitted, state reason in description), I guess it does its part of the sample already
 - [x] Rebased on top of `main` at time of PR, this one YES
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices), of course
 - [ ] Documentation created or updated: not needed

 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
