### PR TITLE
Fix mvvmtk0045 warnings for `SpeechToTextViewModel`

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Essentials/SpeechToTextViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Essentials/SpeechToTextViewModel.cs
@@ -24,13 +24,13 @@ public partial class SpeechToTextViewModel : BaseViewModel
 	public partial string? RecognitionText { get; set; } = "Welcome to .NET MAUI Community Toolkit!";
 
 	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ListenCommand))]
-	bool canListenExecute = true;
+	public partial bool CanListenExecute { get; set; } = true;
 
 	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(StartListenCommand))]
-	bool canStartListenExecute = true;
+	public partial bool CanStartListenExecute { get; set; } = true;
 
 	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(StopListenCommand))]
-	bool canStopListenExecute = false;
+	public partial bool CanStopListenExecute { get; set; } = false;
 
 	public SpeechToTextViewModel(ITextToSpeech textToSpeech, ISpeechToText speechToText)
 	{


### PR DESCRIPTION
 - Bug fix

 ### Description of Change ###

Fix MVVM warnings about `ObservableProperties` in `SpeechToTextViewModel`. More Can be found here: https://learn.microsoft.com/en-gb/dotnet/communitytoolkit/mvvm/generators/errors/mvvmtk0045

 ### Linked Issues ###

 - Fixes #

 ### PR Checklist ###

 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###
Fixes `ObservableProperties` by adding `public partial` and adding setters and getters.
 
