### PR TITLE
Change expander to use the trimming safe binding

### DIFF
--- a/src/CommunityToolkit.Maui/Views/Expander/Expander.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Expander/Expander.shared.cs
@@ -12,7 +12,6 @@ namespace CommunityToolkit.Maui.Views;
 [BindableProperty<object>("CommandParameter")]
 [BindableProperty<ICommand>("Command")]
 [ContentProperty(nameof(Content))]
-[RequiresUnreferencedCode("Calls Microsoft.Maui.Controls.Binding.Binding(String, BindingMode, IValueConverter, Object, String, Object)")]
 public partial class Expander : ContentView, IExpander
 {
 	/// <summary>
@@ -83,7 +82,7 @@ public partial class Expander : ContentView, IExpander
 		var expander = (Expander)bindable;
 		if (newValue is View view)
 		{
-			view.SetBinding(IsVisibleProperty, new Binding(nameof(IsExpanded), source: expander));
+			view.SetBinding<Expander, bool>(IsVisibleProperty, static ex => ex.IsVisible);
 
 			expander.ContentGrid.Remove(oldValue);
 			expander.ContentGrid.Add(newValue);


### PR DESCRIPTION
This PR updates `Expander` to use the new and AoT friendly Binding API introduced by .NET MAUI.

With this we can make sure our code is trimming safe. For reference you can watch this part of [Peppers presentation on .NET Conf](https://youtu.be/FntsxTqtQEU?t=21708)