### PR TITLE
Make iOS StatusBarBehavior more robust and not throw exceptions

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/StatusBarBehaviorPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Behaviors/StatusBarBehaviorPage.xaml
@@ -86,7 +86,7 @@
             <Label Text="Red" />
             <Slider
                 Margin="20,0"
-                Maximum="255"
+                Maximum="1"
                 MaximumTrackColor="Red"
                 Minimum="0"
                 MinimumTrackColor="Red"
@@ -96,7 +96,7 @@
             <Label Text="Green" />
             <Slider
                 Margin="20,0"
-                Maximum="255"
+                Maximum="1"
                 MaximumTrackColor="Green"
                 Minimum="0"
                 MinimumTrackColor="Green"
@@ -106,7 +106,7 @@
             <Label Text="Blue" />
             <Slider
                 Margin="20,0"
-                Maximum="255"
+                Maximum="1"
                 MaximumTrackColor="Blue"
                 Minimum="0"
                 MinimumTrackColor="Blue"

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Behaviors/StatusBarBehaviorViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Behaviors/StatusBarBehaviorViewModel.cs
@@ -6,7 +6,7 @@ public partial class StatusBarBehaviorViewModel : BaseViewModel
 {
 	[ObservableProperty]
 	[NotifyPropertyChangedFor(nameof(StatusBarColor))]
-	int redSliderValue, greenSliderValue, blueSliderValue;
+	double redSliderValue, greenSliderValue, blueSliderValue;
 
 	[ObservableProperty]
 	[NotifyPropertyChangedFor(nameof(StatusBarColor))]

--- a/src/CommunityToolkit.Maui.Core/Platform/StatusBar/StatusBar.ios.cs
+++ b/src/CommunityToolkit.Maui.Core/Platform/StatusBar/StatusBar.ios.cs
@@ -128,13 +128,13 @@ static partial class StatusBar
 
 	static void UpdateStatusBarAppearance(UIWindow? window)
 	{
-		var vc = window?.RootViewController ?? WindowStateManager.Default.GetCurrentUIViewController() ?? throw new InvalidOperationException($"{nameof(window.RootViewController)} cannot be null");
+		var vc = window?.RootViewController ?? WindowStateManager.Default.GetCurrentUIViewController();
 
-		while (vc.PresentedViewController is not null)
+		while (vc?.PresentedViewController is not null)
 		{
 			vc = vc.PresentedViewController;
 		}
 
-		vc.SetNeedsStatusBarAppearanceUpdate();
+		vc?.SetNeedsStatusBarAppearanceUpdate();
 	}
 }

--- a/src/CommunityToolkit.Maui.Core/Platform/StatusBar/StatusBar.ios.cs
+++ b/src/CommunityToolkit.Maui.Core/Platform/StatusBar/StatusBar.ios.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Versioning;
+﻿using System.Diagnostics;
+using System.Runtime.Versioning;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Platform;
 
@@ -7,6 +8,48 @@ namespace CommunityToolkit.Maui.Core.Platform;
 [UnsupportedOSPlatform("MacCatalyst")]
 static partial class StatusBar
 {
+	/// <summary>
+	/// Method to update the status bar size.
+	/// </summary>
+	public static void UpdateBarSize()
+	{
+		if (OperatingSystem.IsIOSVersionAtLeast(13))
+		{
+			var statusBarTag = new IntPtr(38482);
+			foreach (var window in UIApplication.SharedApplication.Windows)
+			{
+				var statusBar = window.ViewWithTag(statusBarTag);
+				var statusBarFrame = window.WindowScene?.StatusBarManager?.StatusBarFrame;
+				if (statusBarFrame is null)
+				{
+					continue;
+				}
+
+				statusBar ??= new UIView(statusBarFrame.Value);
+				statusBar.Tag = statusBarTag;
+				statusBar.Frame = UIApplication.SharedApplication.StatusBarFrame;
+				var statusBarSubViews = window.Subviews.Where(x => x.Tag == statusBarTag).ToList();
+				foreach (var statusBarSubView in statusBarSubViews)
+				{
+					statusBarSubView.RemoveFromSuperview();
+				}
+
+				window.AddSubview(statusBar);
+
+				TryUpdateStatusBarAppearance(window);
+			}
+		}
+		else
+		{
+			if (UIApplication.SharedApplication.ValueForKey(new NSString("statusBar")) is UIView statusBar)
+			{
+				statusBar.Frame = UIApplication.SharedApplication.StatusBarFrame;
+			}
+
+			TryUpdateStatusBarAppearance();
+		}
+	}
+	
 	static void PlatformSetColor(Color color)
 	{
 		var uiColor = color.ToPlatform();
@@ -38,7 +81,7 @@ static partial class StatusBar
 
 				window.AddSubview(statusBar);
 
-				UpdateStatusBarAppearance(window);
+				TryUpdateStatusBarAppearance(window);
 			}
 		}
 		else
