### PR TITLE
Add On-Device Android Speech Recognition Support

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Essentials/SpeechToText/SpeechToTextImplementation.android.cs
+++ b/src/CommunityToolkit.Maui.Core/Essentials/SpeechToText/SpeechToTextImplementation.android.cs
@@ -80,8 +80,11 @@ public sealed partial class SpeechToTextImplementation
 		{
 			throw new FeatureNotSupportedException("Speech Recognition is not available on this device");
 		}
-
-		speechRecognizer = SpeechRecognizer.CreateSpeechRecognizer(Application.Context);
+		if (SpeechRecognizer.isOnDeviceRecognitionAvailable(Application.Context)) {
+            speechRecognizer = SpeechRecognizer.createOnDeviceSpeechRecognizer(Application.Context);
+        } else {
+			speechRecognizer = SpeechRecognizer.CreateSpeechRecognizer(Application.Context);
+		}
 		if (speechRecognizer is null)
 		{
 			throw new FeatureNotSupportedException("Speech recognizer is not available on this device");

--- a/src/CommunityToolkit.Maui.Core/Essentials/SpeechToText/SpeechToTextImplementation.android.cs
+++ b/src/CommunityToolkit.Maui.Core/Essentials/SpeechToText/SpeechToTextImplementation.android.cs
@@ -80,11 +80,16 @@ public sealed partial class SpeechToTextImplementation
 		{
 			throw new FeatureNotSupportedException("Speech Recognition is not available on this device");
 		}
-		if (SpeechRecognizer.isOnDeviceRecognitionAvailable(Application.Context)) {
-            speechRecognizer = SpeechRecognizer.createOnDeviceSpeechRecognizer(Application.Context);
-        } else {
+		
+		if (SpeechRecognizer.IsOnDeviceRecognitionAvailable(Application.Context))
+		{
+            speechRecognizer = SpeechRecognizer.CreateOnDeviceSpeechRecognizer(Application.Context);
+        } 
+		else 
+		{
 			speechRecognizer = SpeechRecognizer.CreateSpeechRecognizer(Application.Context);
 		}
+		
 		if (speechRecognizer is null)
 		{
 			throw new FeatureNotSupportedException("Speech recognizer is not available on this device");


### PR DESCRIPTION
Fixes ASR failures that occur when network is down/unreachable. 

Recent versions of Android support on device speech recognition.
The benefits include:
* lower latency/improved performance
* no data consumption to run ASR
* ability for ASR to succeed even when network/data connections are unavailable.

SpeechToText Unit Tests all passed with this change.
Tested on a modern Android device to ensure on-device ASR works even when network is disconnected.

The change is fully transparent to the apps/clients so no changes are needed to use this feature, therefore no samples provided.

 ### Description of Change ###

Add a check for device capability, and if available, use on device ASR.

 ### Linked Issues ###
https://github.com/CommunityToolkit/Maui/discussions/2028

 - Fixes #

 ### PR Checklist ###

 - [X] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [X] Has tests (if omitted, state reason in description)
 - [X] Has samples (if omitted, state reason in description)
 - [X] Rebased on top of `main` at time of PR
 - [X] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
