### PR TITLE
Bugfix. StatusBar.Android.PlatformSetColor() accidently clears all Window flags

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Platform/StatusBar/StatusBar.android.cs
+++ b/src/CommunityToolkit.Maui.Core/Platform/StatusBar/StatusBar.android.cs
@@ -44,12 +44,12 @@ static partial class StatusBar
 			if (isColorTransparent)
 			{
 				Activity.Window.ClearFlags(WindowManagerFlags.DrawsSystemBarBackgrounds);
-				Activity.Window.SetFlags(WindowManagerFlags.LayoutNoLimits, WindowManagerFlags.LayoutNoLimits);
+				Activity.Window.AddFlags(WindowManagerFlags.LayoutNoLimits | WindowManagerFlags.LayoutNoLimits);
 			}
 			else
 			{
 				Activity.Window.ClearFlags(WindowManagerFlags.LayoutNoLimits);
-				Activity.Window.SetFlags(WindowManagerFlags.DrawsSystemBarBackgrounds, WindowManagerFlags.DrawsSystemBarBackgrounds);
+				Activity.Window.AddFlags(WindowManagerFlags.DrawsSystemBarBackgrounds | WindowManagerFlags.DrawsSystemBarBackgrounds);
 			}
 
 			WindowCompat.SetDecorFitsSystemWindows(Activity.Window, !isColorTransparent);

--- a/src/CommunityToolkit.Maui.Core/Platform/StatusBar/StatusBar.android.cs
+++ b/src/CommunityToolkit.Maui.Core/Platform/StatusBar/StatusBar.android.cs
@@ -44,12 +44,12 @@ static partial class StatusBar
 			if (isColorTransparent)
 			{
 				Activity.Window.ClearFlags(WindowManagerFlags.DrawsSystemBarBackgrounds);
-				Activity.Window.AddFlags(WindowManagerFlags.LayoutNoLimits | WindowManagerFlags.LayoutNoLimits);
+				Activity.Window.AddFlags(WindowManagerFlags.LayoutNoLimits);
 			}
 			else
 			{
 				Activity.Window.ClearFlags(WindowManagerFlags.LayoutNoLimits);
-				Activity.Window.AddFlags(WindowManagerFlags.DrawsSystemBarBackgrounds | WindowManagerFlags.DrawsSystemBarBackgrounds);
+				Activity.Window.AddFlags(WindowManagerFlags.DrawsSystemBarBackgrounds);
 			}
 
 			WindowCompat.SetDecorFitsSystemWindows(Activity.Window, !isColorTransparent);


### PR DESCRIPTION
 ### Description of Change ###

Call AddFlags() instead of SetFlags().

 ### Linked Issues ###

 - Fixes https://github.com/CommunityToolkit/Maui/issues/2289

 ### PR Checklist ###
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests - tested locally.
 - [ ] Has samples - No sample code
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls
