### PR TITLE
Tint navigate bug

### DIFF
--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.windows.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.windows.cs
@@ -55,13 +55,7 @@ public partial class IconTintColorBehavior
 
 	static bool TryGetButtonImage(WButton button, [NotNullWhen(true)] out WImage? image)
 	{
-		image = button.Content switch
-		{
-			WImage windowsImage => windowsImage,
-			Microsoft.UI.Xaml.Controls.Panel panel => panel.Children?.OfType<WImage>().FirstOrDefault(),
-			_ => null
-		};
-
+		image = button.Content as WImage;
 		return image is not null;
 	}
 
@@ -130,7 +124,7 @@ public partial class IconTintColorBehavior
 
 	void LoadAndApplyImageTintColor(View element, WImage image, Color color)
 	{
-		// In toggle source button, WImage source is not initially correct, 
+		// Sometimes WImage source doesn't match View source so the image is not ready to be tinted, have to wait for next ImageOpened event
 		if (element is IImageElement { Source: FileImageSource fileImageSource } &&
 			image.Source is BitmapImage bitmapImage &&
 			Uri.Compare(new Uri($"{bitmapImage.UriSource.Scheme}:///{fileImageSource.File}"), bitmapImage.UriSource, UriComponents.Path, UriFormat.Unescaped, StringComparison.OrdinalIgnoreCase) != 0)

--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.windows.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.windows.cs
@@ -140,10 +140,6 @@ public partial class IconTintColorBehavior
 
 			ApplyTintColor();
 		}
-		else if (image.IsLoaded)
-		{
-			ApplyTintColor();
-		}
 		else
 		{
 			image.ImageOpened += OnImageOpened;

--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.windows.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.windows.cs
@@ -124,6 +124,12 @@ public partial class IconTintColorBehavior
 
 	void LoadAndApplyImageTintColor(View element, WImage image, Color color)
 	{
+		// Sometimes image source is not correct, in that case get the correct source from element
+		if (element is IImageElement { Source: FileImageSource fileImageSource })
+		{
+			image.Source = new BitmapImage(new Uri($"ms-appx:///{fileImageSource.File}"));
+		}
+
 		if (element is IImageElement { Source: UriImageSource uriImageSource })
 		{
 			image.Source = Path.GetExtension(uriImageSource.Uri.AbsolutePath) switch
@@ -132,6 +138,10 @@ public partial class IconTintColorBehavior
 				_ => new BitmapImage(uriImageSource.Uri)
 			};
 
+			ApplyTintColor();
+		}
+		else if (image.IsLoaded)
+		{
 			ApplyTintColor();
 		}
 		else


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

On Windows, if an image was already loaded (ie. after loading the page then navigating away and back to the page) the tint color is no longer applied because the ImageOpened event is not triggered. Adding a check for if the image is already loaded fixes this, but then causes an issue with the ToggleImageSource button. This was fixed by adding another check to see if the WImage source and the View source was the same, if not that means the toggle hasn't happened yet so we wait for the ImageOpened event to apply the tint.

This change also fixes the issue with the change tint color button not working in the sample app.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #1595 
 and #1957 (seem to be referring to the same issue)
- Fixes #1734

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###
OS: Windows 10

Testing the behavior is fixed: go to the IconTintColorBehavior page, click on a different page in the FlyoutMenu, then click back on Behaviors (which should still show the IconTintColorBehavior). Before these changes, when navigating back some tint colors weren't applied.