### PR TITLE
Adding constraints to Popup View on iOS

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/Popup/MauiPopup.macios.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using CommunityToolkit.Maui.Core.Extensions;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Handlers;
 
@@ -56,6 +57,12 @@ public class MauiPopup : UIViewController
 		}
 
 		SetElementSize(new Size(View.Bounds.Width, View.Bounds.Height));
+
+		if (VirtualView is not null)
+		{
+			PopupExtensions.SetSize(this, VirtualView);
+			PopupExtensions.SetLayout(this, VirtualView);
+		}
 	}
 
 	/// <inheritdoc/>
@@ -176,6 +183,11 @@ public class MauiPopup : UIViewController
 		view.AddSubview(control.ViewController?.View ?? throw new InvalidOperationException($"{nameof(control.ViewController.View)} cannot be null."));
 		view.Bounds = new CGRect(0, 0, PreferredContentSize.Width, PreferredContentSize.Height);
 		AddChildViewController(control.ViewController);
+
+		view.SafeTopAnchor().ConstraintEqualTo(control.ViewController.View.SafeTopAnchor()).Active = true;
+		view.SafeBottomAnchor().ConstraintEqualTo(control.ViewController.View.SafeBottomAnchor()).Active = true;
+		view.SafeLeadingAnchor().ConstraintEqualTo(control.ViewController.View.SafeLeadingAnchor()).Active = true;
+		view.SafeTrailingAnchor().ConstraintEqualTo(control.ViewController.View.SafeTrailingAnchor()).Active = true;
 
 		if (VirtualView is not null)
 		{


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

This PR resolves the issue where the Popup size does not change according to the change in the Popup content size.

 ### Description of Change ###

Currently, there are no constraints, so it is not possible to change the size of the Popup in response to changes in the size of the Popup's content. First, add a constraint so that the ViewDidLayoutSubviews method is called as the Popup's content changes.

[src\CommunityToolkit.Maui.Core\Views\Popup\MauiPopup.macios.cs]

	void SetView(UIView view, IPlatformViewHandler control)
	{
		view.AddSubview(control.ViewController?.View ?? throw new InvalidOperationException($"{nameof(control.ViewController.View)} cannot be null."));
		view.Bounds = new CGRect(0, 0, PreferredContentSize.Width, PreferredContentSize.Height);
		AddChildViewController(control.ViewController);

		view.SafeTopAnchor().ConstraintEqualTo(control.ViewController.View.SafeTopAnchor()).Active = true;
		view.SafeBottomAnchor().ConstraintEqualTo(control.ViewController.View.SafeBottomAnchor()).Active = true;
		view.SafeLeadingAnchor().ConstraintEqualTo(control.ViewController.View.SafeLeadingAnchor()).Active = true;
		view.SafeTrailingAnchor().ConstraintEqualTo(control.ViewController.View.SafeTrailingAnchor()).Active = true;

		if (VirtualView is not null)
		{
			this.SetBackgroundColor(VirtualView);
		}
	}

Next, within the ViewDidLayoutSubviews method, call methods to resize and layout the Popup.

[src\CommunityToolkit.Maui.Core\Views\Popup\MauiPopup.macios.cs]

	public override void ViewDidLayoutSubviews()
	{
		base.ViewDidLayoutSubviews();

		_ = View ?? throw new InvalidOperationException($"{nameof(View)} cannot be null.");

		View.Superview.Layer.CornerRadius = 0.0f;
		View.Superview.Layer.MasksToBounds = false;

		if (PresentationController is not null)
		{
			SetShadowView(PresentationController.ContainerView);
		}

		SetElementSize(new Size(View.Bounds.Width, View.Bounds.Height));

		if (VirtualView is not null)
		{
			PopupExtensions.SetSize(this, VirtualView);
			PopupExtensions.SetLayout(this, VirtualView);
		}
	}

With this fix, the size of the Popup itself will change according to the change in the size of the Popup's Content.

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #1974

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

Below is the verification video. For verification, we used the source code provided in Issue #1974.

https://github.com/CommunityToolkit/Maui/assets/125236133/481d4cb6-27aa-4f61-a210-6b3bdf8e71af

You can see that the size of the Popup itself changes according to the change in the size of the Popup's Content.

The following is the verification result when HorizontalOptions and VerticalOptions are set to End.

https://github.com/CommunityToolkit/Maui/assets/125236133/87136c7c-cf1b-4eed-8763-6c0eac892dbf

The following is the verification result when HorizontalOptions and VerticalOptions are set to Start.

https://github.com/CommunityToolkit/Maui/assets/125236133/d66c3ed0-8a3d-4cab-9972-e7a0a8874fcc

You can see that both cases give the expected results.

The following is the verification result when the Popup size is explicitly specified as (300, 300).

https://github.com/CommunityToolkit/Maui/assets/125236133/540089e4-9195-4443-a9fd-49983b757a8a

You can see that the size of the Popup itself does not change as the size of the Popup's Content changes, and that the size specified for the Popup takes precedence.

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
