### PR TITLE
MediaElement MacIOS code quality fixes

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
@@ -152,26 +152,24 @@ public partial class MediaManager : IDisposable
 		token.ThrowIfCancellationRequested();
 
 		var seekTaskCompletionSource = new TaskCompletionSource();
-
+		
 		if (Player?.CurrentItem is null)
 		{
 			throw new InvalidOperationException($"{nameof(AVPlayer)}.{nameof(AVPlayer.CurrentItem)} is not yet initialized");
 		}
 
-		if (Player?.Status is not AVPlayerStatus.ReadyToPlay)
+		if (Player.Status is not AVPlayerStatus.ReadyToPlay)
 		{
 			throw new InvalidOperationException($"{nameof(AVPlayer)}.{nameof(AVPlayer.Status)} must first be set to {AVPlayerStatus.ReadyToPlay}");
 		}
 
 		var ranges = Player.CurrentItem.SeekableTimeRanges;
 		var seekToTime = new CMTime(Convert.ToInt64(position.TotalMilliseconds), 1000);
-
-		foreach (var v in ranges)
+		foreach(var range in ranges.Select(r => r.CMTimeRangeValue))
 		{
-			if (seekToTime >= (seekToTime - v.CMTimeRangeValue.Start)
-				&& seekToTime < (v.CMTimeRangeValue.Start + v.CMTimeRangeValue.Duration))
+			if (seekToTime >= range.Start && seekToTime < (range.Start + range.Duration))
 			{
-				Player.Seek(seekToTime + v.CMTimeRangeValue.Start, complete =>
+				Player.Seek(seekToTime, complete =>
 				{
 					if (!complete)
 					{
@@ -294,9 +292,9 @@ public partial class MediaManager : IDisposable
 		{
 			MediaElement.MediaOpened();
 
-			var mediaDimensions = GetVideoDimensions(PlayerItem);
-			MediaElement.MediaWidth = mediaDimensions.Width;
-			MediaElement.MediaHeight = mediaDimensions.Height;
+			var (Width, Height) = GetVideoDimensions(PlayerItem);
+			MediaElement.MediaWidth = Width;
+			MediaElement.MediaHeight = Height;
 
 			if (MediaElement.ShouldAutoPlay)
 			{
@@ -676,7 +674,7 @@ public partial class MediaManager : IDisposable
 		}
 	}
 
-	(int Width, int Height) GetVideoDimensions(AVPlayerItem avPlayerItem)
+	static (int Width, int Height) GetVideoDimensions(AVPlayerItem avPlayerItem)
 	{
 		// Create an AVAsset instance with the video file URL
 		var asset = avPlayerItem.Asset;

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
@@ -292,9 +292,7 @@ public partial class MediaManager : IDisposable
 		{
 			MediaElement.MediaOpened();
 
-			var (Width, Height) = GetVideoDimensions(PlayerItem);
-			MediaElement.MediaWidth = Width;
-			MediaElement.MediaHeight = Height;
+			(MediaElement.MediaWidth, MediaElement.MediaHeight) = GetVideoDimensions(PlayerItem);
 
 			if (MediaElement.ShouldAutoPlay)
 			{


### PR DESCRIPTION
 ### Description of Change ###

 - Remove redundant null checks
- Refactory foreach loop to use range operator
- deconstruct variable to return a tuple appropriately
- Add static keyword to tuple `GetVideoDimensions(AVPlayerItem avPlayerItem)`

 ### PR Checklist ###

 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

Minor code quality updates to fix code compliance issues. This PR fixes a redundant null check, deconstructs a variable that returns a tuple and adds the `static` keyword to the same tuple.
 
