### PR TITLE
[CameraView] Android - Fix SetSurfaceProvider crash

### DIFF
--- a/src/CommunityToolkit.Maui.Camera/CameraManager.android.cs
+++ b/src/CommunityToolkit.Maui.Camera/CameraManager.android.cs
@@ -172,7 +172,7 @@ partial class CameraManager
 
 	protected async Task StartUseCase(CancellationToken token)
 	{
-		if (resolutionSelector is null)
+		if (resolutionSelector is null || cameraExecutor is null)
 		{
 			return;
 		}
@@ -183,7 +183,7 @@ partial class CameraManager
 		imageCapture?.Dispose();
 
 		cameraPreview = new Preview.Builder().SetResolutionSelector(resolutionSelector).Build();
-		cameraPreview.SetSurfaceProvider(previewView?.SurfaceProvider);
+		cameraPreview.SetSurfaceProvider(cameraExecutor, previewView?.SurfaceProvider);
 
 		imageCapture = new ImageCapture.Builder()
 		.SetCaptureMode(ImageCapture.CaptureModeMaximizeQuality)

--- a/src/CommunityToolkit.Maui.Camera/CommunityToolkit.Maui.Camera.csproj
+++ b/src/CommunityToolkit.Maui.Camera/CommunityToolkit.Maui.Camera.csproj
@@ -51,8 +51,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
-    <PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.3.1.1" />
-    <PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.3.1.1" />
+    <PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.4.1" />
+    <PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.4.1" />
 
     <!--  Ensure Linker does not remove required libraries -->
     <None Include="linker.xml" Pack="true" PackagePath="build\$(PackageId).LinkerConfigurationFile.xml" />


### PR DESCRIPTION
 ### Description of Change ###

Update both `Xamarin.AndroidX.Camera.Camera2` and `Xamarin.AndroidX.Camera.View` packages.  
Fix the call to `SetSurfaceProvider` that changed with the new packages.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #2438 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [ ] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