@@ -49,7 +92,7 @@ static partial class StatusBar
 				statusBar.BackgroundColor = uiColor;
 			}
 
-			UpdateStatusBarAppearance();
+			TryUpdateStatusBarAppearance();
 		}
 	}
 
@@ -65,76 +108,46 @@ static partial class StatusBar
 
 		UIApplication.SharedApplication.SetStatusBarStyle(uiStyle, false);
 
-		UpdateStatusBarAppearance();
+		TryUpdateStatusBarAppearance();
 	}
 
-	/// <summary>
-	/// Method to update the status bar size.
-	/// </summary>
-	public static void UpdateBarSize()
+	static bool TryUpdateStatusBarAppearance()
 	{
 		if (OperatingSystem.IsIOSVersionAtLeast(13))
 		{
-			var statusBarTag = new IntPtr(38482);
+			var didUpdateAllStatusBars = true;
+			
 			foreach (var window in UIApplication.SharedApplication.Windows)
 			{
-				var statusBar = window.ViewWithTag(statusBarTag);
-				var statusBarFrame = window.WindowScene?.StatusBarManager?.StatusBarFrame;
-				if (statusBarFrame is null)
-				{
-					continue;
-				}
-
-				statusBar ??= new UIView(statusBarFrame.Value);
-				statusBar.Tag = statusBarTag;
-				statusBar.Frame = UIApplication.SharedApplication.StatusBarFrame;
-				var statusBarSubViews = window.Subviews.Where(x => x.Tag == statusBarTag).ToList();
-				foreach (var statusBarSubView in statusBarSubViews)
-				{
-					statusBarSubView.RemoveFromSuperview();
-				}
-
-				window.AddSubview(statusBar);
-
-				UpdateStatusBarAppearance(window);
-			}
-		}
-		else
-		{
-			if (UIApplication.SharedApplication.ValueForKey(new NSString("statusBar")) is UIView statusBar)
-			{
-				statusBar.Frame = UIApplication.SharedApplication.StatusBarFrame;
+				didUpdateAllStatusBars &= TryUpdateStatusBarAppearance(window);
 			}
 
-			UpdateStatusBarAppearance();
-		}
-	}
-
-	static void UpdateStatusBarAppearance()
-	{
-		if (OperatingSystem.IsIOSVersionAtLeast(13))
-		{
-			foreach (var window in UIApplication.SharedApplication.Windows)
-			{
-				UpdateStatusBarAppearance(window);
-			}
+			return didUpdateAllStatusBars;
 		}
 		else
 		{
 			var window = UIApplication.SharedApplication.KeyWindow;
-			UpdateStatusBarAppearance(window);
+			return TryUpdateStatusBarAppearance(window);
 		}
 	}
 
-	static void UpdateStatusBarAppearance(UIWindow? window)
+	static bool TryUpdateStatusBarAppearance(UIWindow? window)
 	{
 		var vc = window?.RootViewController ?? WindowStateManager.Default.GetCurrentUIViewController();
 
-		while (vc?.PresentedViewController is not null)
+		if (vc is null)
+		{
+			Trace.WriteLine("Unable to update Status Bar Appearance because Current UIViewController is null");
+			return false;
+		}
+
+		while (vc.PresentedViewController is not null)
 		{
 			vc = vc.PresentedViewController;
 		}
 
-		vc?.SetNeedsStatusBarAppearanceUpdate();
+		vc.SetNeedsStatusBarAppearanceUpdate();
+
+		return true;
 	}
 }


### PR DESCRIPTION
### Description of Change ###

While working on a Blazor Hybrid project I implemented the StatusBarBehavior. I also added the new way of setting the root page for a .NET MAUI app by not using MainPage (also see #2054)

I ran into an issue that when setting the status bar color from XAML, I would get an exception. Probably due to the fact that the window isn't created yet, but the page is being created that wants to set the status bar.

To be ahead of the curve for this new change in .NET MAUI, I adapted this code a little so that it doesn't thrown an exception but handles it more gracefully. The actual functionality still seems to work fine.

 
