### PR TITLE
Version Toolkit assemblies alike the NuGet package version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -269,27 +269,27 @@ jobs:
       - task: CmdLine@2
         displayName: 'Build CommunityToolkit.Maui.Core'
         inputs:
-          script: 'dotnet build $(PathToCommunityToolkitCoreCsproj) -c Release -p:PackageVersion=$(NugetPackageVersion)'
+          script: 'dotnet build $(PathToCommunityToolkitCoreCsproj) -c Release -p:PackageVersion=$(NugetPackageVersion)' -p:Version=$(NugetPackageVersion)'
 
       - task: CmdLine@2
         displayName: 'Build CommunityToolkit.Maui'
         inputs:
-          script: 'dotnet build $(PathToCommunityToolkitCsproj) -c Release -p:PackageVersion=$(NugetPackageVersion)'
+          script: 'dotnet build $(PathToCommunityToolkitCsproj) -c Release -p:PackageVersion=$(NugetPackageVersion)' -p:Version=$(NugetPackageVersion)'
 
       - task: CmdLine@2
         displayName: 'Build CommunityToolkit.Maui.Camera'
         inputs:
-          script: 'dotnet build $(PathToCommunityToolkitCameraCsproj) -c Release -p:PackageVersion=$(NugetPackageVersionCamera)'
+          script: 'dotnet build $(PathToCommunityToolkitCameraCsproj) -c Release -p:PackageVersion=$(NugetPackageVersionCamera)' -p:Version=$(NugetPackageVersion)'
 
       - task: CmdLine@2
         displayName: 'Build CommunityToolkit.Maui.MediaElement'
         inputs:
-          script: 'dotnet build $(PathToCommunityToolkitMediaElementCsproj) -c Release -p:PackageVersion=$(NugetPackageVersionMediaElement)'
+          script: 'dotnet build $(PathToCommunityToolkitMediaElementCsproj) -c Release -p:PackageVersion=$(NugetPackageVersionMediaElement)' -p:Version=$(NugetPackageVersion)'
 
       - task: CmdLine@2
         displayName: 'Build CommunityToolkit.Maui.Maps'
         inputs:
-          script: 'dotnet build $(PathToCommunityToolkitMapsCsproj) -c Release -p:PackageVersion=$(NugetPackageVersionMaps)'
+          script: 'dotnet build $(PathToCommunityToolkitMapsCsproj) -c Release -p:PackageVersion=$(NugetPackageVersionMaps)' -p:Version=$(NugetPackageVersion)'
 
       - task: CmdLine@2
         displayName: 'Run CommunityToolkit.Maui.Analyzers.UnitTests'
@@ -324,27 +324,27 @@ jobs:
       - task: CmdLine@2
         displayName: 'Pack CommunityToolkit.Maui.Core NuGet'
         inputs:
-          script: 'dotnet pack $(PathToCommunityToolkitCoreCsproj) -c Release -p:PackageVersion=$(NugetPackageVersion)'
+          script: 'dotnet pack $(PathToCommunityToolkitCoreCsproj) -c Release -p:PackageVersion=$(NugetPackageVersion)' -p:Version=$(NugetPackageVersion)'
 
       - task: CmdLine@2
         displayName: 'Pack CommunityToolkit.Maui NuGet'
         inputs:
-          script: 'dotnet pack $(PathToCommunityToolkitCsproj) -c Release -p:PackageVersion=$(NugetPackageVersion)'
+          script: 'dotnet pack $(PathToCommunityToolkitCsproj) -c Release -p:PackageVersion=$(NugetPackageVersion)' -p:Version=$(NugetPackageVersion)'
 
       - task: CmdLine@2
         displayName: 'Pack CommunityToolkit.Maui.Camera NuGet'
         inputs:
