### PR TITLE
Fix bug: Support for arrays in IsListNotNullOrEmptyConverter/IsListNotNullOrEmptyConverter

### DIFF
--- a/src/CommunityToolkit.Maui.UnitTests/Converters/IsListNotNullOrEmptyConverterTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/IsListNotNullOrEmptyConverterTests.cs
@@ -10,30 +10,30 @@ public class IsListNotNullOrEmptyConverterTests : BaseOneWayConverterTest<IsList
 	public static TheoryData<IEnumerable?, bool> Data { get; } = new()
 	{
 		{
-			new List<string>(), true
+			new List<string>(), false
 		},
 		{
-			Array.Empty<string>(), true
+			Array.Empty<string>(), false
 		},
 		{
 			new List<string>
 			{
 				"TestValue"
 			},
-			false
+			true
 		},
 		{
 			new []
 			{
 				"TestValue"
 			},
-			false
+			true
 		},
 		{
-			null, true
+			null, false
 		},
 		{
-			Enumerable.Range(1, 3), false
+			Enumerable.Range(1, 3), true
 		}
 	};
 

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/IsListNotNullOrEmptyConverterTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/IsListNotNullOrEmptyConverterTests.cs
@@ -10,21 +10,31 @@ public class IsListNotNullOrEmptyConverterTests : BaseOneWayConverterTest<IsList
 	public static TheoryData<IEnumerable?, bool> Data { get; } = new()
 	{
 		{
-			new List<string>(), false
+			new List<string>(), true
+		},
+		{
+			Array.Empty<string>(), true
 		},
 		{
 			new List<string>
 			{
 				"TestValue"
 			},
-			true
+			false
 		},
 		{
-			null, false
+			new []
+			{
+				"TestValue"
+			},
+			false
 		},
 		{
-			Enumerable.Range(1, 3), true
+			null, true
 		},
+		{
+			Enumerable.Range(1, 3), false
+		}
 	};
 
 	[Theory]

--- a/src/CommunityToolkit.Maui.UnitTests/Converters/IsListNullOrEmptyConverterTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/IsListNullOrEmptyConverterTests.cs
@@ -13,7 +13,17 @@ public class IsListNullOrEmptyConverterTests : BaseOneWayConverterTest<IsListNul
 			new List<string>(), true
 		},
 		{
+			Array.Empty<string>(), true
+		},
+		{
 			new List<string>
+			{
+				"TestValue"
+			},
+			false
+		},
+		{
+			new []
 			{
 				"TestValue"
 			},
@@ -24,7 +34,7 @@ public class IsListNullOrEmptyConverterTests : BaseOneWayConverterTest<IsListNul
 		},
 		{
 			Enumerable.Range(1, 3), false
-		},
+		}
 	};
 
 	[Theory]

--- a/src/CommunityToolkit.Maui/Converters/IsListNullOrEmptyConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/IsListNullOrEmptyConverter.shared.cs
@@ -30,7 +30,11 @@ public partial class IsListNullOrEmptyConverter : BaseConverterOneWay<IEnumerabl
 		var enumerator = value.GetEnumerator();
 		bool result = !enumerator.MoveNext();
 
-		((IDisposable)enumerator).Dispose();
+		if (enumerator is IDisposable disposable)
+		{
+			disposable.Dispose();
+		}
+
 		return result;
 	}
 }


### PR DESCRIPTION
 ### Description of Change ###
Added check that enumerator is disposable before calling dispose, allowing support for ArrayEnumerator

 ### Linked Issues ###

 - Fixes #2395 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [ ] Rebased on top of `main` at time of PR
 - [ ] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
