### PR TITLE
fix: Spelling mistake in ICommunityToolkitBehavior

### DIFF
--- a/src/CommunityToolkit.Maui/Behaviors/BaseBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/BaseBehavior.shared.cs
@@ -41,7 +41,7 @@ public abstract class BaseBehavior<TView> : Behavior<TView>, ICommunityToolkitBe
 	{
 		base.OnAttachedTo(bindable);
 
-		((ICommunityToolkitBehavior<TView>)this).AssignViewAndBingingContext(bindable);
+		((ICommunityToolkitBehavior<TView>)this).AssignViewAndBindingContext(bindable);
 	}
 
 	/// <inheritdoc/>
@@ -49,7 +49,7 @@ public abstract class BaseBehavior<TView> : Behavior<TView>, ICommunityToolkitBe
 	{
 		base.OnDetachingFrom(bindable);
 
-		((ICommunityToolkitBehavior<TView>)this).UnassignViewAndBingingContext(bindable);
+		((ICommunityToolkitBehavior<TView>)this).UnassignViewAndBindingContext(bindable);
 	}
 
 	/// <summary>

--- a/src/CommunityToolkit.Maui/Behaviors/ICommunityToolkitBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/ICommunityToolkitBehavior.shared.cs
@@ -53,7 +53,7 @@ public interface ICommunityToolkitBehavior<TView> where TView : Element
 	}
 
 	[MemberNotNull(nameof(View))]
-	internal void AssignViewAndBingingContext(TView bindable)
+	internal void AssignViewAndBindingContext(TView bindable)
 	{
 		View = bindable;
 		bindable.PropertyChanged += OnViewPropertyChanged;
@@ -61,7 +61,7 @@ public interface ICommunityToolkitBehavior<TView> where TView : Element
 		TrySetBindingContextToAttachedViewBindingContext();
 	}
 
-	internal void UnassignViewAndBingingContext(TView bindable)
+	internal void UnassignViewAndBindingContext(TView bindable)
 	{
 		TryRemoveBindingContext();
 

--- a/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/BasePlatformBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/PlatformBehaviors/BasePlatformBehavior.shared.cs
@@ -68,7 +68,7 @@ public abstract class BasePlatformBehavior<TView, TPlatformView> : PlatformBehav
 	{
 		base.OnAttachedTo(bindable, platformView);
 
-		((ICommunityToolkitBehavior<TView>)this).AssignViewAndBingingContext(bindable);
+		((ICommunityToolkitBehavior<TView>)this).AssignViewAndBindingContext(bindable);
 	}
 
 	/// <inheritdoc/>
@@ -76,7 +76,7 @@ public abstract class BasePlatformBehavior<TView, TPlatformView> : PlatformBehav
 	{
 		base.OnDetachedFrom(bindable, platformView);
 
-		((ICommunityToolkitBehavior<TView>)this).UnassignViewAndBingingContext(bindable);
+		((ICommunityToolkitBehavior<TView>)this).UnassignViewAndBindingContext(bindable);
 	}
 
 	void ICommunityToolkitBehavior<TView>.OnViewPropertyChanged(TView sender, PropertyChangedEventArgs e) => OnViewPropertyChanged(sender, e);


### PR DESCRIPTION
 ### Description of Change ###

Fixing minor spelling mistake. 
`UnassignViewAndBingingContext` -> `UnassignViewAndBindingContext`
`AssignViewAndBingingContext` -> `AssignViewAndBindingContext`

 ### PR Checklist ###
 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###
 