-          script: 'dotnet pack $(PathToCommunityToolkitCameraCsproj) -c Release -p:PackageVersion=$(NugetPackageVersionCamera)'
+          script: 'dotnet pack $(PathToCommunityToolkitCameraCsproj) -c Release -p:PackageVersion=$(NugetPackageVersionCamera)' -p:Version=$(NugetPackageVersion)'
 
       - task: CmdLine@2
         displayName: 'Pack CommunityToolkit.Maui.MediaElement NuGet'
         inputs:
-          script: 'dotnet pack $(PathToCommunityToolkitMediaElementCsproj) -c Release -p:PackageVersion=$(NugetPackageVersionMediaElement)'
+          script: 'dotnet pack $(PathToCommunityToolkitMediaElementCsproj) -c Release -p:PackageVersion=$(NugetPackageVersionMediaElement)' -p:Version=$(NugetPackageVersion)'
 
       - task: CmdLine@2
         displayName: 'Pack CommunityToolkit.Maui.Maps NuGet'
         inputs:
-          script: 'dotnet pack $(PathToCommunityToolkitMapsCsproj) -c Release -p:PackageVersion=$(NugetPackageVersionMaps)'
+          script: 'dotnet pack $(PathToCommunityToolkitMapsCsproj) -c Release -p:PackageVersion=$(NugetPackageVersionMaps)' -p:Version=$(NugetPackageVersion)'
 
       # check vulnerabilities
       - powershell: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -269,27 +269,27 @@ jobs:
       - task: CmdLine@2
         displayName: 'Build CommunityToolkit.Maui.Core'
         inputs:
-          script: 'dotnet build $(PathToCommunityToolkitCoreCsproj) -c Release -p:PackageVersion=$(NugetPackageVersion)' -p:Version=$(NugetPackageVersion)'
+          script: 'dotnet build $(PathToCommunityToolkitCoreCsproj) -c Release -p:PackageVersion=$(NugetPackageVersion) -p:Version=$(NugetPackageVersion)'
 
       - task: CmdLine@2
         displayName: 'Build CommunityToolkit.Maui'
         inputs:
-          script: 'dotnet build $(PathToCommunityToolkitCsproj) -c Release -p:PackageVersion=$(NugetPackageVersion)' -p:Version=$(NugetPackageVersion)'
+          script: 'dotnet build $(PathToCommunityToolkitCsproj) -c Release -p:PackageVersion=$(NugetPackageVersion) -p:Version=$(NugetPackageVersion)'
 
       - task: CmdLine@2
         displayName: 'Build CommunityToolkit.Maui.Camera'
         inputs:
-          script: 'dotnet build $(PathToCommunityToolkitCameraCsproj) -c Release -p:PackageVersion=$(NugetPackageVersionCamera)' -p:Version=$(NugetPackageVersion)'
+          script: 'dotnet build $(PathToCommunityToolkitCameraCsproj) -c Release -p:PackageVersion=$(NugetPackageVersionCamera) -p:Version=$(NugetPackageVersion)'
 
       - task: CmdLine@2
         displayName: 'Build CommunityToolkit.Maui.MediaElement'
         inputs:
-          script: 'dotnet build $(PathToCommunityToolkitMediaElementCsproj) -c Release -p:PackageVersion=$(NugetPackageVersionMediaElement)' -p:Version=$(NugetPackageVersion)'
+          script: 'dotnet build $(PathToCommunityToolkitMediaElementCsproj) -c Release -p:PackageVersion=$(NugetPackageVersionMediaElement) -p:Version=$(NugetPackageVersion)'
 
       - task: CmdLine@2
         displayName: 'Build CommunityToolkit.Maui.Maps'
         inputs:
-          script: 'dotnet build $(PathToCommunityToolkitMapsCsproj) -c Release -p:PackageVersion=$(NugetPackageVersionMaps)' -p:Version=$(NugetPackageVersion)'
+          script: 'dotnet build $(PathToCommunityToolkitMapsCsproj) -c Release -p:PackageVersion=$(NugetPackageVersionMaps) -p:Version=$(NugetPackageVersion)'
 
       - task: CmdLine@2
         displayName: 'Run CommunityToolkit.Maui.Analyzers.UnitTests'
