### PR TITLE
Information label and bound value in CompareConverter sample don't match

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Converters/CompareConverterPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Converters/CompareConverterPage.xaml
@@ -1,52 +1,48 @@
-<pages:BasePage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="CommunityToolkit.Maui.Sample.Pages.Converters.CompareConverterPage"
-             xmlns:vm="clr-namespace:CommunityToolkit.Maui.Sample.ViewModels.Converters"
-             xmlns:converters="clr-namespace:CommunityToolkit.Maui.Sample.Converters"
-             xmlns:mct="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
-             xmlns:pages="clr-namespace:CommunityToolkit.Maui.Sample.Pages"
-             x:TypeArguments="vm:CompareConverterViewModel"
-             x:DataType="vm:CompareConverterViewModel">
+<pages:BasePage
+    x:Class="CommunityToolkit.Maui.Sample.Pages.Converters.CompareConverterPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:converters="clr-namespace:CommunityToolkit.Maui.Sample.Converters"
+    xmlns:mct="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+    xmlns:pages="clr-namespace:CommunityToolkit.Maui.Sample.Pages"
+    xmlns:vm="clr-namespace:CommunityToolkit.Maui.Sample.ViewModels.Converters"
+    x:DataType="vm:CompareConverterViewModel"
+    x:TypeArguments="vm:CompareConverterViewModel">
 
     <pages:BasePage.Resources>
         <ResourceDictionary>
-            <x:Double x:Key="ComparingValue">0.5</x:Double>
+            <x:Double x:Key="ComparingValue">5.0</x:Double>
             <Color x:Key="LightGreen">LightGreen</Color>
             <Color x:Key="PaleVioletRed">PaleVioletRed</Color>
-            
+
             <converters:CompareDoubleToColorConverter
                 x:Key="isLargerThanOneConverter"
                 ComparingValue="1"
                 ComparisonOperator="Greater"
-                TrueObject="LightGreen"
-                FalseObject="PaleVioletRed" />
+                FalseObject="PaleVioletRed"
+                TrueObject="LightGreen" />
         </ResourceDictionary>
     </pages:BasePage.Resources>
-    
+
     <VerticalStackLayout Spacing="20">
 
-        <Label 
-            Text="The CompareConverter is a Converter that converts an object of a type implementing IComparable, and returns the comparison result as a bool if no objects were specified through the TrueObject and/or FalseObject properties. If values are assigned to the TrueObject and/or FalseObject properties, the CompareConverter returns the respective object assigned." 
-            TextColor="{StaticResource NormalLabelTextColor}"/>
+        <Label Text="The CompareConverter is a Converter that converts an object of a type implementing IComparable, and returns the comparison result as a bool if no objects were specified through the TrueObject and/or FalseObject properties. If values are assigned to the TrueObject and/or FalseObject properties, the CompareConverter returns the respective object assigned." TextColor="{StaticResource NormalLabelTextColor}" />
 
         <Slider
+            HorizontalOptions="FillAndExpand"
             Maximum="10"
             Minimum="0"
-            Value="{Binding SliderValue, Mode=TwoWay}"
-            HorizontalOptions="FillAndExpand"/>
-
-        <Label 
-            Text="The background of this label will be green if the value of the slider is greater than 1, and red otherwise."
-            BackgroundColor="{Binding SliderValue, Mode=OneWay, Converter={StaticResource isLargerThanOneConverter}}"
-            TextColor="Black"
-            Padding="4, 0"/>
-
-        <Label 
-            Text="The following label will show whether the value of the slider is greater than or equal to 50%:"
-            TextColor="{StaticResource NormalLabelTextColor}"/>
+            Value="{Binding SliderValue, Mode=TwoWay}" />
 
         <Label
-            Text="{Binding SliderValue, Mode=OneWay, Converter={mct:CompareConverter ComparingValue={StaticResource ComparingValue}, ComparisonOperator=GreaterOrEqual}}" />
+            Padding="4,0"
+            BackgroundColor="{Binding SliderValue, Mode=OneWay, Converter={StaticResource isLargerThanOneConverter}}"
+            Text="The background of this label will be green if the value of the slider is greater than 1, and red otherwise."
+            TextColor="Black" />
+
+        <Label Text="The following label will show whether the value of the slider is greater than or equal to 50%:" TextColor="{StaticResource NormalLabelTextColor}" />
+
+        <Label Text="{Binding SliderValue, Mode=OneWay, Converter={mct:CompareConverter ComparingValue={StaticResource ComparingValue}, ComparisonOperator=GreaterOrEqual}}" />
 
     </VerticalStackLayout>
 </pages:BasePage>


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

Changed the value of the `Comparingvalue` to be 50% of the `Slider` range, thus matching the label text.  Not unit tests or documentation need to be updated.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #1980

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [X] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [X] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [X] Rebased on top of `main` at time of PR
 - [X] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###
Tested on:
- [X] Windows 11
- [X] Android
- [ ] iOS
- [ ] Maccatalyst