### PR TITLE
Fix Windows Autoplay bug

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.macios.cs
@@ -23,7 +23,7 @@ public partial class MediaElementHandler : ViewHandler<MediaElement, MauiMediaEl
 			Dispatcher.GetForCurrentThread() ?? throw new InvalidOperationException($"{nameof(IDispatcher)} cannot be null"));
 
 		(_, playerViewController) = mediaManager.CreatePlatformView();
-		
+
 		return new(playerViewController, VirtualView);
 	}
 

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.macios.cs
@@ -1,8 +1,8 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using AVKit;
-using CommunityToolkit.Maui.Views;
 using CommunityToolkit.Maui.Extensions;
+using CommunityToolkit.Maui.Views;
 using Microsoft.Maui.Controls.Handlers.Items;
 using Microsoft.Maui.Handlers;
 using UIKit;

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.windows.cs
@@ -345,6 +345,11 @@ partial class MediaManager : IDisposable
 		}
 	}
 
+	static bool IsZero<TValue>(TValue numericValue) where TValue : INumber<TValue>
+	{
+		return TValue.IsZero(numericValue);
+	}
+
 	async ValueTask UpdateMetadata()
 	{
 		if (systemMediaControls is null || Player is null)
@@ -497,9 +502,5 @@ partial class MediaManager : IDisposable
 	void OnPlaybackSessionSeekCompleted(MediaPlaybackSession sender, object args)
 	{
 		MediaElement?.SeekCompleted();
-	}
-	static bool IsZero<TValue>(TValue numericValue) where TValue : INumber<TValue>
-	{
-		return TValue.IsZero(numericValue);
 	}
 }

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.windows.cs
@@ -160,12 +160,12 @@ partial class MediaManager : IDisposable
 		Player.MediaPlayer.PlaybackRate = MediaElement.Speed;
 
 		// Only trigger once when going to the paused state
-		if (AreFloatingPointNumbersEqual(MediaElement.Speed, 0) && previousSpeed > 0)
+		if ((int)MediaElement.Speed == 0 && previousSpeed > 0)
 		{
 			Player.MediaPlayer.Pause();
 		}
 		// Only trigger once when we move from the paused state
-		else if (MediaElement.Speed > 0 && AreFloatingPointNumbersEqual(previousSpeed, 0))
+		else if (MediaElement.Speed > 0 && (int)previousSpeed == 0)
 		{
 			MediaElement.Play();
 		}

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.windows.cs
@@ -160,17 +160,17 @@ partial class MediaManager : IDisposable
 		Player.MediaPlayer.PlaybackRate = MediaElement.Speed;
 
 		// Only trigger once when going to the paused state
-		if ((int)MediaElement.Speed == 0 && previousSpeed > 0)
+		if (IsFloatingPointNumberZero(MediaElement.Speed) && previousSpeed > 0)
 		{
 			Player.MediaPlayer.Pause();
 		}
 		// Only trigger once when we move from the paused state
-		else if (MediaElement.Speed > 0 && (int)previousSpeed == 0)
+		else if (MediaElement.Speed > 0 && IsFloatingPointNumberZero(previousSpeed))
 		{
 			MediaElement.Play();
 		}
 	}
-
+	static bool IsFloatingPointNumberZero(double a) => (((int)a * 100) == 0);
 	protected virtual partial void PlatformUpdateShouldShowPlaybackControls()
 	{
 		if (Player is null)

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.windows.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Numerics;
 using CommunityToolkit.Maui.Core.Primitives;
 using CommunityToolkit.Maui.Views;
 using Microsoft.Extensions.Logging;
@@ -8,7 +9,6 @@ using Windows.Media;
 using Windows.Media.Playback;
 using Windows.Storage;
 using Windows.System.Display;
-using Page = Microsoft.Maui.Controls.Page;
 using ParentWindow = CommunityToolkit.Maui.Extensions.PageExtensions.ParentWindow;
 using WindowsMediaElement = Windows.Media.Playback.MediaPlayer;
 using WinMediaSource = Windows.Media.Core.MediaSource;
@@ -160,17 +160,17 @@ partial class MediaManager : IDisposable
 		Player.MediaPlayer.PlaybackRate = MediaElement.Speed;
 
 		// Only trigger once when going to the paused state
-		if (IsFloatingPointNumberZero(MediaElement.Speed) && previousSpeed > 0)
+		if (IsZero<double>(MediaElement.Speed) && previousSpeed > 0)
 		{
 			Player.MediaPlayer.Pause();
 		}
 		// Only trigger once when we move from the paused state
-		else if (MediaElement.Speed > 0 && IsFloatingPointNumberZero(previousSpeed))
+		else if (MediaElement.Speed > 0 && IsZero<double>(previousSpeed))
 		{
 			MediaElement.Play();
 		}
 	}
-	static bool IsFloatingPointNumberZero(double a) => (((int)a * 100) == 0);
+
 	protected virtual partial void PlatformUpdateShouldShowPlaybackControls()
 	{
 		if (Player is null)
@@ -485,7 +485,7 @@ partial class MediaManager : IDisposable
 		};
 
 		MediaElement?.CurrentStateChanged(newState);
-		if (sender.PlaybackState == MediaPlaybackState.Playing && AreFloatingPointNumbersEqual(sender.PlaybackRate, 0))
+		if (sender.PlaybackState == MediaPlaybackState.Playing && IsZero<double>(sender.PlaybackRate))
 		{
 			Dispatcher.Dispatch(() =>
 			{
@@ -497,5 +497,9 @@ partial class MediaManager : IDisposable
 	void OnPlaybackSessionSeekCompleted(MediaPlaybackSession sender, object args)
 	{
 		MediaElement?.SeekCompleted();
+	}
+	static bool IsZero<TValue>(TValue numericValue) where TValue : INumber<TValue>
+	{
+		return TValue.IsZero(numericValue);
 	}
 }


### PR DESCRIPTION
 ### Description of Change ###
Current behavior of autoplay has player pause on opening. Changing the comparision to `IsZero<double>(MediaElement.Speed)` and `IsZero<double>(previousSpeed)` fixes it.

 ### Linked Issues ###

 - Fixes #2237

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

Recently added comparison for doubles was incorrectly returning bad value when comparing to a value of zero. Issue is fixed by casting int onto the double instead of comparing small variation in value.
 
