### PR TITLE
Fix mvvmtk0045 warnings for `VariableMultiValueConverterViewModel`

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Converters/VariableMultiValueConverterViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Converters/VariableMultiValueConverterViewModel.cs
@@ -5,6 +5,26 @@ namespace CommunityToolkit.Maui.Sample.ViewModels.Converters;
 public partial class VariableMultiValueConverterViewModel : BaseViewModel
 {
 	[ObservableProperty]
-	bool isAllGroupSwitch1On, isAllGroupSwitch2On, isAnyGroupSwitch1On, isAnyGroupSwitch2On,
-		isGreaterThanGroupSwitch1On, isGreaterThanGroupSwitch2On, isGreaterThanGroupSwitch3On, isGreaterThanGroupSwitch4On;
+	public partial bool IsAllGroupSwitch1On { get; set; }
+
+	[ObservableProperty]
+	public partial bool IsAllGroupSwitch2On { get; set; }
+
+	[ObservableProperty]
+	public partial bool IsAnyGroupSwitch1On { get; set; }
+
+	[ObservableProperty]
+	public partial bool IsAnyGroupSwitch2On { get; set; }
+
+	[ObservableProperty]
+	public partial bool IsGreaterThanGroupSwitch1On { get; set; }
+
+	[ObservableProperty]
+	public partial bool IsGreaterThanGroupSwitch2On { get; set; }
+
+	[ObservableProperty]
+	public partial bool IsGreaterThanGroupSwitch3On { get; set; }
+
+	[ObservableProperty]
+	public partial bool IsGreaterThanGroupSwitch4On { get; set; }
 }


### PR DESCRIPTION
 - Bug fix

 ### Description of Change ###

Fix MVVM errors in `VariableMultiValueConverter` View Model. This fixes mvvm0045 errors. This error is caused by not using public partial properties with `ObservableProperties`

 ### Linked Issues ###

 - Fixes #

 ### PR Checklist ###
 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

Fixes MVVM errors with `ObservableProperties` and failure to include `public partial`.
 
