### PR TITLE
[MacCatalyst] [iOS] Fix IconTintColorBehavior ImageButton Disappearing and Crash On Source Change

### DIFF
--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.macios.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/IconTintColor/IconTintColorBehavior.macios.cs
@@ -98,7 +98,7 @@ public partial class IconTintColorBehavior
 
 	static void SetUIButtonTintColor(UIButton button, View element, Color color)
 	{
-		if (button.ImageView.Image is null)
+		if (button.ImageView.Image is null || button.CurrentImage is null)
 		{
 			return;
 		}


### PR DESCRIPTION
 ### Description of Change ###

Fixes issues when the image source is changed on a ButtonImage in MacCatalyst where IconTintBehavior would throw a null reference on button.CurrentImage due to a race condition.

 ### Linked Issues ###
#2313

 - Fixes #

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###
This checks if the CurrentImage is null before proceeding. MacCatalyst and iOS has been tested, both found to have the bug and are fixed with this patch.
 
