### PR TITLE
Removed spare Element checking in OnDetachedFrom

### DIFF
--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/Touch/TouchBehavior.android.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/Touch/TouchBehavior.android.cs
@@ -75,11 +75,6 @@ public partial class TouchBehavior
 
 		view = platformView;
 
-		if (Element is null)
-		{
-			return;
-		}
-
 		try
 		{
 			if (accessibilityManager is not null && accessibilityListener is not null)


### PR DESCRIPTION
 ### Description of Change ###

Take look into `OnDetachedFrom()`
```CSharp
	protected override void OnDetachedFrom(VisualElement bindable, AView platformView)
	{
		base.OnDetachedFrom(bindable, platformView);

		view = platformView;

		if (Element is null)
		{
			return;
		}
...
```
We exiting when `Element` is null.
The thing is that  `Element`  is always null because it returns a `View`  and `base.OnDetachedFrom()` calls `UnassignViewAndBingingContext()` which sets it to null. 

 ### Linked Issues ###

 - Fixes #2082

 ### PR Checklist ###
 - [x ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x ] Rebased on top of `main` at time of PR
 - [ x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls 

Sample code is not needed. You can check it using a `CommunityToolkit.Maui.Sample` by  placing a breakpoint at 
`TouchBehaviou.android.cs:76` (or somewhere else in `OnDetachedFrom()`) and checking an `Element`.

 ### Additional information ###

 
