### PR TITLE
Update IconTintColorBehavior so it applies tint to Button image on Android and Windows like iOS and Mac Catalyst

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/IconTintColorBehaviorPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/IconTintColorBehaviorPage.xaml
@@ -13,7 +13,7 @@
         <Grid
 			Padding="20" 
 			ColumnDefinitions="*, *, *"
-			RowDefinitions="Auto, Auto, 60, Auto, 60, Auto, Auto, 60"
+			RowDefinitions="Auto, Auto, 60, Auto, 60, Auto, Auto, 60, Auto"
 			RowSpacing="20">
 
             <Label
@@ -149,6 +149,19 @@
                     <mct:IconTintColorBehavior TintColor="Purple" />
                 </Image.Behaviors>
             </Image>
+
+			<!-- Applies tint color to Button images in iOS and Mac Catalyst pending #2040 -->
+			<Button 
+                Grid.Row="9"
+                Grid.ColumnSpan="3"
+                HorizontalOptions="Center"
+                VerticalOptions="End"
+				Text="Button with IconTintColorBehavior"
+                ImageSource="https://api.nuget.org/v3-flatcontainer/communitytoolkit.maui/9.0.1/icon">
+                <Button.Behaviors>
+                    <mct:IconTintColorBehavior TintColor="Red" />
+                </Button.Behaviors>
+            </Button>
         </Grid>
     </ScrollView>
 </pages:BasePage>

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/IconTintColorBehaviorPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/IconTintColorBehaviorPage.xaml
@@ -159,8 +159,7 @@
                 FontSize="18"
                 HorizontalTextAlignment="Center"
                 Text="Button with Image" />
-
-			<!-- Applies tint color to Button images in iOS and Mac Catalyst pending #2040 -->
+            
 			<Button 
                 Grid.Row="9"
                 Grid.ColumnSpan="3"

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/IconTintColorBehaviorPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/IconTintColorBehaviorPage.xaml
@@ -13,7 +13,7 @@
         <Grid
 			Padding="20" 
 			ColumnDefinitions="*, *, *"
-			RowDefinitions="Auto, Auto, 60, Auto, 60, Auto, Auto, 60, Auto"
+			RowDefinitions="Auto, Auto, 60, Auto, 60, Auto, Auto, 60, Auto, 60, Auto"
 			RowSpacing="20">
 
             <Label
@@ -149,19 +149,40 @@
                     <mct:IconTintColorBehavior TintColor="Purple" />
                 </Image.Behaviors>
             </Image>
+            
+            <Label
+                Grid.Column="0"
+                Grid.ColumnSpan="3"
+                Grid.Row="8"
+                Padding="0,20,0,0"
+                FontAttributes="Bold"
+                FontSize="18"
+                HorizontalTextAlignment="Center"
+                Text="Button with Image" />
 
 			<!-- Applies tint color to Button images in iOS and Mac Catalyst pending #2040 -->
 			<Button 
                 Grid.Row="9"
                 Grid.ColumnSpan="3"
+                Clicked="HandleButtonClicked"
                 HorizontalOptions="Center"
                 VerticalOptions="End"
 				Text="Button with IconTintColorBehavior"
                 ImageSource="https://api.nuget.org/v3-flatcontainer/communitytoolkit.maui/9.0.1/icon">
-                <Button.Behaviors>
-                    <mct:IconTintColorBehavior TintColor="Red" />
-                </Button.Behaviors>
             </Button>
+            
+            <Label
+                Grid.Row="10"
+                Grid.ColumnSpan="3"
+                Margin="0"
+                Padding="0"
+                FontSize="Micro"
+                FontAttributes="Italic"
+                HorizontalOptions="Center"
+                VerticalOptions="Start"
+                VerticalTextAlignment="Center"
+                HorizontalTextAlignment="Center"
+                Text="Clicking this Button adds/removes the TintColorBehavior for its icon. Click it!"/>
         </Grid>
     </ScrollView>
 </pages:BasePage>

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/IconTintColorBehaviorPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/IconTintColorBehaviorPage.xaml
@@ -163,9 +163,11 @@
                 Grid.Row="9"
                 Grid.ColumnSpan="3"
                 Clicked="HandleButtonClicked"
