### PR TITLE
[BUG FIX] Fix Android APK crash on API Level 21-24

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Platforms/Android/AndroidManifest.xml
+++ b/samples/CommunityToolkit.Maui.Sample/Platforms/Android/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application android:allowBackup="true" android:icon="@mipmap/appicon" android:enableOnBackInvokedCallback="true"
                  android:supportsRtl="true">
-        <service android:name="CommunityToolkit.Maui.Media.Services" android:exported="false" android:enabled="true"
+        <service android:name="communityToolkit.maui.media.services" android:exported="false" android:enabled="true"
                  android:foregroundServiceType="mediaPlayback">
             <intent-filter>
                 <action android:name="android.intent.action.MEDIA_BUTTON"/>

--- a/src/CommunityToolkit.Maui.MediaElement/Services/MediaControlsService.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Services/MediaControlsService.android.cs
@@ -17,7 +17,7 @@ using Resource = Microsoft.Maui.Resource;
 
 namespace CommunityToolkit.Maui.Media.Services;
 
-[Service(Exported = false, Enabled = true, Name = "CommunityToolkit.Maui.Media.Services", ForegroundServiceType = ForegroundService.TypeMediaPlayback)]
+[Service(Exported = false, Enabled = true, Name = "communityToolkit.maui.media.services", ForegroundServiceType = ForegroundService.TypeMediaPlayback)]
 class MediaControlsService : Service
 {
 	public const string ACTION_PLAY = "MediaAction.play";


### PR DESCRIPTION
 ### Description of Change ###

- Changed the service name in AndroidManifest.xml and MediaControlsService.android.cs from `CommunityToolkit.Maui.Media.Services` to `communityToolkit.maui.media.services` to adhere to lowercase naming conventions.

 ### Linked Issues ###

 - Fixes #2043

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

Service name changed to prevent crash on API level below 24. It has had all uppercase letters replaced with lowercase to maintain compliance with earlier standards.
 
