### PR TITLE
Bugfix for issue #1985 - PopupService ignoring passed ViewModel instance

### DIFF
--- a/src/CommunityToolkit.Maui.UnitTests/PopupServiceTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/PopupServiceTests.cs
@@ -291,6 +291,32 @@ public class PopupServiceTests : BaseHandlerTest
 		Assert.True(popupViewModel.HasLoaded);
 	}
 
+	[Fact]
+	public void ShowPopupWithViewModelParameterShouldUseItAsBindingContext()
+	{
+		var popupViewModel = new MockPageViewModel();
+		var popupInstance = new MockPopup();
+		
+		SetupTest(popupInstance, () => popupViewModel, out var popupService);
+		
+		popupService.ShowPopup(popupViewModel);
+		
+		Assert.Equal(popupInstance.BindingContext, popupViewModel);
+	}
+	
+	[Fact]
+	public async Task ShowPopupAsyncWithViewModelParameterShouldUseItAsBindingContext()
+	{
+		var popupViewModel = new MockPageViewModel();
+		var popupInstance = new MockPopup();
+		
+		SetupTest(popupInstance, () => popupViewModel, out var popupService);
+		
+		await popupService.ShowPopupAsync(popupViewModel);
+		
+		Assert.Equal(popupInstance.BindingContext, popupViewModel);
+	}
+
 	static void SetupTest(
 		Popup popup,
 		Func<INotifyPropertyChanged> createViewModelInstance,

--- a/src/CommunityToolkit.Maui/PopupService.cs
+++ b/src/CommunityToolkit.Maui/PopupService.cs
@@ -61,7 +61,7 @@ public class PopupService : IPopupService
 	{
 		ArgumentNullException.ThrowIfNull(viewModel);
 
-		var popup = GetPopup(typeof(TViewModel));
+		var popup = GetPopup(viewModel);
 
 		ValidateBindingContext<TViewModel>(popup, out _);
 
@@ -117,7 +117,7 @@ public class PopupService : IPopupService
 	{
 		ArgumentNullException.ThrowIfNull(viewModel);
 
-		var popup = GetPopup(typeof(TViewModel));
+		var popup = GetPopup(viewModel);
 
 		ValidateBindingContext<TViewModel>(popup, out _);
 
@@ -183,6 +183,18 @@ public class PopupService : IPopupService
 			throw new InvalidOperationException(
 				$"Unable to resolve popup type for {viewModelType} please make sure that you have called {nameof(AddTransientPopup)}");
 		}
+
+		return popup;
+	}
+	
+	Popup GetPopup<TViewModel>(
+		TViewModel viewModel)
+	{
+		var popup = GetPopup(
+			typeof(TViewModel));
+		
+		popup.BindingContext = viewModel;
+
 
 		return popup;
 	}


### PR DESCRIPTION
 ### Description of Change ###

Created method `GetPopup<TViewModel>(TViewModel viewModel)` to further pass the ViewModel instance and set it as the popup's `BindingContext` after successful creation.
Since 

 ### Linked Issues ###

 - Fixes #1985 

 ### PR Checklist ###
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [ ] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated


 ### Additional information ###

