### PR TITLE
Fix Android App Exit On Back button pressed

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Services/MediaControlsService.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Services/MediaControlsService.android.cs
@@ -220,10 +220,6 @@ class MediaControlsService : Service
 	public override void OnDestroy()
 	{
 		Platform.CurrentActivity?.StopService(new Intent(Platform.AppContext, typeof(MediaControlsService)));
-		System.Diagnostics.Trace.TraceInformation("MediaControlsService destroyed.");
-		Platform.CurrentActivity?.FinishAndRemoveTask();
-		System.Environment.Exit(0);
-		System.Diagnostics.Trace.TraceInformation("Application exiting.");
 		base.OnDestroy();
 	}
 	static void BroadcastUpdate(string receiver, string action)


### PR DESCRIPTION
 - Bug fix

 ### Description of Change ###
In Android service destroy method the app was exiting. I removed the app exit method calls and now the destroy method only shuts the service down. This is still required as pressing back button to exit page should close service.

 ### Linked Issues ###

 - Fixes #2143

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

 I had put a call to exit app in the Destroy method for Android notification service and did not realize the back button would call it. It has been removed now. I tested against the provided sample and the app does not close when pressing back button in Android now. I kept the call to end service when you leave page. 

I need that to be there for lifecycle behavior when app is restored from being killed by OS it is retaining state when it should not. This `Platform.CurrentActivity?.StopService(new Intent(Platform.AppContext, typeof(MediaControlsService)));` line of code that is now in destroy method in collaboration with  calling `android:stopWithTask="true"` in manifest file prevents the app from restoring. I like the idea of app restore but many developers complained about this not being expected.