### PR TITLE
[Housekeeping] Fix `The active test run was aborted. Reason: Test host process crashed`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -272,7 +272,7 @@ jobs:
         displayName: 'Run CommunityToolkit.Maui.Analyzers.UnitTests'
         inputs:
           script: |
-            echo $(VSTEST_TESTHOST_SHUTDOWN_TIMEOUT)
+            echo VSTEST_TESTHOST_SHUTDOWN_TIMEOUT: $(VSTEST_TESTHOST_SHUTDOWN_TIMEOUT)
             dotnet test $(PathToCommunityToolkitAnalyzersUnitTestCsproj) -c Release
 
       - task: CmdLine@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,7 +65,7 @@ jobs:
       vmImage: $(image)
     variables: 
       - name: VSTEST_TESTHOST_SHUTDOWN_TIMEOUT # Fixes "The active test run was aborted. Reason: Test host process crashed" https://dev.azure.com/dotnet/CommunityToolkit/_build/results?buildId=109660&view=logs&j=3f96dcf5-6e1e-5485-3200-c557d5216be3&t=12286b69-c788-55db-0a8c-ef899858fbe6&l=76 (source: https://github.com/microsoft/vstest/issues/2952#issuecomment-2234253765)
-        value: '10000'
+        value: '11000'
     steps:
       - task: CmdLine@2
         displayName: 'Set Xcode v$(CommunityToolkitSampleApp_Xcode_Version)'
@@ -271,7 +271,9 @@ jobs:
       - task: CmdLine@2
         displayName: 'Run CommunityToolkit.Maui.Analyzers.UnitTests'
         inputs:
-          script: 'dotnet test $(PathToCommunityToolkitAnalyzersUnitTestCsproj) -c Release'
+          script: |
+            echo $(VSTEST_TESTHOST_SHUTDOWN_TIMEOUT)
+            dotnet test $(PathToCommunityToolkitAnalyzersUnitTestCsproj) -c Release
 
       - task: CmdLine@2
         displayName: 'Build CommunityToolkit.Maui.Core'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -270,9 +270,7 @@ jobs:
         env:
           VSTEST_TESTHOST_SHUTDOWN_TIMEOUT: 1100 # Fixes "The active test run was aborted. Reason: Test host process crashed" https://dev.azure.com/dotnet/CommunityToolkit/_build/results?buildId=109660&view=logs&j=3f96dcf5-6e1e-5485-3200-c557d5216be3&t=12286b69-c788-55db-0a8c-ef899858fbe6&l=76 (source: https://github.com/microsoft/vstest/issues/2952#issuecomment-2234253765): $(sauceUsername)
         inputs:
-          script: |
-            echo VSTEST_TESTHOST_SHUTDOWN_TIMEOUT: $(VSTEST_TESTHOST_SHUTDOWN_TIMEOUT)
-            dotnet test $(PathToCommunityToolkitAnalyzersUnitTestCsproj) -c Release —-blame
+          script: 'dotnet test $(PathToCommunityToolkitAnalyzersUnitTestCsproj) -c Release —-blame'
 
       - task: CmdLine@2
         displayName: 'Build CommunityToolkit.Maui.Core'
@@ -304,9 +302,7 @@ jobs:
         env:
           VSTEST_TESTHOST_SHUTDOWN_TIMEOUT: 1100 # Fixes "The active test run was aborted. Reason: Test host process crashed" https://dev.azure.com/dotnet/CommunityToolkit/_build/results?buildId=109660&view=logs&j=3f96dcf5-6e1e-5485-3200-c557d5216be3&t=12286b69-c788-55db-0a8c-ef899858fbe6&l=76 (source: https://github.com/microsoft/vstest/issues/2952#issuecomment-2234253765): $(sauceUsername)
         inputs:
-          script: |
-            echo VSTEST_TESTHOST_SHUTDOWN_TIMEOUT: $(VSTEST_TESTHOST_SHUTDOWN_TIMEOUT)
-            dotnet test $(PathToCommunityToolkitUnitTestCsproj) -c Release —-blame --settings ".runsettings" --collect "XPlat code coverage" --logger trx --results-directory $(Agent.TempDirectory)
+          script: 'dotnet test $(PathToCommunityToolkitUnitTestCsproj) -c Release —-blame --settings ".runsettings" --collect "XPlat code coverage" --logger trx --results-directory $(Agent.TempDirectory)'
 
       - task: PublishTestResults@2
         condition: eq(variables['Agent.OS'], 'Windows_NT') # Only run this step on Windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -306,7 +306,7 @@ jobs:
         inputs:
           script: |
             echo VSTEST_TESTHOST_SHUTDOWN_TIMEOUT: $(VSTEST_TESTHOST_SHUTDOWN_TIMEOUT)
-            dotnet test $(PathToCommunityToolkitUnitTestCsproj) -c Release --settings ".runsettings" --collect "XPlat code coverage" --logger trx --results-directory $(Agent.TempDirectory)
+            dotnet test $(PathToCommunityToolkitUnitTestCsproj) -c Release —-blame --settings ".runsettings" --collect "XPlat code coverage" --logger trx --results-directory $(Agent.TempDirectory)
 
       - task: PublishTestResults@2
         condition: eq(variables['Agent.OS'], 'Windows_NT') # Only run this step on Windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -270,7 +270,7 @@ jobs:
         env:
           VSTEST_TESTHOST_SHUTDOWN_TIMEOUT: 1100 # Fixes "The active test run was aborted. Reason: Test host process crashed" https://dev.azure.com/dotnet/CommunityToolkit/_build/results?buildId=109660&view=logs&j=3f96dcf5-6e1e-5485-3200-c557d5216be3&t=12286b69-c788-55db-0a8c-ef899858fbe6&l=76 (source: https://github.com/microsoft/vstest/issues/2952#issuecomment-2234253765): $(sauceUsername)
         inputs:
-          script: 'dotnet test $(PathToCommunityToolkitAnalyzersUnitTestCsproj) -c Release —-blame'
+          script: 'dotnet test $(PathToCommunityToolkitAnalyzersUnitTestCsproj) —-blame-crash -c Release'
 
       - task: CmdLine@2
         displayName: 'Build CommunityToolkit.Maui.Core'
@@ -302,7 +302,7 @@ jobs:
         env:
           VSTEST_TESTHOST_SHUTDOWN_TIMEOUT: 1100 # Fixes "The active test run was aborted. Reason: Test host process crashed" https://dev.azure.com/dotnet/CommunityToolkit/_build/results?buildId=109660&view=logs&j=3f96dcf5-6e1e-5485-3200-c557d5216be3&t=12286b69-c788-55db-0a8c-ef899858fbe6&l=76 (source: https://github.com/microsoft/vstest/issues/2952#issuecomment-2234253765): $(sauceUsername)
         inputs:
-          script: 'dotnet test $(PathToCommunityToolkitUnitTestCsproj) -c Release —-blame --settings ".runsettings" --collect "XPlat code coverage" --logger trx --results-directory $(Agent.TempDirectory)'
+          script: 'dotnet test $(PathToCommunityToolkitUnitTestCsproj) —-blame-crash -c Release --settings ".runsettings" --collect "XPlat code coverage" --logger trx --results-directory $(Agent.TempDirectory)'
 
       - task: PublishTestResults@2
         condition: eq(variables['Agent.OS'], 'Windows_NT') # Only run this step on Windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,6 +63,9 @@ jobs:
           image: 'macos-14'
     pool:
       vmImage: $(image)
+    variables: 
+      - name: VSTEST_TESTHOST_SHUTDOWN_TIMEOUT # Fixes "The active test run was aborted. Reason: Test host process crashed" https://dev.azure.com/dotnet/CommunityToolkit/_build/results?buildId=109660&view=logs&j=3f96dcf5-6e1e-5485-3200-c557d5216be3&t=12286b69-c788-55db-0a8c-ef899858fbe6&l=76 (source: https://github.com/microsoft/vstest/issues/2952#issuecomment-2234253765)
+        value: '10000'
     steps:
       - task: CmdLine@2
         displayName: 'Set Xcode v$(CommunityToolkitSampleApp_Xcode_Version)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,9 +63,6 @@ jobs:
           image: 'macos-14'
     pool:
       vmImage: $(image)
