### PR TITLE
Fix mvvmtk0045 and XC0045 warnings

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Converters/IndexToArrayItemConverterPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Converters/IndexToArrayItemConverterPage.xaml
@@ -45,8 +45,8 @@
                      Grid.Column="0"
                      Grid.Row="2"/>
 
-            <Label Text="{Binding Source={x:Reference Stepper},
-                                Path=Value, StringFormat='Selected index: {0}'}"
+            <Label x:DataType="{x:Type Stepper}" 
+                    Text="{Binding Source={x:Reference Stepper}, Path=Value, StringFormat='Selected index: {0}'}"
                     VerticalOptions="CenterAndExpand"
                     FontAttributes="Bold"
                     Grid.Row="2"

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Essentials/SpeechToTextViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Essentials/SpeechToTextViewModel.cs
@@ -17,6 +17,18 @@ public partial class SpeechToTextViewModel : BaseViewModel
 	readonly ITextToSpeech textToSpeech;
 	readonly ISpeechToText speechToText;
 
+	public SpeechToTextViewModel(ITextToSpeech textToSpeech, ISpeechToText speechToText)
+	{
+		this.textToSpeech = textToSpeech;
+		this.speechToText = speechToText;
+
+		Locales.CollectionChanged += HandleLocalesCollectionChanged;
+		this.speechToText.StateChanged += HandleSpeechToTextStateChanged;
+		this.speechToText.RecognitionResultCompleted += HandleRecognitionResultCompleted;
+	}
+
+	public ObservableCollection<Locale> Locales { get; } = [];
+	
 	[ObservableProperty]
 	public partial Locale? CurrentLocale { get; set; }
 
@@ -31,18 +43,6 @@ public partial class SpeechToTextViewModel : BaseViewModel
 
 	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(StopListenCommand))]
 	public partial bool CanStopListenExecute { get; set; } = false;
