### PR TITLE
Catch ObjectDisposedException in IconTintColorBehavior

### DIFF
--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.android.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.android.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Diagnostics;
 using Android.Graphics;
 using Android.Widget;
 using Microsoft.Maui.Platform;
@@ -44,22 +45,29 @@ public partial class IconTintColorBehavior
 			return;
 		}
 
-		switch (nativeView)
+		try
 		{
-			case ImageView image:
-				SetImageViewTintColor(image, tintColor);
-				break;
+			switch (nativeView)
+			{
+				case ImageView image:
+					SetImageViewTintColor(image, tintColor);
+					break;
 
-			case AndroidMaterialButton materialButton when tintColor is not null:
-				SetMaterialButtonTintColor(materialButton, tintColor);
-				break;
+				case AndroidMaterialButton materialButton when tintColor is not null:
+					SetMaterialButtonTintColor(materialButton, tintColor);
+					break;
 
-			case AndroidWidgetButton widgetButton:
-				SetWidgetButtonTintColor(widgetButton, tintColor);
-				break;
+				case AndroidWidgetButton widgetButton:
+					SetWidgetButtonTintColor(widgetButton, tintColor);
+					break;
 
-			default:
-				throw new NotSupportedException($"{nameof(IconTintColorBehavior)} only currently supports Android.Widget.Button and {nameof(ImageView)}.");
+				default:
+					throw new NotSupportedException($"{nameof(IconTintColorBehavior)} only currently supports Android.Widget.Button and {nameof(ImageView)}.");
+			}
+		}
+		catch (ObjectDisposedException)
+		{
+			Trace.WriteLine("IconTintColorBehavior is already disposed.");
 		}
 
 		static void SetImageViewTintColor(ImageView image, Color? color)
@@ -109,22 +117,29 @@ public partial class IconTintColorBehavior
 			return;
 		}
 
-		switch (nativeView)
+		try
 		{
-			case ImageView image:
-				image.ClearColorFilter();
-				break;
+			switch (nativeView)
+			{
+				case ImageView image:
+					image.ClearColorFilter();
+					break;
 
-			case AndroidMaterialButton mButton:
-				mButton.IconTint = null;
-				break;
-			case AndroidWidgetButton button:
-				foreach (var drawable in button.GetCompoundDrawables())
-				{
-					drawable.ClearColorFilter();
-				}
+				case AndroidMaterialButton mButton:
+					mButton.IconTint = null;
+					break;
+				case AndroidWidgetButton button:
+					foreach (var drawable in button.GetCompoundDrawables())
+					{
+						drawable.ClearColorFilter();
+					}
 
-				break;
+					break;
+			}
+		}
+		catch (ObjectDisposedException)
+		{
+			Trace.WriteLine("IconTintColorBehavior is already disposed.");
 		}
 	}
 

--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.android.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.android.cs
@@ -138,7 +138,6 @@ public partial class IconTintColorBehavior
 		}
 		catch (ObjectDisposedException)
 		{
-			Trace.WriteLine("IconTintColorBehavior is already disposed.");
 		}
 	}
 

--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.android.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.android.cs
@@ -67,7 +67,6 @@ public partial class IconTintColorBehavior
 		}
 		catch (ObjectDisposedException)
 		{
-			Trace.WriteLine("IconTintColorBehavior is already disposed.");
 		}
 
 		static void SetImageViewTintColor(ImageView image, Color? color)


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###
 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->
Related to the last PR for this issue (#2012). This PR explicitly catches ObjectDisposedException in the same way as [TouchBehavior](https://github.com/CommunityToolkit/Maui/blob/main/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/Touch/TouchBehavior.android.cs#L105). Not an optimal solution, but it's a simple fix and makes absolutely sure that it won't crash the app.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #1819 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [X] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [X] Rebased on top of `main` at time of PR
 - [X] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###
<!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
Android only, occurs in a production application. After the previous PR the crash couldn't be reproduced, but a few occurrences were spotted in error reporting.