-    variables: 
-      - name: VSTEST_TESTHOST_SHUTDOWN_TIMEOUT # Fixes "The active test run was aborted. Reason: Test host process crashed" https://dev.azure.com/dotnet/CommunityToolkit/_build/results?buildId=109660&view=logs&j=3f96dcf5-6e1e-5485-3200-c557d5216be3&t=12286b69-c788-55db-0a8c-ef899858fbe6&l=76 (source: https://github.com/microsoft/vstest/issues/2952#issuecomment-2234253765)
-        value: '11000'
     steps:
       - task: CmdLine@2
         displayName: 'Set Xcode v$(CommunityToolkitSampleApp_Xcode_Version)'
@@ -270,10 +267,12 @@ jobs:
 
       - task: CmdLine@2
         displayName: 'Run CommunityToolkit.Maui.Analyzers.UnitTests'
+        env:
+          VSTEST_TESTHOST_SHUTDOWN_TIMEOUT: 1100 # Fixes "The active test run was aborted. Reason: Test host process crashed" https://dev.azure.com/dotnet/CommunityToolkit/_build/results?buildId=109660&view=logs&j=3f96dcf5-6e1e-5485-3200-c557d5216be3&t=12286b69-c788-55db-0a8c-ef899858fbe6&l=76 (source: https://github.com/microsoft/vstest/issues/2952#issuecomment-2234253765): $(sauceUsername)
         inputs:
           script: |
             echo VSTEST_TESTHOST_SHUTDOWN_TIMEOUT: $(VSTEST_TESTHOST_SHUTDOWN_TIMEOUT)
-            dotnet test $(PathToCommunityToolkitAnalyzersUnitTestCsproj) -c Release
+            dotnet test $(PathToCommunityToolkitAnalyzersUnitTestCsproj) -c Release —-blame
 
       - task: CmdLine@2
         displayName: 'Build CommunityToolkit.Maui.Core'
@@ -302,8 +301,12 @@ jobs:
 
       - task: CmdLine@2
         displayName: 'Run CommunityToolkit.Maui.UnitTests'
+        env:
+          VSTEST_TESTHOST_SHUTDOWN_TIMEOUT: 1100 # Fixes "The active test run was aborted. Reason: Test host process crashed" https://dev.azure.com/dotnet/CommunityToolkit/_build/results?buildId=109660&view=logs&j=3f96dcf5-6e1e-5485-3200-c557d5216be3&t=12286b69-c788-55db-0a8c-ef899858fbe6&l=76 (source: https://github.com/microsoft/vstest/issues/2952#issuecomment-2234253765): $(sauceUsername)
         inputs:
-          script: 'dotnet test $(PathToCommunityToolkitUnitTestCsproj) -c Release --settings ".runsettings" --collect "XPlat code coverage" --logger trx --results-directory $(Agent.TempDirectory)'
+          script: |
+            echo VSTEST_TESTHOST_SHUTDOWN_TIMEOUT: $(VSTEST_TESTHOST_SHUTDOWN_TIMEOUT)
+            dotnet test $(PathToCommunityToolkitUnitTestCsproj) -c Release --settings ".runsettings" --collect "XPlat code coverage" --logger trx --results-directory $(Agent.TempDirectory)
 
       - task: PublishTestResults@2
         condition: eq(variables['Agent.OS'], 'Windows_NT') # Only run this step on Windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -270,7 +270,7 @@ jobs:
         env:
           VSTEST_TESTHOST_SHUTDOWN_TIMEOUT: 1100 # Fixes "The active test run was aborted. Reason: Test host process crashed" https://dev.azure.com/dotnet/CommunityToolkit/_build/results?buildId=109660&view=logs&j=3f96dcf5-6e1e-5485-3200-c557d5216be3&t=12286b69-c788-55db-0a8c-ef899858fbe6&l=76 (source: https://github.com/microsoft/vstest/issues/2952#issuecomment-2234253765): $(sauceUsername)
         inputs:
-          script: 'dotnet test $(PathToCommunityToolkitAnalyzersUnitTestCsproj) —-blame-crash -c Release'
+          script: 'dotnet test $(PathToCommunityToolkitAnalyzersUnitTestCsproj) —-blame-crash --configuration Release'
 
       - task: CmdLine@2
         displayName: 'Build CommunityToolkit.Maui.Core'
@@ -302,7 +302,7 @@ jobs:
         env:
           VSTEST_TESTHOST_SHUTDOWN_TIMEOUT: 1100 # Fixes "The active test run was aborted. Reason: Test host process crashed" https://dev.azure.com/dotnet/CommunityToolkit/_build/results?buildId=109660&view=logs&j=3f96dcf5-6e1e-5485-3200-c557d5216be3&t=12286b69-c788-55db-0a8c-ef899858fbe6&l=76 (source: https://github.com/microsoft/vstest/issues/2952#issuecomment-2234253765): $(sauceUsername)
         inputs:
-          script: 'dotnet test $(PathToCommunityToolkitUnitTestCsproj) —-blame-crash -c Release --settings ".runsettings" --collect "XPlat code coverage" --logger trx --results-directory $(Agent.TempDirectory)'
+          script: 'dotnet test $(PathToCommunityToolkitUnitTestCsproj) —-blame-crash --configuration Release --settings ".runsettings" --collect "XPlat code coverage" --logger trx --results-directory $(Agent.TempDirectory)'
 
       - task: PublishTestResults@2
         condition: eq(variables['Agent.OS'], 'Windows_NT') # Only run this step on Windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -270,7 +270,7 @@ jobs:
         env:
           VSTEST_TESTHOST_SHUTDOWN_TIMEOUT: 1100 # Fixes "The active test run was aborted. Reason: Test host process crashed" https://dev.azure.com/dotnet/CommunityToolkit/_build/results?buildId=109660&view=logs&j=3f96dcf5-6e1e-5485-3200-c557d5216be3&t=12286b69-c788-55db-0a8c-ef899858fbe6&l=76 (source: https://github.com/microsoft/vstest/issues/2952#issuecomment-2234253765): $(sauceUsername)
         inputs:
-          script: 'dotnet test $(PathToCommunityToolkitAnalyzersUnitTestCsproj) —-blame-crash --configuration Release'
+          script: 'dotnet test $(PathToCommunityToolkitAnalyzersUnitTestCsproj) -c Release'
 
       - task: CmdLine@2
         displayName: 'Build CommunityToolkit.Maui.Core'
@@ -302,7 +302,7 @@ jobs:
         env:
           VSTEST_TESTHOST_SHUTDOWN_TIMEOUT: 1100 # Fixes "The active test run was aborted. Reason: Test host process crashed" https://dev.azure.com/dotnet/CommunityToolkit/_build/results?buildId=109660&view=logs&j=3f96dcf5-6e1e-5485-3200-c557d5216be3&t=12286b69-c788-55db-0a8c-ef899858fbe6&l=76 (source: https://github.com/microsoft/vstest/issues/2952#issuecomment-2234253765): $(sauceUsername)
         inputs:
-          script: 'dotnet test $(PathToCommunityToolkitUnitTestCsproj) —-blame-crash --configuration Release --settings ".runsettings" --collect "XPlat code coverage" --logger trx --results-directory $(Agent.TempDirectory)'
+          script: 'dotnet test $(PathToCommunityToolkitUnitTestCsproj) -c Release --settings ".runsettings" --collect "XPlat code coverage" --logger trx --results-directory $(Agent.TempDirectory)'
 
       - task: PublishTestResults@2
         condition: eq(variables['Agent.OS'], 'Windows_NT') # Only run this step on Windows