+                HeightRequest="110"
+                WidthRequest="350"
                 HorizontalOptions="Center"
                 VerticalOptions="Center"
-				Text="Button with IconTintColorBehavior"
+				Text="Button with Image"
                 ImageSource="https://api.nuget.org/v3-flatcontainer/communitytoolkit.maui/9.0.1/icon">
             </Button>
             

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/IconTintColorBehaviorPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/IconTintColorBehaviorPage.xaml
@@ -13,7 +13,7 @@
         <Grid
 			Padding="20" 
 			ColumnDefinitions="*, *, *"
-			RowDefinitions="Auto, Auto, 60, Auto, 60, Auto, Auto, 60, Auto, 60, Auto"
+			RowDefinitions="Auto, Auto, 60, Auto, 60, Auto, Auto, 60, 40, 112, Auto"
 			RowSpacing="20">
 
             <Label
@@ -151,9 +151,8 @@
             </Image>
             
             <Label
-                Grid.Column="0"
-                Grid.ColumnSpan="3"
                 Grid.Row="8"
+                Grid.ColumnSpan="3"
                 Padding="0,20,0,0"
                 FontAttributes="Bold"
                 FontSize="18"
@@ -165,7 +164,7 @@
                 Grid.ColumnSpan="3"
                 Clicked="HandleButtonClicked"
                 HorizontalOptions="Center"
-                VerticalOptions="End"
+                VerticalOptions="Center"
 				Text="Button with IconTintColorBehavior"
                 ImageSource="https://api.nuget.org/v3-flatcontainer/communitytoolkit.maui/9.0.1/icon">
             </Button>

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/IconTintColorBehaviorPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/IconTintColorBehaviorPage.xaml.cs
@@ -1,3 +1,4 @@
+using CommunityToolkit.Maui.Behaviors;
 using CommunityToolkit.Maui.Sample.ViewModels.Behaviors;
 
 namespace CommunityToolkit.Maui.Sample.Pages.Behaviors;
@@ -8,5 +9,24 @@ public partial class IconTintColorBehaviorPage : BasePage<IconTintColorBehaviorV
 		: base(iconTintColorBehaviorViewModel)
 	{
 		InitializeComponent();
+	}
+	
+	void HandleButtonClicked(object? sender, EventArgs e)
+	{
+		ArgumentNullException.ThrowIfNull(sender);
+		
+		var button = (Button)sender;
+
+		if (button.Behaviors.OfType<IconTintColorBehavior>().SingleOrDefault() is IconTintColorBehavior iconTintColorBehavior)
+		{
+			button.Behaviors.Remove(iconTintColorBehavior);
+		}
+		else
+		{
+			button.Behaviors.Add(new IconTintColorBehavior
+			{
+				TintColor = Colors.Green
+			});
+		}
 	}
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/IconTintColorBehaviorPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/IconTintColorBehaviorPage.xaml.cs
@@ -10,11 +10,11 @@ public partial class IconTintColorBehaviorPage : BasePage<IconTintColorBehaviorV
 	{
 		InitializeComponent();
 	}
-	
+
 	void HandleButtonClicked(object? sender, EventArgs e)
 	{
 		ArgumentNullException.ThrowIfNull(sender);
-		
+
 		var button = (Button)sender;
 
 		if (button.Behaviors.OfType<IconTintColorBehavior>().SingleOrDefault() is IconTintColorBehavior iconTintColorBehavior)

--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.android.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.android.cs
@@ -37,28 +37,6 @@ public partial class IconTintColorBehavior
 		PropertyChanged -= OnTintedImagePropertyChanged;
 	}
 
