### PR TITLE
Fix MediaElement CTD on Windows

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.windows.cs
@@ -353,6 +353,12 @@ partial class MediaManager : IDisposable
 
 		metadata ??= new(systemMediaControls, MediaElement, Dispatcher);
 		metadata.SetMetadata(MediaElement);
+		
+		if(string.IsNullOrEmpty(MediaElement.MetadataArtworkUrl))
+		{
+			// NOTE: MediaElement cannot have a null or empty MetadataArtworkUrl. 
+			return;
+		}
 		Dispatcher.Dispatch(() => Player.PosterSource = new BitmapImage(new Uri(MediaElement.MetadataArtworkUrl)));
 	}
 

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.windows.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using CommunityToolkit.Maui.Core.Primitives;
 using CommunityToolkit.Maui.Views;
 using Microsoft.Extensions.Logging;
@@ -344,7 +345,7 @@ partial class MediaManager : IDisposable
 		}
 	}
 
-	void UpdateMetadata()
+	async ValueTask UpdateMetadata()
 	{
 		if (systemMediaControls is null || Player is null)
 		{
@@ -353,16 +354,29 @@ partial class MediaManager : IDisposable
 
 		metadata ??= new(systemMediaControls, MediaElement, Dispatcher);
 		metadata.SetMetadata(MediaElement);
-		
-		if(string.IsNullOrEmpty(MediaElement.MetadataArtworkUrl))
+
+		if (!Uri.TryCreate(MediaElement.MetadataArtworkUrl, UriKind.RelativeOrAbsolute, out var metadataArtworkUri))
 		{
-			// NOTE: MediaElement cannot have a null or empty MetadataArtworkUrl. 
+			Trace.WriteLine($"{nameof(MediaElement)} unable to update artwork because {nameof(MediaElement.MetadataArtworkUrl)} is not a valid URI");
 			return;
 		}
-		Dispatcher.Dispatch(() => Player.PosterSource = new BitmapImage(new Uri(MediaElement.MetadataArtworkUrl)));
+
+		if (Dispatcher.IsDispatchRequired)
+		{
+			await Dispatcher.DispatchAsync(() => UpdatePosterSource(Player, metadataArtworkUri));
+		}
+		else
+		{
+			UpdatePosterSource(Player, metadataArtworkUri);
+		}
+
+		static void UpdatePosterSource(in MediaPlayerElement player, in Uri metadataArtworkUri)
+		{
+			player.PosterSource = new BitmapImage(metadataArtworkUri);
+		}
 	}
 
-	void OnMediaElementMediaOpened(WindowsMediaElement sender, object args)
+	async void OnMediaElementMediaOpened(WindowsMediaElement sender, object args)
 	{
 		if (Player is null)
 		{
@@ -380,7 +394,7 @@ partial class MediaManager : IDisposable
 
 		MediaElement.MediaOpened();
 
-		UpdateMetadata();
+		await UpdateMetadata();
 
 		static void SetDuration(in IMediaElement mediaElement, in MediaPlayerElement mediaPlayerElement)
 		{

--- a/src/CommunityToolkit.Maui.UnitTests/Views/MediaElement/MediaElementTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/MediaElement/MediaElementTests.cs
@@ -13,6 +13,23 @@ public class MediaElementTests : BaseHandlerTest
 	}
 
 	[Fact]
+	public void PosterIsNotStringEmptyorNull()
+	{
+		MediaElement mediaElement = new();
+		mediaElement.MetadataArtworkUrl = "https://www.example.com/image.jpg";
+		Assert.True(!string.IsNullOrEmpty(mediaElement.MetadataArtworkUrl));
+	}
+
+	[Fact]
+	public void PosterIsStringEmptyDoesNotThrow()
+	{
+		MediaElement mediaElement = new();
+		mediaElement.MetadataArtworkUrl = string.Empty;
+		Assert.True(string.IsNullOrEmpty(mediaElement.MetadataArtworkUrl));
+		Assert.True(mediaElement.MetadataArtworkUrl == string.Empty);
+	}
+
+	[Fact]
 	public void BindingContextPropagation()
 	{
 		object context = new();


### PR DESCRIPTION
 - Bug fix

 ### Description of Change ###

- Updated `UpdateMetadata` in `MediaManager.windows.cs` to return early if `MediaElement.MetadataArtworkUrl` is null or empty.
- Added tests in `MediaElementTests.cs`:
  - `PosterIsNotStringEmptyorNull`: Verifies `MetadataArtworkUrl` is not null or empty when set to a valid URL.
  - `PosterIsStringEmptyDoesNotThrow`: Ensures no exceptions when `MetadataArtworkUrl` is an empty string and correctly identifies it as empty.
  - 
 ### Linked Issues ###
 - Fixes

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###
Fixes a nasty bug where App crashes when you do not set artwork for media element. When setting poster we cannot set it to string empty. That is what is crashing windows. Added `string.IsNullOrEmpty` check to `MediaElement.MetadataArtworkUrl` so that we do not set the poster if it is not present.
 