--- a/samples/CommunityToolkit.Maui.Sample/AppShell.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/AppShell.xaml.cs
@@ -24,8 +24,7 @@ namespace CommunityToolkit.Maui.Sample;
 
 public partial class AppShell : Shell
 {
-	static readonly IReadOnlyDictionary<Type, (Type GalleryPageType, Type ContentPageType)> viewModelMappings = new Dictionary<Type, (Type, Type)>(new[]
-	{
+	static readonly IReadOnlyDictionary<Type, (Type GalleryPageType, Type ContentPageType)> viewModelMappings = new Dictionary<Type, (Type, Type)>([
 		// Add Alerts View Models
 		CreateViewModelMapping<SnackbarPage, SnackbarViewModel, AlertsGalleryPage, AlertsGalleryViewModel>(),
 		CreateViewModelMapping<ToastPage, ToastViewModel, AlertsGalleryPage, AlertsGalleryViewModel>(),
@@ -137,8 +136,8 @@ public partial class AppShell : Shell
 		CreateViewModelMapping<StylePopupPage, StylePopupViewModel, ViewsGalleryPage, ViewsGalleryViewModel>(),
 
 		// Add PlatformSpecific View Models
-		CreateViewModelMapping<NavigationBarPage, NavigationBarAndroidViewModel, PlatformSpecificGalleryPage, PlatformSpecificGalleryViewModel>(),
-	});
+		CreateViewModelMapping<NavigationBarPage, NavigationBarAndroidViewModel, PlatformSpecificGalleryPage, PlatformSpecificGalleryViewModel>()
+	]);
 
 	public AppShell()
 	{

--- a/samples/CommunityToolkit.Maui.Sample/AppShell.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/AppShell.xaml.cs
@@ -1,4 +1,5 @@
-﻿using CommunityToolkit.Maui.Sample.Pages;
+﻿using System.Collections.ObjectModel;
+using CommunityToolkit.Maui.Sample.Pages;
 using CommunityToolkit.Maui.Sample.Pages.Alerts;
 using CommunityToolkit.Maui.Sample.Pages.Behaviors;
 using CommunityToolkit.Maui.Sample.Pages.Converters;
@@ -24,7 +25,8 @@ namespace CommunityToolkit.Maui.Sample;
 
 public partial class AppShell : Shell
 {
-	static readonly IReadOnlyDictionary<Type, (Type GalleryPageType, Type ContentPageType)> viewModelMappings = new Dictionary<Type, (Type, Type)>([
+	static readonly ReadOnlyDictionary<Type, (Type GalleryPageType, Type ContentPageType)> viewModelMappings = new Dictionary<Type, (Type, Type)>(
+	[
 		// Add Alerts View Models
 		CreateViewModelMapping<SnackbarPage, SnackbarViewModel, AlertsGalleryPage, AlertsGalleryViewModel>(),
 		CreateViewModelMapping<ToastPage, ToastViewModel, AlertsGalleryPage, AlertsGalleryViewModel>(),
@@ -137,7 +139,7 @@ public partial class AppShell : Shell
 
 		// Add PlatformSpecific View Models
 		CreateViewModelMapping<NavigationBarPage, NavigationBarAndroidViewModel, PlatformSpecificGalleryPage, PlatformSpecificGalleryViewModel>()
-	]);
+	]).AsReadOnly();
 
 	public AppShell()
 	{

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Converters/StringToListConverterPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Converters/StringToListConverterPage.xaml.cs
@@ -11,7 +11,7 @@ public partial class StringToListConverterPage : BasePage<StringToListConverterV
 		Resources.Add(nameof(StringToListConverter), new StringToListConverter
 		{
 			SplitOptions = StringSplitOptions.RemoveEmptyEntries,
-			Separators = new[] { ",", ".", ";" }
+			Separators = [",", ".", ";"]
 		});
 
 		InitializeComponent();

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Converters/ItemTappedEventArgsConverterViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Converters/ItemTappedEventArgsConverterViewModel.cs
@@ -9,12 +9,12 @@ public partial class ItemTappedEventArgsConverterViewModel : BaseViewModel
 	[ObservableProperty]
 	Person? itemSelected = null;
 
-	public IReadOnlyList<Person> Items { get; } = new[]
-	{
+	public IReadOnlyList<Person> Items { get; } =
+	[
 		new Person(1, "John Doe"),
 		new Person(2, "Jane Doe"),
 		new Person(3, "Joe Doe")
-	};
+	];
 
 	[RelayCommand]
 	Task ItemTapped(Person? person, CancellationToken token)

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Converters/ListToStringConverterViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Converters/ListToStringConverterViewModel.cs
@@ -3,11 +3,11 @@ namespace CommunityToolkit.Maui.Sample.ViewModels.Converters;
 
 public class ListToStringConverterViewModel : BaseViewModel
 {
-	public IReadOnlyList<string> ItemSource { get; } = new[]
-	{
+	public IReadOnlyList<string> ItemSource { get; } =
+	[
 		"This",
 		"Is",
 		"The",
 		"ListToStringConverter"
-	};
+	];
 }

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Converters/SelectedItemEventArgsConverterViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Converters/SelectedItemEventArgsConverterViewModel.cs
@@ -11,15 +11,15 @@ public partial class SelectedItemEventArgsConverterViewModel : BaseViewModel
 	[ObservableProperty]
 	string labelText = "This label will display the selected item";
 
-	public IReadOnlyList<string> StringItemSource { get; } = new[]
-	{
+	public IReadOnlyList<string> StringItemSource { get; } =
+	[
 		"Item 0",
 		"Item 1",
 		"Item 2",
 		"Item 3",
 		"Item 4",
-		"Item 5",
-	};
+		"Item 5"
+	];
 
 	[RelayCommand]
 	void HandleItemSelected(string text)

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/ImageSources/GravatarImageSourceViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/ImageSources/GravatarImageSourceViewModel.cs
@@ -20,8 +20,8 @@ public partial class GravatarImageSourceViewModel : BaseViewModel
 
 	public TimeSpan CacheValidityTimespan => TimeSpan.FromDays(CacheValidityInDays);
 
-	public IReadOnlyList<DefaultImage> DefaultGravatarItems { get; } = new[]
-	{
+	public IReadOnlyList<DefaultImage> DefaultGravatarItems { get; } =
+	[
 		DefaultImage.MysteryPerson,
 		DefaultImage.FileNotFound,
 		DefaultImage.Identicon,
@@ -30,5 +30,5 @@ public partial class GravatarImageSourceViewModel : BaseViewModel
 		DefaultImage.Robohash,
 		DefaultImage.Wavatar,
 		DefaultImage.Blank
-	};
+	];
 }

--- a/src/CommunityToolkit.Maui.Camera.Analyzers.CodeFixes/UseCommunityToolkitCameraViewInitializationAnalyzerCodeFixProvider.cs
+++ b/src/CommunityToolkit.Maui.Camera.Analyzers.CodeFixes/UseCommunityToolkitCameraViewInitializationAnalyzerCodeFixProvider.cs
@@ -13,7 +13,7 @@ namespace CommunityToolkit.Maui.Camera.Analyzers;
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UseCommunityToolkitCameraInitializationAnalyzerCodeFixProvider)), Shared]
 public class UseCommunityToolkitCameraInitializationAnalyzerCodeFixProvider : CodeFixProvider
 {
-	public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create(UseCommunityToolkitCameraInitializationAnalyzer.DiagnosticId);
+	public sealed override ImmutableArray<string> FixableDiagnosticIds { get; } = [UseCommunityToolkitCameraInitializationAnalyzer.DiagnosticId];
 
 	public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 

--- a/src/CommunityToolkit.Maui.Camera.Analyzers/UseCommunityToolkitCameraInitializationAnalyzer.cs
+++ b/src/CommunityToolkit.Maui.Camera.Analyzers/UseCommunityToolkitCameraInitializationAnalyzer.cs
@@ -19,7 +19,7 @@ public class UseCommunityToolkitCameraInitializationAnalyzer : DiagnosticAnalyze
 
 	static readonly DiagnosticDescriptor rule = new(DiagnosticId, title, messageFormat, category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: description);
 
-	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(rule);
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = [rule];
 
 	public override void Initialize(AnalysisContext context)
 	{

--- a/src/CommunityToolkit.Maui.Core/Views/DrawingView/DrawingLine.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/DrawingView/DrawingLine.shared.cs
@@ -68,6 +68,6 @@ public class DrawingLine : IDrawingLine
 	/// <returns><see cref="ValueTask{Stream}"/> containing the data of the requested image with data that's currently on the <see cref="IDrawingView"/>.</returns>
 	public ValueTask<Stream> GetImageStream(double imageSizeWidth, double imageSizeHeight, Paint background, CancellationToken token = default)
 	{
-		return DrawingViewService.GetImageStream(Points.ToList(), new Size(imageSizeWidth, imageSizeHeight), LineWidth, LineColor, background, token);
+		return DrawingViewService.GetImageStream([.. Points], new Size(imageSizeWidth, imageSizeHeight), LineWidth, LineColor, background, token);
 	}
 }

--- a/src/CommunityToolkit.Maui.MediaElement/Primitives/AndroidMediaPermissions.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Primitives/AndroidMediaPermissions.android.cs
@@ -10,7 +10,7 @@ sealed class AndroidMediaPermissions : BasePlatformPermission
 
 	static (string androidPermission, bool isRuntime)[] CreatePermissions()
 	{
-		List<(string androidPermission, bool isRuntime)> requiredPermissionsList = new();
+		List<(string androidPermission, bool isRuntime)> requiredPermissionsList = [];
 
 		if (OperatingSystem.IsAndroidVersionAtLeast(28))
 		{

--- a/src/CommunityToolkit.Maui.UnitTests/BaseHandlerTest.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/BaseHandlerTest.cs
@@ -13,13 +13,13 @@ public abstract class BaseHandlerTest : BaseTest
 
 	protected IServiceProvider ServiceProvider { get; }
 
-	protected static TElementHandler CreateElementHandler<TElementHandler>(IElement view, bool hasMauiContext = true)
+	protected static TElementHandler CreateElementHandler<TElementHandler>(IElement view, bool doesRequireMauiContext = true)
 		where TElementHandler : IElementHandler, new()
 	{
 		var mockElementHandler = new TElementHandler();
 		mockElementHandler.SetVirtualView(view);
 
-		if (hasMauiContext)
+		if (doesRequireMauiContext)
 		{
 			mockElementHandler.SetMauiContext(Application.Current?.Handler?.MauiContext ?? throw new NullReferenceException());
 		}
@@ -27,13 +27,13 @@ public abstract class BaseHandlerTest : BaseTest
 		return mockElementHandler;
 	}
 
-	protected static TViewHandler CreateViewHandler<TViewHandler>(IView view, bool hasMauiContext = true)
+	protected static TViewHandler CreateViewHandler<TViewHandler>(IView view, bool doesRequireMauiContext = true)
 		where TViewHandler : IViewHandler, new()
 	{
 		var mockViewHandler = new TViewHandler();
 		mockViewHandler.SetVirtualView(view);
 
-		if (hasMauiContext)
+		if (doesRequireMauiContext)
 		{
 			mockViewHandler.SetMauiContext(Application.Current?.Handler?.MauiContext ?? throw new NullReferenceException());
 		}

--- a/src/CommunityToolkit.Maui.UnitTests/Behaviors/MaskedBehaviorTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Behaviors/MaskedBehaviorTests.cs
@@ -60,15 +60,15 @@ public class MaskedBehaviorTests() : BaseBehaviorTest<MaskedBehavior, InputView>
 	[Fact]
 	public void AttachedToInvalidElementTest()
 	{
-		IReadOnlyList<VisualElement> invalidVisualElements = new[]
-		{
+		IReadOnlyList<VisualElement> invalidVisualElements =
+		[
 			new Button(),
 			new Frame(),
 			new Label(),
 			new ProgressBar(),
 			new VisualElement(),
-			new View(),
-		};
+			new View()
+		];
 
 		foreach (var invalidVisualElement in invalidVisualElements)
 		{

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/StringToListConverterTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/StringToListConverterTests.cs
@@ -24,7 +24,7 @@ public class StringToListConverterTests : BaseOneWayConverterTest<StringToListCo
 		var stringToListConverter = new StringToListConverter
 		{
 			Separator = "~",
-			Separators = new[] { "@", "*" }
+			Separators = ["@", "*"]
 		};
 
 		var convertFromResult = stringToListConverter.ConvertFrom(value, parameter);
@@ -37,13 +37,16 @@ public class StringToListConverterTests : BaseOneWayConverterTest<StringToListCo
 	[Fact]
 	public void StringToListConverter_EnsureParameterDoesNotOverrideProperty()
 	{
-		var converter = new StringToListConverter { Separators = new[] { ",", " " } };
+		var converter = new StringToListConverter
+		{
+			Separators = [",", " "]
+		};
 
 		var parameterResult = converter.ConvertFrom("maui/toolkit tests", new[] { "/", " " });
-		Assert.Equal(new[] { "maui", "toolkit", "tests" }, parameterResult);
+		Assert.Equal(["maui", "toolkit", "tests"], parameterResult);
 
 		var propertyResult = converter.ConvertFrom("maui,toolkit tests");
-		Assert.Equal(new[] { "maui", "toolkit", "tests" }, propertyResult);
+		Assert.Equal(["maui", "toolkit", "tests"], propertyResult);
 	}
 
 	[Fact]
@@ -55,7 +58,7 @@ public class StringToListConverterTests : BaseOneWayConverterTest<StringToListCo
 		var stringToListConverter = new StringToListConverter
 		{
 			Separator = "~",
-			Separators = new[] { "@", "*" }
+			Separators = ["@", "*"]
 		};
 
 		var convertFromResult = stringToListConverter.ConvertFrom(valueToConvert);

--- a/src/CommunityToolkit.Maui.UnitTests/Mocks/MockCameraProvider.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Mocks/MockCameraProvider.cs
@@ -9,19 +9,18 @@ public class MockCameraProvider : ICameraProvider
 
 	public ValueTask RefreshAvailableCameras(CancellationToken token)
 	{
-		AvailableCameras = new[]
-		{
+		AvailableCameras =
+		[
 			new CameraInfo("Test Camera",
 				Guid.NewGuid().ToString(),
 				CameraPosition.Front,
 				false,
 				1.0f,
 				5.0f,
-				new[]
-				{
+				[
 					new Size(1920, 1080)
-				})
-		};
+				])
+		];
 
 		return ValueTask.CompletedTask;
 	}

--- a/src/CommunityToolkit.Maui.UnitTests/Mocks/MockDrawingViewHandler.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Mocks/MockDrawingViewHandler.cs
@@ -12,7 +12,7 @@ public sealed class MockDrawingViewHandler(IPropertyMapper mapper) : ViewHandler
 {
 	IDrawingLineAdapter adapter = new DrawingLineAdapter();
 
-	public static readonly PropertyMapper<IDrawingView, MockDrawingViewHandler> DrawingViewPropertyMapper = new(ViewMapper)
+	public static readonly PropertyMapper<IDrawingView, MockDrawingViewHandler> DrawingViewPropertyMapper = new()
 	{
 		[nameof(IDrawingView.LineWidth)] = MapLineWidth,
 		[nameof(IDrawingView.LineColor)] = MapLineColor,
@@ -25,13 +25,13 @@ public sealed class MockDrawingViewHandler(IPropertyMapper mapper) : ViewHandler
 	{
 	}
 
+	public List<MauiDrawingLine> Lines { get; } = [];
 	public int MapLineWidthCount { get; private set; }
 	public int MapLineColorCount { get; private set; }
 	public int MapShouldSmoothPathWhenDrawnCount { get; private set; }
 	public int MapIsMultiLineModeEnabledCount { get; private set; }
 	public int MapDrawCount { get; private set; }
-	public List<MauiDrawingLine> Lines { get; } = [];
-	
+
 	/// <inheritdoc />
 	public void SetDrawingLineAdapter(IDrawingLineAdapter drawingLineAdapter)
 	{
@@ -39,11 +39,8 @@ public sealed class MockDrawingViewHandler(IPropertyMapper mapper) : ViewHandler
 	}
 
 	/// <inheritdoc />
-	protected override DrawingView CreatePlatformView()
-	{
-		return new DrawingView();
-	}
-	
+	protected override DrawingView CreatePlatformView() => new();
+
 	/// <inheritdoc />
 	protected override void ConnectHandler(DrawingView platformView)
 	{

--- a/src/CommunityToolkit.Maui.UnitTests/Mocks/MockDrawingViewHandler.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Mocks/MockDrawingViewHandler.cs
@@ -3,11 +3,12 @@ using CommunityToolkit.Maui.Core;
 using CommunityToolkit.Maui.Core.Extensions;
 using CommunityToolkit.Maui.Core.Handlers;
 using CommunityToolkit.Maui.Core.Views;
+using CommunityToolkit.Maui.Views;
 using Microsoft.Maui.Handlers;
 
 namespace CommunityToolkit.Maui.UnitTests.Mocks;
 
-public class MockDrawingViewHandler : ViewHandler<IDrawingView, object>, IDrawingViewHandler
+public sealed class MockDrawingViewHandler(IPropertyMapper mapper) : ViewHandler<IDrawingView, object>(mapper), IDrawingViewHandler
 {
 	IDrawingLineAdapter adapter = new DrawingLineAdapter();
 
@@ -24,11 +25,25 @@ public class MockDrawingViewHandler : ViewHandler<IDrawingView, object>, IDrawin
 	{
 	}
 
-	public MockDrawingViewHandler(IPropertyMapper mapper) : base(mapper)
+	public int MapLineWidthCount { get; private set; }
+	public int MapLineColorCount { get; private set; }
+	public int MapShouldSmoothPathWhenDrawnCount { get; private set; }
+	public int MapIsMultiLineModeEnabledCount { get; private set; }
+	public int MapDrawCount { get; private set; }
+	public List<MauiDrawingLine> Lines { get; } = [];
+	
+	/// <inheritdoc />
+	public void SetDrawingLineAdapter(IDrawingLineAdapter drawingLineAdapter)
 	{
-
+		adapter = drawingLineAdapter;
 	}
 
+	/// <inheritdoc />
+	protected override object CreatePlatformView()
+	{
+		return new DrawingView();
+	}
+	
 	/// <inheritdoc />
 	protected override void ConnectHandler(object platformView)
 	{
@@ -42,13 +57,6 @@ public class MockDrawingViewHandler : ViewHandler<IDrawingView, object>, IDrawin
 		base.DisconnectHandler(platformView);
 		VirtualView.Lines.CollectionChanged -= Lines_CollectionChanged;
 	}
-
-	public int MapLineWidthCount { get; private set; }
-	public int MapLineColorCount { get; private set; }
-	public int MapShouldSmoothPathWhenDrawnCount { get; private set; }
-	public int MapIsMultiLineModeEnabledCount { get; private set; }
-	public int MapDrawCount { get; private set; }
-	public List<MauiDrawingLine> Lines { get; } = [];
 
 	static void MapLineWidth(MockDrawingViewHandler arg1, IDrawingView arg2)
 	{
@@ -75,11 +83,6 @@ public class MockDrawingViewHandler : ViewHandler<IDrawingView, object>, IDrawin
 		arg1.MapDrawCount++;
 	}
 
-	protected override object CreatePlatformView()
-	{
-		return new object();
-	}
-
 	void Lines_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
 	{
 		Lines.Clear();
@@ -101,14 +104,9 @@ public class MockDrawingViewHandler : ViewHandler<IDrawingView, object>, IDrawin
 			VirtualView.OnDrawingLineCompleted(drawingLine);
 		}
 	}
-
-	public void SetDrawingLineAdapter(IDrawingLineAdapter drawingLineAdapter)
-	{
-		adapter = drawingLineAdapter;
-	}
 }
 
-class MockDrawingLineAdapter : IDrawingLineAdapter
+sealed class MockDrawingLineAdapter : IDrawingLineAdapter
 {
 	public IDrawingLine ConvertMauiDrawingLine(MauiDrawingLine mauiDrawingLine)
 	{
@@ -123,7 +121,7 @@ class MockDrawingLineAdapter : IDrawingLineAdapter
 	}
 }
 
-class MockDrawingLine : IDrawingLine
+sealed class MockDrawingLine : IDrawingLine
 {
 	public int Granularity { get; set; }
 	public Color LineColor { get; set; } = Colors.Blue;

--- a/src/CommunityToolkit.Maui.UnitTests/Mocks/MockDrawingViewHandler.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Mocks/MockDrawingViewHandler.cs
@@ -8,7 +8,7 @@ using Microsoft.Maui.Handlers;
 
 namespace CommunityToolkit.Maui.UnitTests.Mocks;
 
-public sealed class MockDrawingViewHandler(IPropertyMapper mapper) : ViewHandler<IDrawingView, object>(mapper), IDrawingViewHandler
+public sealed class MockDrawingViewHandler(IPropertyMapper mapper) : ViewHandler<IDrawingView, DrawingView>(mapper), IDrawingViewHandler
 {
 	IDrawingLineAdapter adapter = new DrawingLineAdapter();
 
@@ -39,20 +39,20 @@ public sealed class MockDrawingViewHandler(IPropertyMapper mapper) : ViewHandler
 	}
 
 	/// <inheritdoc />
-	protected override object CreatePlatformView()
+	protected override DrawingView CreatePlatformView()
 	{
 		return new DrawingView();
 	}
 	
 	/// <inheritdoc />
-	protected override void ConnectHandler(object platformView)
+	protected override void ConnectHandler(DrawingView platformView)
 	{
 		base.ConnectHandler(platformView);
 		VirtualView.Lines.CollectionChanged += Lines_CollectionChanged;
 	}
 
 	/// <inheritdoc />
-	protected override void DisconnectHandler(object platformView)
+	protected override void DisconnectHandler(DrawingView platformView)
 	{
 		base.DisconnectHandler(platformView);
 		VirtualView.Lines.CollectionChanged -= Lines_CollectionChanged;

--- a/src/CommunityToolkit.Maui.UnitTests/Views/DrawingView/DrawingLineTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/DrawingView/DrawingLineTests.cs
@@ -73,10 +73,10 @@ public class DrawingLineTests : BaseHandlerTest
 	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task GetImageStream_CancellationTokenExpired()
 	{
-		var cts = new CancellationTokenSource();
+		var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(1));
 
 		// Ensure CancellationToken Expired
-		await cts.CancelAsync();
+		await Task.Delay(100, CancellationToken.None);
 
 		await Assert.ThrowsAsync<OperationCanceledException>(async () => await drawingLine.GetImageStream(10, 10, Colors.Blue.AsPaint(), cts.Token));
 	}

--- a/src/CommunityToolkit.Maui.UnitTests/Views/DrawingView/DrawingLineTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/DrawingView/DrawingLineTests.cs
@@ -70,13 +70,13 @@ public class DrawingLineTests : BaseHandlerTest
 		drawingLine.Granularity.Should().Be(expectedValue);
 	}
 
-	[Fact(Timeout = (int)TestDuration.Short)]
+	[Fact(Timeout = (int)TestDuration.Medium)]
 	public async Task GetImageStream_CancellationTokenExpired()
 	{
 		var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(1));
 
 		// Ensure CancellationToken Expired
-		await Task.Delay(100, CancellationToken.None);
+		await Task.Delay(TimeSpan.FromSeconds(1), CancellationToken.None);
 
 		await Assert.ThrowsAsync<OperationCanceledException>(async () => await drawingLine.GetImageStream(10, 10, Colors.Blue.AsPaint(), cts.Token));
 	}

--- a/src/CommunityToolkit.Maui.UnitTests/Views/DrawingView/DrawingLineTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/DrawingView/DrawingLineTests.cs
@@ -73,10 +73,10 @@ public class DrawingLineTests : BaseHandlerTest
 	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task GetImageStream_CancellationTokenExpired()
 	{
-		var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(1));
+		var cts = new CancellationTokenSource();
 
 		// Ensure CancellationToken Expired
-		await Task.Delay(100, CancellationToken.None);
+		await cts.CancelAsync();
 
 		await Assert.ThrowsAsync<OperationCanceledException>(async () => await drawingLine.GetImageStream(10, 10, Colors.Blue.AsPaint(), cts.Token));
 	}

--- a/src/CommunityToolkit.Maui.UnitTests/Views/DrawingView/DrawingViewTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/DrawingView/DrawingViewTests.cs
@@ -10,6 +10,7 @@ using Xunit.Abstractions;
 
 namespace CommunityToolkit.Maui.UnitTests.Views;
 
+[Collection(nameof(DrawingViewTests)), CollectionDefinition(nameof(DrawingViewTests), DisableParallelization = true)]
 public class DrawingViewTests(ITestOutputHelper testOutputHelper) : BaseHandlerTest
 {
 	[Fact]
@@ -144,9 +145,11 @@ public class DrawingViewTests(ITestOutputHelper testOutputHelper) : BaseHandlerT
 	[Fact]
 	public void ClearShouldClearLines()
 	{
-		var drawingView = new DrawingView();
+		var drawingView = new DrawingView
+		{
+			Lines = [new DrawingLine()]
+		};
 
-		drawingView.Lines = [new DrawingLine()];
 		drawingView.Lines.Should().HaveCount(1);
 
 		drawingView.Clear();
@@ -162,10 +165,7 @@ public class DrawingViewTests(ITestOutputHelper testOutputHelper) : BaseHandlerT
 		// Ensure CancellationToken Expired
 		await Task.Delay(100, CancellationToken.None);
 
-		await Assert.ThrowsAsync<OperationCanceledException>(async () => await DrawingView.GetImageStream(new[]
-		{
-			new DrawingLine()
-		}, Size.Zero, Colors.Blue, cts.Token));
+		await Assert.ThrowsAsync<OperationCanceledException>(async () => await DrawingView.GetImageStream([new DrawingLine()], Size.Zero, Colors.Blue, cts.Token));
 	}
 
 	[Fact(Timeout = (int)TestDuration.Short)]
@@ -176,10 +176,9 @@ public class DrawingViewTests(ITestOutputHelper testOutputHelper) : BaseHandlerT
 		// Ensure CancellationToken Expired
 		await cts.CancelAsync();
 
-		await Assert.ThrowsAsync<OperationCanceledException>(async () => await DrawingView.GetImageStream(new[]
-		{
+		await Assert.ThrowsAsync<OperationCanceledException>(async () => await DrawingView.GetImageStream([
 			new DrawingLine()
-		}, Size.Zero, Colors.Blue, cts.Token));
+		], Size.Zero, Colors.Blue, cts.Token));
 	}
 
 	[Fact(Timeout = (int)TestDuration.Short)]
@@ -194,10 +193,9 @@ public class DrawingViewTests(ITestOutputHelper testOutputHelper) : BaseHandlerT
 	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task GetImageStreamStaticReturnsNullStream()
 	{
-		var stream = await DrawingView.GetImageStream(new[]
-		{
+		var stream = await DrawingView.GetImageStream([
 			new DrawingLine()
-		}, Size.Zero, Colors.Blue, CancellationToken.None);
+		], Size.Zero, Colors.Blue, CancellationToken.None);
 		stream.Should().BeSameAs(Stream.Null);
 	}
 
@@ -412,10 +410,7 @@ public class DrawingViewTests(ITestOutputHelper testOutputHelper) : BaseHandlerT
 			LineWidth = 15f,
 			ShouldSmoothPathWhenDrawn = false,
 			Granularity = 55,
-			Points = new ObservableCollection<PointF>(new[]
-			{
-				new PointF(10, 10)
-			})
+			Points = [new PointF(10, 10)]
 		};
 
 		IDrawingLine? currentLine = null;

--- a/src/CommunityToolkit.Maui.UnitTests/Views/DrawingView/DrawingViewTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/DrawingView/DrawingViewTests.cs
@@ -3,27 +3,19 @@ using CommunityToolkit.Maui.Core;
 using CommunityToolkit.Maui.Core.Handlers;
 using CommunityToolkit.Maui.Core.Views;
 using CommunityToolkit.Maui.UnitTests.Mocks;
+using CommunityToolkit.Maui.Views;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace CommunityToolkit.Maui.UnitTests.Views;
 
-[CollectionDefinition("DrawingViewCollection", DisableParallelization = true)]
-public class DrawingViewTests : BaseHandlerTest
+public class DrawingViewTests(ITestOutputHelper testOutputHelper) : BaseHandlerTest
 {
-	readonly ITestOutputHelper testOutputHelper;
-	readonly Maui.Views.DrawingView drawingView = new();
-
-	public DrawingViewTests(ITestOutputHelper testOutputHelper)
-	{
-		this.testOutputHelper = testOutputHelper;
-	}
-
 	[Fact]
 	public void DrawingViewShouldBeAssignedToIDrawingView()
 	{
-		new Maui.Views.DrawingView().Should().BeAssignableTo<IDrawingView>();
+		new DrawingView().Should().BeAssignableTo<IDrawingView>();
 	}
 
 	[Fact]
@@ -41,12 +33,14 @@ public class DrawingViewTests : BaseHandlerTest
 	[Fact]
 	public void DefaultLinesShouldNotBeShared()
 	{
-		new Maui.Views.DrawingView().Lines.Should().NotBeSameAs(new Maui.Views.DrawingView().Lines);
+		new DrawingView().Lines.Should().NotBeSameAs(new DrawingView().Lines);
 	}
 
 	[Fact]
 	public void OnLinesCollectionChangedHandlerIsCalled()
 	{
+		var drawingView = new DrawingView();
+
 		var drawingViewHandler = CreateViewHandler<MockDrawingViewHandler>(drawingView);
 		drawingView.Handler.Should().NotBeNull();
 
@@ -60,6 +54,8 @@ public class DrawingViewTests : BaseHandlerTest
 	[Fact]
 	public void LineWidthMapperIsCalled()
 	{
+		var drawingView = new DrawingView();
+
 		var drawingViewHandler = CreateViewHandler<MockDrawingViewHandler>(drawingView);
 		drawingView.Handler.Should().NotBeNull();
 
@@ -72,6 +68,8 @@ public class DrawingViewTests : BaseHandlerTest
 	[Fact]
 	public void ClearOnFinishMapperIsCalled()
 	{
+		var drawingView = new DrawingView();
+
 		var drawingViewHandler = CreateViewHandler<MockDrawingViewHandler>(drawingView);
 		drawingView.Handler.Should().NotBeNull();
 
@@ -84,6 +82,8 @@ public class DrawingViewTests : BaseHandlerTest
 	[Fact]
 	public void LineColorMapperIsCalled()
 	{
+		var drawingView = new DrawingView();
+
 		var drawingViewHandler = CreateViewHandler<MockDrawingViewHandler>(drawingView);
 		drawingView.Handler.Should().NotBeNull();
 
@@ -96,6 +96,8 @@ public class DrawingViewTests : BaseHandlerTest
 	[Fact]
 	public void MultiLineModeMapperIsCalled()
 	{
+		var drawingView = new DrawingView();
+
 		var drawingViewHandler = CreateViewHandler<MockDrawingViewHandler>(drawingView);
 		drawingView.Handler.Should().NotBeNull();
 
@@ -109,6 +111,8 @@ public class DrawingViewTests : BaseHandlerTest
 	[Fact]
 	public void DrawMapperIsCalled()
 	{
+		var drawingView = new DrawingView();
+
 		var drawingViewHandler = CreateViewHandler<MockDrawingViewHandler>(drawingView);
 		drawingView.Handler.Should().NotBeNull();
 
@@ -121,7 +125,9 @@ public class DrawingViewTests : BaseHandlerTest
 	[Fact]
 	public void CheckDefaultValues()
 	{
-		var expectedDefaultValue = new Maui.Views.DrawingView
+		var drawingView = new DrawingView();
+
+		var expectedDefaultValue = new DrawingView
 		{
 			LineColor = DrawingViewDefaults.LineColor,
 			LineWidth = DrawingViewDefaults.LineWidth,
@@ -138,6 +144,8 @@ public class DrawingViewTests : BaseHandlerTest
 	[Fact]
 	public void ClearShouldClearLines()
 	{
+		var drawingView = new DrawingView();
+
 		drawingView.Lines = [new DrawingLine()];
 		drawingView.Lines.Should().HaveCount(1);
 
@@ -154,7 +162,10 @@ public class DrawingViewTests : BaseHandlerTest
 		// Ensure CancellationToken Expired
 		await Task.Delay(100, CancellationToken.None);
 
-		await Assert.ThrowsAsync<OperationCanceledException>(async () => await Maui.Views.DrawingView.GetImageStream(new[] { new DrawingLine() }, Size.Zero, Colors.Blue, cts.Token));
+		await Assert.ThrowsAsync<OperationCanceledException>(async () => await DrawingView.GetImageStream(new[]
+		{
+			new DrawingLine()
+		}, Size.Zero, Colors.Blue, cts.Token));
 	}
 
 	[Fact(Timeout = (int)TestDuration.Short)]
@@ -165,12 +176,17 @@ public class DrawingViewTests : BaseHandlerTest
 		// Ensure CancellationToken Expired
 		await cts.CancelAsync();
 
-		await Assert.ThrowsAsync<OperationCanceledException>(async () => await Maui.Views.DrawingView.GetImageStream(new[] { new DrawingLine() }, Size.Zero, Colors.Blue, cts.Token));
+		await Assert.ThrowsAsync<OperationCanceledException>(async () => await DrawingView.GetImageStream(new[]
+		{
+			new DrawingLine()
+		}, Size.Zero, Colors.Blue, cts.Token));
 	}
 
 	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task GetImageStreamReturnsNullStream()
 	{
+		var drawingView = new DrawingView();
+
 		var stream = await drawingView.GetImageStream(10, 10, CancellationToken.None);
 		stream.Should().BeSameAs(Stream.Null);
 	}
@@ -178,13 +194,18 @@ public class DrawingViewTests : BaseHandlerTest
 	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task GetImageStreamStaticReturnsNullStream()
 	{
-		var stream = await Maui.Views.DrawingView.GetImageStream(new[] { new DrawingLine() }, Size.Zero, Colors.Blue, CancellationToken.None);
+		var stream = await DrawingView.GetImageStream(new[]
+		{
+			new DrawingLine()
+		}, Size.Zero, Colors.Blue, CancellationToken.None);
 		stream.Should().BeSameAs(Stream.Null);
 	}
 
 	[Fact]
 	public void DefaultDrawingLineAdapter_IDrawingLineIsDrawingLine()
 	{
+		var drawingView = new DrawingView();
+
 		CreateViewHandler<MockDrawingViewHandler>(drawingView);
 		IDrawingLine? currentLine = null;
 		var action = new EventHandler<DrawingLineCompletedEventArgs>((_, e) => currentLine = e.LastDrawingLine);
@@ -205,6 +226,8 @@ public class DrawingViewTests : BaseHandlerTest
 	[Fact]
 	public void SetDefaultDrawingLineAdapter_IDrawingLineIsDrawingLine()
 	{
+		var drawingView = new DrawingView();
+
 		var drawingViewHandler = CreateViewHandler<MockDrawingViewHandler>(drawingView);
 		drawingViewHandler.SetDrawingLineAdapter(new DrawingLineAdapter());
 
@@ -228,6 +251,8 @@ public class DrawingViewTests : BaseHandlerTest
 	[Fact]
 	public void SetDrawingLineAdapter_IDrawingLineIsMockDrawingLine()
 	{
+		var drawingView = new DrawingView();
+
 		var drawingViewHandler = CreateViewHandler<MockDrawingViewHandler>(drawingView);
 		drawingViewHandler.SetDrawingLineAdapter(new MockDrawingLineAdapter());
 
@@ -251,6 +276,8 @@ public class DrawingViewTests : BaseHandlerTest
 	[Fact]
 	public void OnDrawingStartedLastPointPassedWithCommand()
 	{
+		var drawingView = new DrawingView();
+
 		var expectedPoint = new PointF(10, 10);
 
 		PointF? point = null;
@@ -263,6 +290,8 @@ public class DrawingViewTests : BaseHandlerTest
 	[Fact]
 	public void OnDrawingLastPointPassedWithCommand()
 	{
+		var drawingView = new DrawingView();
+
 		var expectedPoint = new PointF(10, 10);
 
 		PointF? point = null;
@@ -276,13 +305,18 @@ public class DrawingViewTests : BaseHandlerTest
 	[Obsolete]
 	public void OnDrawingLineCompletedLastDrawingLinePassedWithCommand()
 	{
+		var drawingView = new DrawingView();
+
 		var expectedDrawingLine = new DrawingLine
 		{
 			LineColor = Colors.Grey,
 			LineWidth = 11f,
 			ShouldSmoothPathWhenDrawn = false,
 			Granularity = 21,
-			Points = new ObservableCollection<PointF>(new[] { new PointF(10, 10) })
+			Points = new ObservableCollection<PointF>(new[]
+			{
+				new PointF(10, 10)
+			})
 		};
 
 		IDrawingLine? currentLine = null;
@@ -296,6 +330,8 @@ public class DrawingViewTests : BaseHandlerTest
 	[Obsolete]
 	public void OnDrawingLineCompleted_CommandIsNull_LastDrawingLineNotPassed()
 	{
+		var drawingView = new DrawingView();
+
 		IDrawingLine? currentLine = null;
 		drawingView.DrawingLineCompletedCommand = null;
 		((IDrawingView)drawingView).OnDrawingLineCompleted(new DrawingLine());
@@ -306,6 +342,8 @@ public class DrawingViewTests : BaseHandlerTest
 	[Fact]
 	public void OnDrawingStarted_CommandIsNull_LastDrawingPointNotPassed()
 	{
+		var drawingView = new DrawingView();
+
 		PointF? currentPoint = null;
 		drawingView.DrawingLineStartedCommand = null;
 		((IDrawingView)drawingView).OnDrawingLineStarted(new PointF());
@@ -316,6 +354,8 @@ public class DrawingViewTests : BaseHandlerTest
 	[Fact]
 	public void OnDrawing_CommandIsNull_LastDrawingPointNotPassed()
 	{
+		var drawingView = new DrawingView();
+
 		PointF? currentPoint = null;
 		drawingView.PointDrawnCommand = null;
 		((IDrawingView)drawingView).OnPointDrawn(new PointF());
@@ -327,6 +367,8 @@ public class DrawingViewTests : BaseHandlerTest
 	[Obsolete]
 	public void OnDrawingLineCompleted_CommandIsNotAllowedExecute_LastDrawingLineNotPassed()
 	{
+		var drawingView = new DrawingView();
+
 		IDrawingLine? currentLine = null;
 		drawingView.DrawingLineCompletedCommand = new Command<IDrawingLine>(line => currentLine = line, _ => false);
 		((IDrawingView)drawingView).OnDrawingLineCompleted(new DrawingLine());
@@ -337,6 +379,8 @@ public class DrawingViewTests : BaseHandlerTest
 	[Fact]
 	public void OnDrawingStarted_CommandIsNotAllowedExecute_LastDrawingPointNotPassed()
 	{
+		var drawingView = new DrawingView();
+
 		PointF? currentPoint = null;
 		drawingView.DrawingLineStartedCommand = new Command<PointF>(p => currentPoint = p, _ => false);
 		((IDrawingView)drawingView).OnDrawingLineStarted(new PointF());
@@ -347,6 +391,8 @@ public class DrawingViewTests : BaseHandlerTest
 	[Fact]
 	public void OnDrawing_CommandIsNotAllowedExecute_LastDrawingPointNotPassed()
 	{
+		var drawingView = new DrawingView();
+
 		PointF? currentPoint = null;
 		drawingView.PointDrawnCommand = new Command<PointF>(p => currentPoint = p, _ => false);
 		((IDrawingView)drawingView).OnPointDrawn(new PointF());
@@ -358,13 +404,18 @@ public class DrawingViewTests : BaseHandlerTest
 	[Obsolete]
 	public void OnDrawingLineCompletedLastDrawingLinePassedWithEvent()
 	{
+		var drawingView = new DrawingView();
+
 		var expectedDrawingLine = new DrawingLine
 		{
 			LineColor = Colors.GreenYellow,
 			LineWidth = 15f,
 			ShouldSmoothPathWhenDrawn = false,
 			Granularity = 55,
-			Points = new ObservableCollection<PointF>(new[] { new PointF(10, 10) })
+			Points = new ObservableCollection<PointF>(new[]
+			{
+				new PointF(10, 10)
+			})
 		};
 
 		IDrawingLine? currentLine = null;
@@ -379,6 +430,8 @@ public class DrawingViewTests : BaseHandlerTest
 	[Fact]
 	public void OnDrawingStartedLastDrawingPointPassedWithEvent()
 	{
+		var drawingView = new DrawingView();
+
 		var expectedPoint = new PointF(10, 10);
 
 		PointF? currentPoint = null;
@@ -393,6 +446,8 @@ public class DrawingViewTests : BaseHandlerTest
 	[Fact]
 	public void OnDrawingLastDrawingPointPassedWithEvent()
 	{
+		var drawingView = new DrawingView();
+
 		var expectedPoint = new PointF(10, 10);
 
 		PointF? currentPoint = null;

--- a/src/CommunityToolkit.Maui.UnitTests/Views/DrawingView/DrawingViewTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/DrawingView/DrawingViewTests.cs
@@ -9,6 +9,7 @@ using Xunit.Abstractions;
 
 namespace CommunityToolkit.Maui.UnitTests.Views;
 
+[CollectionDefinition("DrawingViewCollection", DisableParallelization = true)]
 public class DrawingViewTests : BaseHandlerTest
 {
 	readonly ITestOutputHelper testOutputHelper;

--- a/src/CommunityToolkit.Maui.UnitTests/Views/DrawingView/DrawingViewTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/DrawingView/DrawingViewTests.cs
@@ -311,10 +311,7 @@ public class DrawingViewTests(ITestOutputHelper testOutputHelper) : BaseHandlerT
 			LineWidth = 11f,
 			ShouldSmoothPathWhenDrawn = false,
 			Granularity = 21,
-			Points = new ObservableCollection<PointF>(new[]
-			{
-				new PointF(10, 10)
-			})
+			Points = [new PointF(10, 10)]
 		};
 
 		IDrawingLine? currentLine = null;

--- a/src/CommunityToolkit.Maui.UnitTests/Views/SemanticOrderView/SemanticOrderViewTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/SemanticOrderView/SemanticOrderViewTests.cs
@@ -27,7 +27,7 @@ public class SemanticOrderViewTests : BaseHandlerTest
 		var semanticOrderViewHandler = CreateViewHandler<MockSemanticOrderViewHandler>(semanticOrderView);
 		Assert.NotNull(semanticOrderView.Handler);
 		Assert.Equal(1, semanticOrderViewHandler.OnViewOrderCount);
-		((MockSemanticOrderView)semanticOrderView).ViewOrder = new[] { new Button() };
+		((MockSemanticOrderView)semanticOrderView).ViewOrder = [new Button()];
 		Assert.Equal(2, semanticOrderViewHandler.OnViewOrderCount);
 	}
 
@@ -39,7 +39,7 @@ public class SemanticOrderViewTests : BaseHandlerTest
 		var button = new Button();
 		var entry = new Entry();
 
-		((MockSemanticOrderView)semanticOrderView).ViewOrder = new IView[] { button, entry };
+		((MockSemanticOrderView)semanticOrderView).ViewOrder = [button, entry];
 
 		Assert.Equal(2, semanticOrderView.ViewOrder.Count());
 		Assert.Equal(button, semanticOrderView.ViewOrder.First());

--- a/src/CommunityToolkit.Maui/Converters/MathExpressionConverter/MathExpressionConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/MathExpressionConverter/MathExpressionConverter.shared.cs
@@ -21,7 +21,7 @@ public class MathExpressionConverter : BaseConverterOneWay<double, double, strin
 	{
 		ArgumentNullException.ThrowIfNull(parameter);
 
-		var mathExpression = new MathExpression(parameter, new[] { value });
+		var mathExpression = new MathExpression(parameter, [value]);
 		return mathExpression.Calculate();
 	}
 }

--- a/src/CommunityToolkit.Maui/Views/Popup/Popup.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/Popup.shared.cs
@@ -384,7 +384,7 @@ public partial class Popup : Element, IPopup, IWindowController, IPropertyPropag
 		if (Content is not null)
 		{
 			SetInheritedBindingContext(Content, BindingContext);
-			
+
 			if (ReferenceEquals(Content.Parent, this) is false)
 			{
 				Content.Parent = null;


### PR DESCRIPTION
 ### Description of Change ###

This PR _hopefully_ fixes the [random crashing of the Unit Test host process in our CI/CD pipeline](https://dev.azure.com/dotnet/CommunityToolkit/_build/results?buildId=109660&view=logs&j=3f96dcf5-6e1e-5485-3200-c557d5216be3&t=12286b69-c788-55db-0a8c-ef899858fbe6&l=76):
> The active test run was aborted. Reason: Test host process crashed

The VS Test team has added a new Environment Variable, `VSTEST_TESTHOST_SHUTDOWN_TIMEOUT `, that we can leverage to extend the test runner timeout: https://github.com/microsoft/vstest/blob/02a8ba17b12757e0787b5e787b17533f21432b16/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs#L330.

This PR increases the value of `VSTEST_TESTHOST_SHUTDOWN_TIMEOUT` from its default of 100ms to 11000ms to exceed our [longest defined timeout, `BaseTest.TestDuration.Long = 10000`](https://github.com/CommunityToolkit/Maui/blob/52b84a91307364b73ba6453a1fe8424345505a64/src/CommunityToolkit.Maui.UnitTests/BaseTest.cs#L16).




 ### Additional information ###

Source for `VSTEST_TESTHOST_SHUTDOWN_TIMEOUT` information: https://github.com/microsoft/vstest/issues/2952#issuecomment-2234253765

This PR also fixes the crashing test process in `DrawingViewTests`. The crashes were caused by injecting `ViewHandler.ViewMapper` into `MockDrawingViewHandler.DrawingViewPropertyMapper`.

I also used `dotnet format` to ensure we're using CollectionExpressions in each place where we can utilize them to take advantage of their performance benefits.