### PR TITLE
Fix Camera analyzer

### DIFF
--- a/src/CommunityToolkit.Maui.Camera.Analyzers.CodeFixes/CodeFixResources.Designer.cs
+++ b/src/CommunityToolkit.Maui.Camera.Analyzers.CodeFixes/CodeFixResources.Designer.cs
@@ -7,7 +7,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace CommunityToolkit.Maui.CameraView.Analyzers {
+namespace CommunityToolkit.Maui.Camera.Analyzers {
     using System;
     
     
@@ -60,9 +60,9 @@ namespace CommunityToolkit.Maui.CameraView.Analyzers {
         /// <summary>
         ///   Looks up a localized string similar to Add `.UseMauiCommunityToolkitCamera()`.
         /// </summary>
-        internal static string Initialize__NET_MAUI_Community_Toolkit_CameraView_Before_UseMauiApp {
+        internal static string Initialize__NET_MAUI_Community_Toolkit_Camera_Before_UseMauiApp {
             get {
-                return ResourceManager.GetString("Initialize .NET MAUI Community Toolkit CameraView Before UseMauiApp", resourceCulture);
+                return ResourceManager.GetString("Initialize .NET MAUI Community Toolkit Camera Before UseMauiApp", resourceCulture);
             }
         }
     }

--- a/src/CommunityToolkit.Maui.Camera.Analyzers.CodeFixes/CodeFixResources.Designer.cs
+++ b/src/CommunityToolkit.Maui.Camera.Analyzers.CodeFixes/CodeFixResources.Designer.cs
@@ -36,7 +36,7 @@ namespace CommunityToolkit.Maui.CameraView.Analyzers {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("CommunityToolkit.Maui.CameraView.Analyzers.CodeFixResources", typeof(CodeFixResources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("CommunityToolkit.Maui.Camera.Analyzers.CodeFixResources", typeof(CodeFixResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/src/CommunityToolkit.Maui.Camera.Analyzers.CodeFixes/CodeFixResources.resx
+++ b/src/CommunityToolkit.Maui.Camera.Analyzers.CodeFixes/CodeFixResources.resx
@@ -12,7 +12,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Initialize .NET MAUI Community Toolkit CameraView Before UseMauiApp" xml:space="preserve">
+  <data name="Initialize .NET MAUI Community Toolkit Camera Before UseMauiApp" xml:space="preserve">
     <value>Add `.UseMauiCommunityToolkitCamera()`</value>
     <comment>Add `.UseMauiCommunityToolkitCamera()`</comment>
   </data>

--- a/src/CommunityToolkit.Maui.Camera.Analyzers.CodeFixes/UseCommunityToolkitCameraViewInitializationAnalyzerCodeFixProvider.cs
+++ b/src/CommunityToolkit.Maui.Camera.Analyzers.CodeFixes/UseCommunityToolkitCameraViewInitializationAnalyzerCodeFixProvider.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Immutable;
 using System.Composition;
-using CommunityToolkit.Maui.CameraView.Analyzers;
+using CommunityToolkit.Maui.Camera.Analyzers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -10,8 +10,8 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace CommunityToolkit.Maui.Camera.Analyzers;
 
-[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UseCommunityToolkitCameraViewInitializationAnalyzerCodeFixProvider)), Shared]
-public class UseCommunityToolkitCameraViewInitializationAnalyzerCodeFixProvider : CodeFixProvider
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UseCommunityToolkitCameraInitializationAnalyzerCodeFixProvider)), Shared]
+public class UseCommunityToolkitCameraInitializationAnalyzerCodeFixProvider : CodeFixProvider
 {
 	public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(UseCommunityToolkitCameraInitializationAnalyzer.DiagnosticId);
 
@@ -30,9 +30,9 @@ public class UseCommunityToolkitCameraViewInitializationAnalyzerCodeFixProvider 
 		// Register a code action that will invoke the fix.
 		context.RegisterCodeFix(
 			CodeAction.Create(
-				title: CodeFixResources.Initialize__NET_MAUI_Community_Toolkit_CameraView_Before_UseMauiApp,
+				title: CodeFixResources.Initialize__NET_MAUI_Community_Toolkit_Camera_Before_UseMauiApp,
 				createChangedDocument: c => AddUseCommunityToolkit(context.Document, declaration, c),
-				equivalenceKey: nameof(CodeFixResources.Initialize__NET_MAUI_Community_Toolkit_CameraView_Before_UseMauiApp)),
+				equivalenceKey: nameof(CodeFixResources.Initialize__NET_MAUI_Community_Toolkit_Camera_Before_UseMauiApp)),
 			diagnostic);
 	}
 

--- a/src/CommunityToolkit.Maui.Camera.Analyzers/Resources.Designer.cs
+++ b/src/CommunityToolkit.Maui.Camera.Analyzers/Resources.Designer.cs
@@ -7,7 +7,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace CommunityToolkit.Maui.CameraView.Analyzers {
+namespace CommunityToolkit.Maui.Camera.Analyzers {
     using System;
     
     

--- a/src/CommunityToolkit.Maui.Camera.Analyzers/Resources.Designer.cs
+++ b/src/CommunityToolkit.Maui.Camera.Analyzers/Resources.Designer.cs
@@ -36,7 +36,7 @@ namespace CommunityToolkit.Maui.Camera.Analyzers {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("CommunityToolkit.Maui.CameraView.Analyzers.Resources", typeof(Resources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("CommunityToolkit.Maui.Camera.Analyzers.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -67,7 +67,7 @@ namespace CommunityToolkit.Maui.Camera.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to `.UseMauiCommunityToolkitCamera()` is required to initalize .NET MAUI Community Toolkit CameraView.
+        ///   Looks up a localized string similar to `.UseMauiCommunityToolkitCamera()` is required to initalize .NET MAUI Community Toolkit Camera.
         /// </summary>
         internal static string InitializationErrorMessage {
             get {

--- a/src/CommunityToolkit.Maui.Camera.Analyzers/Resources.resx
+++ b/src/CommunityToolkit.Maui.Camera.Analyzers/Resources.resx
@@ -16,7 +16,7 @@
     <value>`.UseMauiCommunityToolkitCamera()` must be chained to `.UseMauiApp&lt;T&gt;()`</value>
   </data>
   <data name="InitializationErrorMessage" xml:space="preserve">
-    <value>`.UseMauiCommunityToolkitCamera()` is required to initalize .NET MAUI Community Toolkit CameraView</value>
+    <value>`.UseMauiCommunityToolkitCamera()` is required to initalize .NET MAUI Community Toolkit Camera</value>
   </data>
   <data name="InitializationErrorTitle" xml:space="preserve">
     <value>`.UseMauiCommunityToolkitCamera()` Not Found on MauiAppBuilder</value>

--- a/src/CommunityToolkit.Maui.Camera.Analyzers/UseCommunityToolkitCameraInitializationAnalyzer.cs
+++ b/src/CommunityToolkit.Maui.Camera.Analyzers/UseCommunityToolkitCameraInitializationAnalyzer.cs
@@ -5,12 +5,12 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
-namespace CommunityToolkit.Maui.CameraView.Analyzers;
+namespace CommunityToolkit.Maui.Camera.Analyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class UseCommunityToolkitCameraInitializationAnalyzer : DiagnosticAnalyzer
 {
-	public const string DiagnosticId = "MCTME001";
+	public const string DiagnosticId = "MCTC001";
 
 	const string category = "Initialization";
 	static readonly LocalizableString title = new LocalizableResourceString(nameof(Resources.InitializationErrorTitle), Resources.ResourceManager, typeof(Resources));


### PR DESCRIPTION
 ### Description of Change ###

 I think one namespace was forgotten in the rename from CameraView to Camera and that is probably why the analyzer couldn't locate things.

 ### Linked Issues ###

 - Fixes #1991

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 