-	static void ClearTintColor(View element, AndroidView control)
-	{
-		switch (control)
-		{
-			case ImageView image:
-				image.ClearColorFilter();
-				break;
-
-			case AndroidMaterialButton mButton:
-				mButton.IconTint = null;
-				break;
-
-			case AndroidWidgetButton button:
-				foreach (var drawable in button.GetCompoundDrawables())
-				{
-					drawable.ClearColorFilter();
-				}
-
-				break;
-		}
-	}
-
 	static void ApplyTintColor(AndroidView? nativeView, Color? tintColor)
 	{
 		if (nativeView is null)
@@ -122,6 +100,28 @@ public partial class IconTintColorBehavior
 			{
 				img.SetTint(color.ToPlatform());
 			}
+		}
+	}
+
+	static void ClearTintColor(View element, AndroidView control)
+	{
+		switch (control)
+		{
+			case ImageView image:
+				image.ClearColorFilter();
+				break;
+
+			case AndroidMaterialButton mButton:
+				mButton.IconTint = null;
+				break;
+
+			case AndroidWidgetButton button:
+				foreach (var drawable in button.GetCompoundDrawables())
+				{
+					drawable.ClearColorFilter();
+				}
+
+				break;
 		}
 	}
 

--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.android.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.android.cs
@@ -2,9 +2,9 @@
 using Android.Graphics;
 using Android.Widget;
 using Microsoft.Maui.Platform;
-using MButton = Google.Android.Material.Button.MaterialButton;
-using AButton = Android.Widget.Button;
-using AView = Android.Views.View;
+using AndroidMaterialButton = Google.Android.Material.Button.MaterialButton;
+using AndroidView = Android.Views.View;
+using AndroidWidgetButton = Android.Widget.Button;
 using Color = Microsoft.Maui.Graphics.Color;
 using ImageButton = Microsoft.Maui.Controls.ImageButton;
 
