### PR TITLE
Fixes [BUG] Map not responding to span (zoom) requests in Windows #1686

### DIFF
--- a/src/CommunityToolkit.Maui.Maps/Handler/Map/MapHandler.Windows.cs
+++ b/src/CommunityToolkit.Maui.Maps/Handler/Map/MapHandler.Windows.cs
@@ -170,7 +170,7 @@ public partial class MapHandlerWindows : MapHandler
 			mapHandler.regionToGo = newRegion;
 		}
 
-		CallJSMethod(handler.PlatformView, $"setRegion({newRegion.Center.Latitude.ToString(CultureInfo.InvariantCulture)},{newRegion.Center.Longitude.ToString(CultureInfo.InvariantCulture)});");
+		CallJSMethod(handler.PlatformView, $"setRegion({newRegion.Center.Latitude.ToString(CultureInfo.InvariantCulture)},{newRegion.Center.Longitude.ToString(CultureInfo.InvariantCulture)},{newRegion.LatitudeDegrees.ToString(CultureInfo.InvariantCulture)},{newRegion.LongitudeDegrees.ToString(CultureInfo.InvariantCulture)});");
 	}
 
 	static void CallJSMethod(FrameworkElement platformWebView, string script)
@@ -290,11 +290,9 @@ public partial class MapHandlerWindows : MapHandler
 								});
 							}
 
-							function setRegion(latitude, longitude)
+							function setRegion(latitude, longitude, latitudeDegrees, longitudeDegrees)
 							{
-								map.setView({
-									center: new Microsoft.Maps.Location(latitude, longitude),
-								});
+								map.setView({bounds: new Microsoft.Maps.LocationRect(new Microsoft.Maps.Location(latitude, longitude), latitudeDegrees, longitudeDegrees) });
 							}
 
 							function addLocationPin(latitude, longitude)


### PR DESCRIPTION
The MoveToRegion command of the Map changes the location but does not change the span or zoom of the map in Windows. The map should change its zoom/span to the requested parameters.

This fix modifies the setRegion method to utilize the additional zoom parameters.

<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->
Modifed the setRegion to utilize zoom lat/lon parameters.

See https://github.com/CommunityToolkit/Maui/issues/1686#issuecomment-2246287104 for example of fix in action.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #1686 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [X] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [X] Has samples (if omitted, state reason in description)
 - [X] Rebased on top of `main` at time of PR
 - [X] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
Edition	Windows 11 Pro
Version	24H2
Installed on	‎11/‎4/‎2024
OS build	26100.2033
Experience	Windows Feature Experience Pack 1000.26100.23.0

