### PR TITLE
Changed to call Popup's MapOnClosed method

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Handlers/Popup/PopupHandler.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Handlers/Popup/PopupHandler.shared.cs
@@ -23,9 +23,9 @@ public partial class PopupHandler
 	/// </summary>
 	public static CommandMapper<IPopup, PopupHandler> PopUpCommandMapper = new(ElementCommandMapper)
 	{
-		[nameof(IPopup.OnClosed)] = MapOnClosed,
 #if !(IOS || MACCATALYST)
 		[nameof(IPopup.OnOpened)] = MapOnOpened,
+		[nameof(IPopup.OnClosed)] = MapOnClosed,
 #endif
 		[nameof(IPopup.OnDismissedByTappingOutsideOfPopup)] = MapOnDismissedByTappingOutsideOfPopup
 	};

--- a/src/CommunityToolkit.Maui/HandlerImplementation/Popup/Popup.macios.cs
+++ b/src/CommunityToolkit.Maui/HandlerImplementation/Popup/Popup.macios.cs
@@ -44,6 +44,8 @@ public partial class Popup
 	/// <param name="result">We don't need to provide the result parameter here.</param>
 	public static void MapOnClosed(PopupHandler handler, IPopup view, object? result)
 	{
+		PopupHandler.MapOnClosed(handler, view, result);
+
 		var parent = view.Parent as Element;
 		if (parent is not null)
 		{


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

In this PR, by applying PR #2166, we resolve the issue where Popup is not closed when the Close or CloseAsync method is called.

 ### Description of Change ###

I added the following code to PR #2166.

[src\CommunityToolkit.Maui\HandlerImplementation\Popup\Popup.shared.cs]

```
	public static CommandMapper<IPopup, PopupHandler> ControlPopUpCommandMapper = new(PopupHandler.PopUpCommandMapper)
	{
#if IOS || MACCATALYST
		[nameof(IPopup.OnOpened)] = MapOnOpened,
		[nameof(IPopup.OnClosed)] = MapOnClosed          // <= here
#endif
	};
```

The above code will no longer call the following method.

[src\CommunityToolkit.Maui.Core\Handlers\Popup\PopupHandler.macios.cs]

```
	public static async void MapOnClosed(PopupHandler handler, IPopup view, object? result)
	{
		var presentationController = handler.PlatformView.PresentationController;
		if (presentationController?.PresentedViewController is UIViewController presentationViewController)
		{
			await presentationViewController.DismissViewControllerAsync(true);
		}

		view.HandlerCompleteTCS.TrySetResult();

		handler.DisconnectHandler(handler.PlatformView);
	}
```

Since the above method is no longer called, the Popup will continue to wait.

Modify the code as below so that the MapOnClosed method is called.

[src\CommunityToolkit.Maui\HandlerImplementation\Popup\Popup.macios.cs]

```
	public static void MapOnClosed(PopupHandler handler, IPopup view, object? result)
	{
		PopupHandler.MapOnClosed(handler, view, result);

		var parent = view.Parent as Element;
		if (parent is not null)
		{
			if (handler.VirtualView is Popup popup)
			{
				if (popup.Content is not null)
				{
					if (popup.Content.Parent is ContentPage contentPage)
					{
						parent.RemoveLogicalChild(contentPage);
					}
				}
				parent.RemoveLogicalChild(popup);
			}
		}
	}
```

Also, remove the MapOnClosed definition from PopupHandler's PopUpCommandMapper only for iOS and MacCatalyst.
PR #2166 lacked this consideration.

[src\CommunityToolkit.Maui.Core\Handlers\Popup\PopupHandler.shared.cs]

```
	public static CommandMapper<IPopup, PopupHandler> PopUpCommandMapper = new(ElementCommandMapper)
	{
#if !(IOS || MACCATALYST)
		[nameof(IPopup.OnOpened)] = MapOnOpened,
		[nameof(IPopup.OnClosed)] = MapOnClosed,
#endif
		[nameof(IPopup.OnDismissedByTappingOutsideOfPopup)] = MapOnDismissedByTappingOutsideOfPopup
	};

```
 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #2201 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

The verification results are shown below.

[Case to call Close method]

https://github.com/user-attachments/assets/4e3a6147-9eee-4e84-8328-d44c666c4dd3

[Case to call CloseAsync method]

https://github.com/user-attachments/assets/e3ae1ea9-655b-4cc3-9afb-e312fc9e0745

You can see that the Popup is closed in both cases.

Below are the verification results for Issue #2149.

[Case of tapping outside of Popup]

https://github.com/user-attachments/assets/718704a8-0fcb-4b44-8782-35b4df117dec

[Case of intentionally calling the close method]

https://github.com/user-attachments/assets/43e913ff-a934-46f6-86f0-1aa1267e47f0

In both cases, you can see that Issue #2149 is resolved.

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->