@@ -324,27 +324,27 @@ jobs:
       - task: CmdLine@2
         displayName: 'Pack CommunityToolkit.Maui.Core NuGet'
         inputs:
-          script: 'dotnet pack $(PathToCommunityToolkitCoreCsproj) -c Release -p:PackageVersion=$(NugetPackageVersion)' -p:Version=$(NugetPackageVersion)'
+          script: 'dotnet pack $(PathToCommunityToolkitCoreCsproj) -c Release -p:PackageVersion=$(NugetPackageVersion) -p:Version=$(NugetPackageVersion)'
 
       - task: CmdLine@2
         displayName: 'Pack CommunityToolkit.Maui NuGet'
         inputs:
-          script: 'dotnet pack $(PathToCommunityToolkitCsproj) -c Release -p:PackageVersion=$(NugetPackageVersion)' -p:Version=$(NugetPackageVersion)'
+          script: 'dotnet pack $(PathToCommunityToolkitCsproj) -c Release -p:PackageVersion=$(NugetPackageVersion) -p:Version=$(NugetPackageVersion)'
 
       - task: CmdLine@2
         displayName: 'Pack CommunityToolkit.Maui.Camera NuGet'
         inputs:
-          script: 'dotnet pack $(PathToCommunityToolkitCameraCsproj) -c Release -p:PackageVersion=$(NugetPackageVersionCamera)' -p:Version=$(NugetPackageVersion)'
+          script: 'dotnet pack $(PathToCommunityToolkitCameraCsproj) -c Release -p:PackageVersion=$(NugetPackageVersionCamera) -p:Version=$(NugetPackageVersion)'
 
       - task: CmdLine@2
         displayName: 'Pack CommunityToolkit.Maui.MediaElement NuGet'
         inputs:
-          script: 'dotnet pack $(PathToCommunityToolkitMediaElementCsproj) -c Release -p:PackageVersion=$(NugetPackageVersionMediaElement)' -p:Version=$(NugetPackageVersion)'
+          script: 'dotnet pack $(PathToCommunityToolkitMediaElementCsproj) -c Release -p:PackageVersion=$(NugetPackageVersionMediaElement) -p:Version=$(NugetPackageVersion)'
 
       - task: CmdLine@2
         displayName: 'Pack CommunityToolkit.Maui.Maps NuGet'
         inputs:
-          script: 'dotnet pack $(PathToCommunityToolkitMapsCsproj) -c Release -p:PackageVersion=$(NugetPackageVersionMaps)' -p:Version=$(NugetPackageVersion)'
+          script: 'dotnet pack $(PathToCommunityToolkitMapsCsproj) -c Release -p:PackageVersion=$(NugetPackageVersionMaps) -p:Version=$(NugetPackageVersion)'
 
       # check vulnerabilities
       - powershell: |

--- a/src/CommunityToolkit.Maui.Camera/CommunityToolkit.Maui.Camera.csproj
+++ b/src/CommunityToolkit.Maui.Camera/CommunityToolkit.Maui.Camera.csproj
@@ -36,8 +36,6 @@
     <Description>Camera contains CameraView, a view for displaying a preview of the camera output and other camera related functionalities in your .NET MAUI app.</Description>
     <PackageIcon>icon.png</PackageIcon>
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
     <Version>1.0.0-pre1</Version>
     <PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/CommunityToolkit.Maui.Camera/CommunityToolkit.Maui.Camera.csproj
+++ b/src/CommunityToolkit.Maui.Camera/CommunityToolkit.Maui.Camera.csproj
@@ -36,6 +36,8 @@
     <Description>Camera contains CameraView, a view for displaying a preview of the camera output and other camera related functionalities in your .NET MAUI app.</Description>
     <PackageIcon>icon.png</PackageIcon>
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
     <Version>1.0.0-pre1</Version>
     <PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/CommunityToolkit.Maui.Core/CommunityToolkit.Maui.Core.csproj