@@ -12,42 +12,55 @@ namespace CommunityToolkit.Maui.Behaviors;
 
 public partial class IconTintColorBehavior
 {
-	AView? nativeView;
+	AndroidView? nativeView;
 
 	/// <inheritdoc/>
-	protected override void OnAttachedTo(View bindable, AView platformView)
+	protected override void OnAttachedTo(View bindable, AndroidView platformView)
 	{
 		base.OnAttachedTo(bindable, platformView);
 		nativeView = platformView;
 
-		ApplyTintColor();
+		ApplyTintColor(nativeView, TintColor);
 
 		bindable.PropertyChanged += OnElementPropertyChanged;
 		PropertyChanged += OnTintedImagePropertyChanged;
 	}
 
-	void OnTintedImagePropertyChanged(object? sender, PropertyChangedEventArgs e)
-	{
-		if (e.PropertyName == TintColorProperty.PropertyName)
-		{
-			ApplyTintColor();
-		}
-	}
-
 	/// <inheritdoc/>
-	protected override void OnDetachedFrom(View bindable, AView platformView)
+	protected override void OnDetachedFrom(View bindable, AndroidView platformView)
 	{
 		base.OnDetachedFrom(bindable, platformView);
 
 		ClearTintColor(bindable, platformView);
+
 		bindable.PropertyChanged -= OnElementPropertyChanged;
 		PropertyChanged -= OnTintedImagePropertyChanged;
 	}
 
-	void ApplyTintColor()
+	static void ClearTintColor(View element, AndroidView control)
 	{
-		var color = TintColor;
+		switch (control)
+		{
+			case ImageView image:
+				image.ClearColorFilter();
+				break;
 
+			case AndroidMaterialButton mButton:
+				mButton.IconTint = null;
+				break;
+
+			case AndroidWidgetButton button:
+				foreach (var drawable in button.GetCompoundDrawables())
+				{
+					drawable.ClearColorFilter();
+				}
+
+				break;
+		}
+	}
+
+	static void ApplyTintColor(AndroidView? nativeView, Color? tintColor)
+	{
 		if (nativeView is null)
 		{
 			return;
@@ -56,11 +69,17 @@ public partial class IconTintColorBehavior
 		switch (nativeView)
 		{
 			case ImageView image:
-				SetImageViewTintColor(image, color);
+				SetImageViewTintColor(image, tintColor);
 				break;
-			case AButton button:
-				SetButtonTintColor(button, color);
+
+			case AndroidMaterialButton materialButton when tintColor is not null:
+				SetMaterialButtonTintColor(materialButton, tintColor);
 				break;
+
+			case AndroidWidgetButton widgetButton:
+				SetWidgetButtonTintColor(widgetButton, tintColor);
+				break;
+
 			default:
 				throw new NotSupportedException($"{nameof(IconTintColorBehavior)} only currently supports Android.Widget.Button and {nameof(ImageView)}.");
 		}
@@ -77,16 +96,18 @@ public partial class IconTintColorBehavior
 			image.SetColorFilter(new PorterDuffColorFilter(color.ToPlatform(), PorterDuff.Mode.SrcIn ?? throw new InvalidOperationException("PorterDuff.Mode.SrcIn should not be null at runtime.")));
 		}
 
-		static void SetButtonTintColor(AButton button, Color? color)
+		static void SetMaterialButtonTintColor(AndroidMaterialButton button, Color color)
 		{
-            if (button is MButton mButton && color is not null)
-            {
-                mButton.IconTintMode = PorterDuff.Mode.SrcIn;
-                mButton.IconTint = new Android.Content.Res.ColorStateList(new int[][] { Array.Empty<int>() }, new int[] { color.ToPlatform() });
-                return;
-            }
+			button.IconTintMode = PorterDuff.Mode.SrcIn;
+			button.IconTint = new Android.Content.Res.ColorStateList(new int[][]
+			{
+				[]
+			}, [color.ToPlatform()]);
+		}
 
-			var drawables = button.GetCompoundDrawables().Where(d => d is not null);
+		static void SetWidgetButtonTintColor(AndroidWidgetButton button, Color? color)
+		{
+			var drawables = button.GetCompoundDrawables().ToList();
 
 			if (color is null)
 			{
@@ -108,7 +129,7 @@ public partial class IconTintColorBehavior
 	{
 		if (args.PropertyName is not string propertyName
 			|| sender is not View bindable
-			|| bindable.Handler?.PlatformView is not AView platformView)
+			|| bindable.Handler?.PlatformView is not AndroidView)
 		{
 			return;
 		}
@@ -119,30 +140,14 @@ public partial class IconTintColorBehavior
 			return;
 		}
 
-		ApplyTintColor();
+		ApplyTintColor(nativeView, TintColor);
 	}
 
-	void ClearTintColor(View element, AView control)
+	void OnTintedImagePropertyChanged(object? sender, PropertyChangedEventArgs e)
 	{
-		switch (control)
+		if (e.PropertyName == TintColorProperty.PropertyName)
 		{
-			case ImageView image:
-				image.ClearColorFilter();
-				break;
-			case AButton button:
-
-				if (button is MButton mButton)
-                {
-                    mButton.IconTint = null;
-                    break;
-                }
-
-				foreach (var drawable in button.GetCompoundDrawables())
-				{
-					drawable?.ClearColorFilter();
-				}
-				
-				break;
+			ApplyTintColor(nativeView, TintColor);
 		}
 	}
 }

--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.android.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.android.cs
@@ -2,6 +2,7 @@
 using Android.Graphics;
 using Android.Widget;
 using Microsoft.Maui.Platform;
+using MButton = Google.Android.Material.Button.MaterialButton;
 using AButton = Android.Widget.Button;
 using AView = Android.Views.View;
 using Color = Microsoft.Maui.Graphics.Color;
@@ -78,6 +79,13 @@ public partial class IconTintColorBehavior
 
 		static void SetButtonTintColor(AButton button, Color? color)
 		{
+            if (button is MButton mButton && color is not null)
+            {
+                mButton.IconTintMode = PorterDuff.Mode.SrcIn;
+                mButton.IconTint = new Android.Content.Res.ColorStateList(new int[][] { Array.Empty<int>() }, new int[] { color.ToPlatform() });
+                return;
+            }
+
 			var drawables = button.GetCompoundDrawables().Where(d => d is not null);
 
 			if (color is null)
@@ -122,10 +130,18 @@ public partial class IconTintColorBehavior
 				image.ClearColorFilter();
 				break;
 			case AButton button:
+
+				if (button is MButton mButton)
+                {
+                    mButton.IconTint = null;
+                    break;
+                }
+
 				foreach (var drawable in button.GetCompoundDrawables())
 				{
 					drawable?.ClearColorFilter();
 				}
+				
 				break;
 		}
 	}