-
-	public SpeechToTextViewModel(ITextToSpeech textToSpeech, ISpeechToText speechToText)
-	{
-		this.textToSpeech = textToSpeech;
-		this.speechToText = speechToText;
-
-		Locales.CollectionChanged += HandleLocalesCollectionChanged;
-		this.speechToText.StateChanged += HandleSpeechToTextStateChanged;
-		this.speechToText.RecognitionResultCompleted += HandleRecognitionResultCompleted;
-	}
-
-	public ObservableCollection<Locale> Locales { get; } = [];
 
 	[RelayCommand]
 	async Task SetLocales(CancellationToken token)

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Views/CameraView/CameraViewViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Views/CameraView/CameraViewViewModel.cs
@@ -7,6 +7,14 @@ namespace CommunityToolkit.Maui.Sample.ViewModels.Views;
 
 public partial class CameraViewViewModel(ICameraProvider cameraProvider) : BaseViewModel
 {
+	readonly ICameraProvider cameraProvider = cameraProvider;
+	
+	public IReadOnlyList<CameraInfo> Cameras => cameraProvider.AvailableCameras ?? [];
+
+	public CancellationToken Token => CancellationToken.None;
+
+	public ICollection<CameraFlashMode> FlashModes { get; } = Enum.GetValues<CameraFlashMode>();
+	
 	[ObservableProperty]
 	public partial CameraFlashMode FlashMode { get; set; }
 
@@ -33,12 +41,6 @@ public partial class CameraViewViewModel(ICameraProvider cameraProvider) : BaseV
 	
 	[ObservableProperty] 
 	public partial string ResolutionText { get; set; } = string.Empty;
-
-	public IReadOnlyList<CameraInfo> Cameras => cameraProvider?.AvailableCameras ?? [];
-
-	public CancellationToken Token => CancellationToken.None;
-
-	public ICollection<CameraFlashMode> FlashModes { get; } = Enum.GetValues<CameraFlashMode>();
 
 	[RelayCommand]
 	async Task RefreshCameras(CancellationToken token) => await cameraProvider.RefreshAvailableCameras(token);

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Views/Popup/CustomSizeAndPositionPopupViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Views/Popup/CustomSizeAndPositionPopupViewModel.cs
@@ -17,13 +17,13 @@ public partial class CustomSizeAndPositionPopupViewModel : BaseViewModel
 	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
 	public partial bool IsStartHorizontalOptionSelected { get; set; } = true;
 	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
-	public partial bool IsCenterHorizontalOptionSelected { get; set; } = true;
+	public partial bool IsCenterHorizontalOptionSelected { get; set; }
 
 	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
-	public partial bool IsEndHorizontalOptionSelected { get; set; } = true;
+	public partial bool IsEndHorizontalOptionSelected { get; set; }
 
 	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
-	public partial bool IsFillHorizontalOptionSelected { get; set; } = true;
+	public partial bool IsFillHorizontalOptionSelected { get; set; }
 
 	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
 	public partial bool IsStartVerticalOptionSelected { get; set; } = true;
@@ -33,10 +33,10 @@ public partial class CustomSizeAndPositionPopupViewModel : BaseViewModel
 
 	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
 	
-	public partial bool IsEndVerticalOptionSelected { get; set; } = true;
+	public partial bool IsEndVerticalOptionSelected { get; set; }
 	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
 	
-	public partial bool IsFillVerticalOptionSelected { get; set; } = true;
+	public partial bool IsFillVerticalOptionSelected { get; set; }
 
 	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
 	public partial int FlowDirectionSelectedIndex { get; set; }

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Views/Popup/CustomSizeAndPositionPopupViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Views/Popup/CustomSizeAndPositionPopupViewModel.cs
@@ -8,6 +8,8 @@ namespace CommunityToolkit.Maui.Sample.ViewModels.Views;
 
 public partial class CustomSizeAndPositionPopupViewModel : BaseViewModel
 {
+	public IReadOnlyList<string> FlowDirectionOptions { get; } = [.. Enum.GetNames<FlowDirection>()];
+	
 	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
 	public partial double Height { get; set; } = 100;
 	
@@ -40,8 +42,6 @@ public partial class CustomSizeAndPositionPopupViewModel : BaseViewModel
 
 	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
 	public partial int FlowDirectionSelectedIndex { get; set; }
-
-	public IReadOnlyList<string> FlowDirectionOptions { get; } = [.. Enum.GetNames<FlowDirection>()];
 
 	[RelayCommand(CanExecute = nameof(CanShowButtonExecute))]
 	public Task ExecuteShowButton(CancellationToken token)

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Views/Popup/CustomSizeAndPositionPopupViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Views/Popup/CustomSizeAndPositionPopupViewModel.cs
@@ -9,14 +9,37 @@ namespace CommunityToolkit.Maui.Sample.ViewModels.Views;
 public partial class CustomSizeAndPositionPopupViewModel : BaseViewModel
 {
 	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
-	double height = 100, width = 100;
+	public partial double Height { get; set; } = 100;
+	
+	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
+	public partial double Width { get; set; } = 100;
 
 	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
-	bool isStartHorizontalOptionSelected = true, isCenterHorizontalOptionSelected, isEndHorizontalOptionSelected, isFillHorizontalOptionSelected,
-		isStartVerticalOptionSelected = true, isCenterVerticalOptionSelected, isEndVerticalOptionSelected, isFillVerticalOptionSelected;
+	public partial bool IsStartHorizontalOptionSelected { get; set; } = true;
+	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
+	public partial bool IsCenterHorizontalOptionSelected { get; set; } = true;
 
 	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
-	int flowDirectionSelectedIndex;
+	public partial bool IsEndHorizontalOptionSelected { get; set; } = true;
+
+	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
+	public partial bool IsFillHorizontalOptionSelected { get; set; } = true;
+
+	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
+	public partial bool IsStartVerticalOptionSelected { get; set; } = true;
+
+	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
+	public partial bool IsCenterVerticalOptionSelected { get; set; }
+
+	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
+	
+	public partial bool IsEndVerticalOptionSelected { get; set; } = true;
+	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
+	
+	public partial bool IsFillVerticalOptionSelected { get; set; } = true;
+
+	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
+	public partial int FlowDirectionSelectedIndex { get; set; }
 
 	public IReadOnlyList<string> FlowDirectionOptions { get; } = Enum.GetNames<FlowDirection>().ToList();
 

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Views/Popup/CustomSizeAndPositionPopupViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Views/Popup/CustomSizeAndPositionPopupViewModel.cs
@@ -16,6 +16,7 @@ public partial class CustomSizeAndPositionPopupViewModel : BaseViewModel
 
 	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
 	public partial bool IsStartHorizontalOptionSelected { get; set; } = true;
+	
 	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
 	public partial bool IsCenterHorizontalOptionSelected { get; set; }
 
@@ -32,16 +33,15 @@ public partial class CustomSizeAndPositionPopupViewModel : BaseViewModel
 	public partial bool IsCenterVerticalOptionSelected { get; set; }
 
 	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
-	
 	public partial bool IsEndVerticalOptionSelected { get; set; }
-	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
 	
+	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
 	public partial bool IsFillVerticalOptionSelected { get; set; }
 
 	[ObservableProperty, NotifyCanExecuteChangedFor(nameof(ExecuteShowButtonCommand))]
 	public partial int FlowDirectionSelectedIndex { get; set; }
 
-	public IReadOnlyList<string> FlowDirectionOptions { get; } = Enum.GetNames<FlowDirection>().ToList();
+	public IReadOnlyList<string> FlowDirectionOptions { get; } = [.. Enum.GetNames<FlowDirection>()];
 
 	[RelayCommand(CanExecute = nameof(CanShowButtonExecute))]
 	public Task ExecuteShowButton(CancellationToken token)


### PR DESCRIPTION
 - Bug fix

 ### Description of Change ###

Fix XamlC warning XC0045 Value not found
fix MVVM warning mvvmtk0045 

 ### Linked Issues ###

 - Fixes #

 ### PR Checklist ###
 
 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

Fix xamlc compiled binding error with `IndexToArrayItemConverterPage` and MVVM error with `ObservableProperty` not using `public partial`
 