+++ b/src/CommunityToolkit.Maui.Core/CommunityToolkit.Maui.Core.csproj
@@ -35,8 +35,6 @@
     <Description>Core library for community toolkits using .NET MAUI</Description>
     <PackageIcon>icon.png</PackageIcon>
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
     <Version>1.0.0-pre1</Version>
     <PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/CommunityToolkit.Maui.Core/CommunityToolkit.Maui.Core.csproj
+++ b/src/CommunityToolkit.Maui.Core/CommunityToolkit.Maui.Core.csproj
@@ -35,6 +35,8 @@
     <Description>Core library for community toolkits using .NET MAUI</Description>
     <PackageIcon>icon.png</PackageIcon>
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
     <Version>1.0.0-pre1</Version>
     <PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/CommunityToolkit.Maui.Maps/CommunityToolkit.Maui.Maps.csproj
+++ b/src/CommunityToolkit.Maui.Maps/CommunityToolkit.Maui.Maps.csproj
@@ -35,8 +35,6 @@
     <Description>The .NET MAUI Community Maps Toolkit is a collection of Maps</Description>
     <PackageIcon>icon.png</PackageIcon>
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
     <Version>1.0.0-pre1</Version>
     <PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/CommunityToolkit.Maui.Maps/CommunityToolkit.Maui.Maps.csproj
+++ b/src/CommunityToolkit.Maui.Maps/CommunityToolkit.Maui.Maps.csproj
@@ -35,6 +35,8 @@
     <Description>The .NET MAUI Community Maps Toolkit is a collection of Maps</Description>
     <PackageIcon>icon.png</PackageIcon>
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
     <Version>1.0.0-pre1</Version>
     <PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/CommunityToolkit.Maui.MediaElement/CommunityToolkit.Maui.MediaElement.csproj
+++ b/src/CommunityToolkit.Maui.MediaElement/CommunityToolkit.Maui.MediaElement.csproj
@@ -37,8 +37,6 @@
     <Description>MediaElement is a view for playing video and audio in your .NET MAUI app.</Description>
     <PackageIcon>icon.png</PackageIcon>
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
     <Version>1.0.0-pre1</Version>
     <PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/CommunityToolkit.Maui.MediaElement/CommunityToolkit.Maui.MediaElement.csproj
+++ b/src/CommunityToolkit.Maui.MediaElement/CommunityToolkit.Maui.MediaElement.csproj
@@ -37,6 +37,8 @@
     <Description>MediaElement is a view for playing video and audio in your .NET MAUI app.</Description>
     <PackageIcon>icon.png</PackageIcon>
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
     <Version>1.0.0-pre1</Version>
     <PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/CommunityToolkit.Maui/CommunityToolkit.Maui.csproj
+++ b/src/CommunityToolkit.Maui/CommunityToolkit.Maui.csproj
@@ -38,8 +38,6 @@
     <Description>The .NET MAUI Community Toolkit is a collection of Animations, Behaviors, Converters, and Custom Views for development with .NET MAUI. It simplifies and demonstrates common developer tasks building iOS, Android, macOS and Windows apps with .NET MAUI.</Description>
     <PackageIcon>icon.png</PackageIcon>
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
     <Version>1.0.0-pre1</Version>
     <PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/src/CommunityToolkit.Maui/CommunityToolkit.Maui.csproj
+++ b/src/CommunityToolkit.Maui/CommunityToolkit.Maui.csproj
@@ -38,6 +38,8 @@
     <Description>The .NET MAUI Community Toolkit is a collection of Animations, Behaviors, Converters, and Custom Views for development with .NET MAUI. It simplifies and demonstrates common developer tasks building iOS, Android, macOS and Windows apps with .NET MAUI.</Description>
     <PackageIcon>icon.png</PackageIcon>
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
     <Version>1.0.0-pre1</Version>
     <PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
### Description of Change ###

Adds the `-p:Version` property to the pipeline which will apply the right version to the assemblies in the NuGets

 ### Linked Issues ###

 - Fixes #2299

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [ ] Rebased on top of `main` at time of PR
 - [ ] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->