--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.windows.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.windows.cs
@@ -56,6 +56,10 @@ public partial class IconTintColorBehavior
 	static bool TryGetButtonImage(WButton button, [NotNullWhen(true)] out WImage? image)
 	{
 		image = button.Content as WImage;
+
+		if (image == null && button.Content is Microsoft.UI.Xaml.Controls.Panel panel)
+			image = panel.Children?.FirstOrDefault(i => i is WImage) as WImage;
+
 		return image is not null;
 	}
 

--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.windows.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.windows.cs
@@ -57,7 +57,7 @@ public partial class IconTintColorBehavior
 	{
 		image = button.Content as WImage;
 
-		if (image == null && button.Content is Microsoft.UI.Xaml.Controls.Panel panel)
+		if (image is null && button.Content is Microsoft.UI.Xaml.Controls.Panel panel)
 			image = panel.Children?.FirstOrDefault(i => i is WImage) as WImage;
 
 		return image is not null;

--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.windows.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.windows.cs
@@ -55,12 +55,12 @@ public partial class IconTintColorBehavior
 
 	static bool TryGetButtonImage(WButton button, [NotNullWhen(true)] out WImage? image)
 	{
-		image = button.Content as WImage;
-
-		if (image is null && button.Content is Microsoft.UI.Xaml.Controls.Panel panel)
+		image = button.Content switch
 		{
-			image = panel.Children?.FirstOrDefault(i => i is WImage) as WImage;
-		}
+			WImage windowsImage => windowsImage,
+			Microsoft.UI.Xaml.Controls.Panel panel => panel.Children?.OfType<WImage>().FirstOrDefault(),
+			_ => null
+		};
 
 		return image is not null;
 	}

--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.windows.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.windows.cs
@@ -59,6 +59,7 @@ public partial class IconTintColorBehavior
 
 		if (image is null && button.Content is Microsoft.UI.Xaml.Controls.Panel panel)
 			image = panel.Children?.FirstOrDefault(i => i is WImage) as WImage;
+		}
 
 		return image is not null;
 	}

--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.windows.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.windows.cs
@@ -58,6 +58,7 @@ public partial class IconTintColorBehavior
 		image = button.Content as WImage;
 
 		if (image is null && button.Content is Microsoft.UI.Xaml.Controls.Panel panel)
+		{
 			image = panel.Children?.FirstOrDefault(i => i is WImage) as WImage;
 		}
 


### PR DESCRIPTION
### Description of Change

Updated IconTintColorBehavior Android and Windows implementations so they apply the tint to Button images like on iOS and Mac Catalyst.

### Linked Issues

 - Fixes #2040

 ### PR Checklist

 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)

 ### Additional information ###

PR submitted as draft due to issue [#2040](https://github.com/CommunityToolkit/Maui/issues/2040) awaiting approved. AFAICT updates to existing documentation, tests, and samples are not required. 
 
