### PR TITLE
Fix Media Element fails to load a URL

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.windows.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.windows.cs
@@ -105,7 +105,17 @@ public class MauiMediaElement : Grid, IDisposable
 
 		if (disposing)
 		{
+			mediaPlayerElement.MediaPlayer.Pause();
+			
+			if(mediaPlayerElement.MediaPlayer.Source is Windows.Media.Core.MediaSource mediaSource)
+			{
+				// Dispose the MediaSource to release the resources
+				// https://learn.microsoft.com/en-us/windows/uwp/audio-video-camera/play-audio-and-video-with-mediaplayer Shows how to dispose the MediaSource
+				mediaSource.Dispose();
+			}
+			mediaPlayerElement.MediaPlayer.Source = null;
 			mediaPlayerElement.MediaPlayer.Dispose();
+			mediaPlayerElement.SetMediaPlayer(null);
 		}
 
 		isDisposed = true;


### PR DESCRIPTION
 - Bug fix

 ### Description of Change ###

Updated the Dispose method in MauiMediaElement.windows.cs to include:
- Pausing the media player before disposal.
- Explicitly disposing of MediaSource if used.
- Setting the media player's source to null.
- Disposing of the media player.
- Setting the media player element's media player to null.

These changes ensure proper release of resources, preventing memory leaks.

 ### Linked Issues ###

 - Fixes #2264

 ### PR Checklist ###
 
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [x] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

This PR fixes an issue where upon entering and leaving a page 3 times results in Media Element failing to load any URL and showing blank controls with no buttons in Windows environment. This does not fix the issue with being unable to renter the page a second time without visiting a different page. Can be any page including other media element pages. Just not the same one.
 
