### PR TITLE
Fix PublishCodeCoverageResults in Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -323,7 +323,7 @@ jobs:
           testResultsFiles: '**/*.trx'
           searchFolder: $(Agent.TempDirectory)
 
-      - task: PublishCodeCoverageResults@2
+      - task: PublishCodeCoverageResults@1
         condition: eq(variables['Agent.OS'], 'Windows_NT') # Only run this step on Windows
         displayName: 'Publish Code Coverage Results'
         inputs:


### PR DESCRIPTION
### Description of Change ###

CI has been failing on the PublishCodeCoverageResults step. Seems like v2 of that step isn't doing great as by reports on the internet. Reverting back to v1 isn't ideal, but seems to be working and is better than disabling this entirely. So doing that for now.
 
