### PR TITLE
Fix MediaElement CTD in Windows

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.windows.cs
@@ -354,7 +354,7 @@ partial class MediaManager : IDisposable
 
 		metadata ??= new(systemMediaControls, MediaElement, Dispatcher);
 		metadata.SetMetadata(MediaElement);
-		if(string.IsNullOrEmpty(MediaElement.MetadataArtworkUrl))
+		if (string.IsNullOrEmpty(MediaElement.MetadataArtworkUrl))
 		{
 			return;
 		}

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.windows.cs
@@ -354,7 +354,10 @@ partial class MediaManager : IDisposable
 
 		metadata ??= new(systemMediaControls, MediaElement, Dispatcher);
 		metadata.SetMetadata(MediaElement);
-
+		if(string.IsNullOrEmpty(MediaElement.MetadataArtworkUrl))
+		{
+			return;
+		}
 		if (!Uri.TryCreate(MediaElement.MetadataArtworkUrl, UriKind.RelativeOrAbsolute, out var metadataArtworkUri))
 		{
 			Trace.WriteLine($"{nameof(MediaElement)} unable to update artwork because {nameof(MediaElement.MetadataArtworkUrl)} is not a valid URI");


### PR DESCRIPTION
 - Bug fix
  

 ### Description of Change ###

 Add null check for `MediaElement.MetadataArtworkUrl` in `UpdateMetadata` to fix a crash to desktop in Windows. This fixes an issue where the application will crash if the artwork URL is a `string.empty` which is the default if developer does not set the value.

 ### Linked Issues ###

 - Fixes #2150

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->
 

 
