### PR TITLE
Enhance media player with artwork display support

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.android.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Android.Content;
 using Android.Graphics;
+using Android.Graphics.Drawables;
 using Android.OS;
 using Android.Support.V4.Media;
 using Android.Support.V4.Media.Session;
@@ -659,7 +660,14 @@ public partial class MediaManager : Java.Lang.Object, IPlayer.IListener
 			await checkPermissionsTask.WaitAsync(cancellationToken);
 		}
 
+		ArgumentNullException.ThrowIfNull(PlayerView);
+		PlayerView.ArtworkDisplayMode = StyledPlayerView.ArtworkDisplayModeFit;
+		Android.Content.Context? context = Platform.AppContext;
+		Android.Content.Res.Resources? resources = context.Resources;
+
 		var bitmap = await GetBitmapFromUrl(MediaElement.MetadataArtworkUrl, cancellationToken);
+		PlayerView.DefaultArtwork = new BitmapDrawable(resources, bitmap);
+
 		var mediaMetadata = new MediaMetadataCompat.Builder();
 		mediaMetadata.PutString(MediaMetadataCompat.MetadataKeyArtist, MediaElement.MetadataArtist);
 		mediaMetadata.PutString(MediaMetadataCompat.MetadataKeyTitle, MediaElement.MetadataTitle);


### PR DESCRIPTION
 - Bug fix

 ### Description of Change ###

Add poster support for artwork in Android when using MediaElement. When you play music it will now show a default poster from metadata artwork Url if present.

 ### Linked Issues ###

 - Fixes #2107

 ### PR Checklist ###
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###


 

https://github.com/user-attachments/assets/d3dad3d2-bd06-4dcd-a64c-45c49fe56748

