### PR TITLE
Fix mvvmtk0045 warning for `StateContainerViewModel`

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Layouts/StateContainerViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Layouts/StateContainerViewModel.cs
@@ -6,16 +6,28 @@ namespace CommunityToolkit.Maui.Sample.ViewModels.Layouts;
 public partial class StateContainerViewModel : BaseViewModel
 {
 	[ObservableProperty]
-	string? currentState, gridState, noAnimateState, notFoundState, fullPageState;
+	public partial string? CurrentState { get; set; }
+
+	[ObservableProperty]
+	public partial string? GridState { get; set; }
+
+	[ObservableProperty]
+	public partial string? NoAnimateState { get; set; }
+
+	[ObservableProperty]
+	public partial string? NotFoundState { get; set; }
+
+	[ObservableProperty]
+	public partial string? FullPageState { get; set; }
 
 	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ToggleGridStateCommand))]
-	bool canGridStateChange = true;
+	public partial bool CanGridStateChange { get; set; } = true;
 
 	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(CycleStatesCommand))]
-	bool canCycleStateChange = true;
+	public partial bool CanCycleStateChange { get; set; } = true;
 
 	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ToggleFullPageStateCommand))]
-	bool canFullPageStateChange = true;
+	public partial bool CanFullPageStateChange { get; set; } = true;
 
 	[ObservableProperty]
 	public partial bool CanAnimationStateChange { get; set; } = true;


### PR DESCRIPTION
 - Bug fix

 ### Description of Change ###

Fix mvvmtk0045 errors in View Model for StateContainer.

 ### Linked Issues ###

 - Fixes #

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

Update `StateContainerViewModel` to be compliant with changes to MVVM for dotnet 9 and use public partial for `ObservableProperties`
 
