### PR TITLE
Fix Touch Behavior Cancelled too fast if user just tap it once

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/TouchBehavior/TouchBehaviorPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/TouchBehavior/TouchBehaviorPage.xaml
@@ -223,7 +223,7 @@
                         <mct:TouchBehavior
                             BindingContext="{Binding Path=BindingContext, Source={x:Reference CurrentPage}, x:DataType=ContentPage}"
                             Command="{Binding IncreaseTouchCountCommand}"
-                            DefaultAnimationDuration="150"
+                            DefaultAnimationDuration="500"
                             DefaultAnimationEasing="{x:Static Easing.CubicInOut}"
                             PressedBackgroundColor="LightGray"
                             PressedOpacity="0.8"

--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/Touch/GestureManager.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/Touch/GestureManager.shared.cs
@@ -93,7 +93,15 @@ sealed partial class GestureManager : IDisposable, IAsyncDisposable
 		var touchState = touchBehavior.CurrentTouchState;
 		var hoverState = touchBehavior.CurrentHoverState;
 
-		await AbortAnimations(touchBehavior, token);
+		if (touchBehavior.DefaultAnimationDuration > 0 && touchStatus == TouchStatus.Completed)
+		{
+			await Task.Delay(touchBehavior.DefaultAnimationDuration, token);
+		}
+		else
+		{
+			await AbortAnimations(touchBehavior, token);
+		}
+
 		animationTokenSource = new CancellationTokenSource();
 
 		if (touchBehavior.Element is not null)


### PR DESCRIPTION
 ### Description of Change ###
When user tap the button or element that have `TouchBehavior`, the `TouchBehavior` animation didn't respect `DefaultAnimationDuration` to finish the animation. So basically after user tap it will directly cancel and it will throw stacktrace
```
System.Threading.Tasks.TaskCanceledException: A task was canceled.
   at CommunityToolkit.Maui.Behaviors.GestureManager.SetScale(TouchBehavior sender, TouchState touchState, HoverState hoverState, TimeSpan duration, Easing easing, CancellationToken token) in /Users/albilaga/Documents/Personal/CommunityToolkit.Maui/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/Touch/GestureManager.shared.cs:line 475
   at CommunityToolkit.Maui.Behaviors.GestureManager.RunAnimationTask(TouchBehavior sender, TouchState touchState, HoverState hoverState, CancellationToken token, Nullable`1 durationMultiplier) in /Users/albilaga/Documents/Personal/CommunityToolkit.Maui/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/Touch/GestureManager.shared.cs:line 799
   at CommunityToolkit.Maui.Behaviors.GestureManager.ChangeStateAsync(TouchBehavior sender, Boolean animated, CancellationToken token) in /Users/albilaga/Documents/Personal/CommunityToolkit.Maui/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/Touch/GestureManager.shared.cs:line 118
   at CommunityToolkit.Maui.Behaviors.TouchBehavior.ForceUpdateState(CancellationToken token, Boolean animated) in /Users/albilaga/Documents/Personal/CommunityToolkit.Maui/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/Touch/TouchBehavior.methods.shared.cs:line 65
System.Threading.Tasks.TaskCanceledException: A task was canceled.
```
This PR attempt to fix that by waiting with `Task.Delay` from `DefaultAnimationDuration` instead of just directly abort it 

 ### Linked Issues ###
 - Fixes #2063

 ### PR Checklist ###

 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->
