### PR TITLE
Update to Xcode 15.4 in CI pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,8 +26,8 @@ variables:
   PathToCommunityToolkitMediaElementAnalyzersCodeFixCsproj: 'src/CommunityToolkit.Maui.MediaElement.Analyzers.CodeFixes/CommunityToolkit.Maui.MediaElement.Analyzers.CodeFixes.csproj'
   PathToCommunityToolkitAnalyzersUnitTestCsproj: 'src/CommunityToolkit.Maui.Analyzers.UnitTests/CommunityToolkit.Maui.Analyzers.UnitTests.csproj'
   DotNetMauiRollbackFile: 'https://maui.blob.core.windows.net/metadata/rollbacks/8.0.6.json'
-  CommunityToolkitSampleApp_Xcode_Version: '15.2.0'
-  CommunityToolkitLibrary_Xcode_Version: '15.3.0'
+  CommunityToolkitSampleApp_Xcode_Version: '15.4'
+  CommunityToolkitLibrary_Xcode_Version: '15.4'
 
 trigger:
   branches:


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###
CI pipelines are currently broken with:
```
ILLINK : warning MT0079: The recommended Xcode version for Microsoft.MacCatalyst 17.5.8018 is Xcode 15.4 or later. The current Xcode version (found in /Applications/Xcode_15.2.0.app/Contents/Developer) is 15.2. [/Users/runner/work/1/s/samples/CommunityToolkit.Maui.Sample/CommunityToolkit.Maui.Sample.csproj::TargetFramework=net8.0-maccatalyst]
ILLink : unknown error IL7000: An error occured while executing the custom linker steps. Please review the build log for more information. [/Users/runner/work/1/s/samples/CommunityToolkit.Maui.Sample/CommunityToolkit.Maui.Sample.csproj::TargetFramework=net8.0-ios]
ILLINK : error MT0180: This version of Microsoft.iOS requires the iOS 17.5 SDK (shipped with Xcode 15.4). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options > Linker Behavior (to try to avoid the new APIs). [/Users/runner/work/1/s/samples/CommunityToolkit.Maui.Sample/CommunityToolkit.Maui.Sample.csproj::TargetFramework=net8.0-ios]
ILLINK : error MT2301: The linker step 'Setup' failed during processing: This version of Microsoft.iOS requires the iOS 17.5 SDK (shipped with Xcode 15.4). Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link Framework SDKs Only in your project's iOS Build Options > Linker Behavior (to try to avoid the new APIs). [/Users/runner/work/1/s/samples/CommunityToolkit.Maui.Sample/CommunityToolkit.Maui.Sample.csproj::TargetFramework=net8.0-ios]
/Users/runner/.nuget/packages/microsoft.net.illink.tasks/8.0.7/build/Microsoft.NET.ILLink.targets(87,5): error NETSDK1144: Optimizing assemblies for size failed. Optimization can be disabled by setting the PublishTrimmed property to false. [/Users/runner/work/1/s/samples/CommunityToolkit.Maui.Sample/CommunityToolkit.Maui.Sample.csproj::TargetFramework=net8.0-ios]
```
 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [ ] Rebased on top of `main` at time of PR
 - [ ] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
