### PR TITLE
Fix for #2407 - MapHandler Throws InvalidSystemOperationExcetption

### DIFF
--- a/src/CommunityToolkit.Maui.Maps/Handler/Map/MapHandler.Windows.cs
+++ b/src/CommunityToolkit.Maui.Maps/Handler/Map/MapHandler.Windows.cs
@@ -179,6 +179,8 @@ public partial class MapHandlerWindows : MapHandler
 	{
 		if (platformWebView is WebView2 webView2)
 		{
+			await webView2.EnsureCoreWebView2Async();
+
 			var tcs = new TaskCompletionSource();
 			webView2.DispatcherQueue.TryEnqueue(async () =>
 			{


### PR DESCRIPTION
Fixes #2407

<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->
Explicitly trigger the initialization of the control's [CoreWebView2](https://learn.microsoft.com/en-us/dotnet/api/microsoft.web.webview2.wpf.webview2.corewebview2?view=webview2-dotnet-1.0.2903.40#microsoft-web-webview2-wpf-webview2-corewebview2).Call EnsureCoreWebView2Async() in the MapHandler's CallJSMethod() before trying to execute script.

No automated tests have been created. 

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #2407 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [X] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [X] Has samples (if omitted, state reason in description)
 - [X] Rebased on top of `main` at time of PR
 - [X] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
