### PR TITLE
Add missing setter for AnimateCommand

### DIFF
--- a/src/CommunityToolkit.Maui/Behaviors/AnimationBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/AnimationBehavior.shared.cs
@@ -28,7 +28,10 @@ public class AnimationBehavior : EventToCommandBehavior
 	/// <remarks>
 	/// <see cref="AnimateCommand"/> has a <see cref="Type"/> of Command&lt;CancellationToken&gt; which requires a <see cref="CancellationToken"/> as a CommandParameter. See <see cref="Command{CancellationToken}"/> and <see cref="System.Windows.Input.ICommand.Execute(object)"/> for more information on passing a <see cref="CancellationToken"/> into <see cref="Command{T}"/> as a CommandParameter"
 	/// </remarks>
-	public Command<CancellationToken> AnimateCommand => (Command<CancellationToken>)GetValue(AnimateCommandProperty);
+	public Command<CancellationToken> AnimateCommand {
+		get => (Command<CancellationToken>)GetValue(AnimateCommandProperty);
+		set => SetValue(AnimateCommandProperty, value);
+	}
 
 	/// <summary>
 	/// The type of animation to perform.


### PR DESCRIPTION
 ### Description of Change ###

Fix https://developercommunity.visualstudio.com/t/Hot-reload-stops-working-when-using-Comm/10707756

Control properties should have both a getter and setter so that Hot Reload (and C# code) can update them.
AnimateCommand was missing the setter - likely just an oversight. Hot Reload now works with this change.

<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->

 ### Linked Issues ###
 - Fixes # https://developercommunity.visualstudio.com/t/Hot-reload-stops-working-when-using-Comm/10707756

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
