### PR TITLE
Remove log messages that were confusing and not required.

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Services/MediaControlsService.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Services/MediaControlsService.android.cs
@@ -230,7 +230,6 @@ class MediaControlsService : Service
 	{
 		if (Build.VERSION.SdkInt >= BuildVersionCodes.Tiramisu)
 		{
-			System.Diagnostics.Trace.WriteLine($"{LocalBroadcastManager.GetInstance} not supported on Android 13 and above.");
 			return;
 		}
 		var intent = new Intent(receiver);

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.android.cs
@@ -703,7 +703,6 @@ public partial class MediaManager : Java.Lang.Object, IPlayer.IListener
 	{
 		if (Build.VERSION.SdkInt >= BuildVersionCodes.Tiramisu)
 		{
-			Logger.LogError("{LocalBroadcastManager} not supported on Android 13 and above.", typeof(LocalBroadcastManager));
 			return;
 		}
 		Intent intent = new(MediaControlsService.ACTION_UPDATE_UI);


### PR DESCRIPTION
 - Bug fix

 ### Description of Change ###

Remove confusing log Message in `MediaElement` that led to questions about app behavior.


 ### PR Checklist ###

 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

There was a question asked on StackOverflow about the error message and its possible implications in an app crash from a developer. The log message displayed an error about a class being deprecated as of Android 33. This log message has no impact on behavior and has confused developers about the apps behavior. This PR removes the message as it is not needed and is confusing people
 
