### PR TITLE
Add IProvideParentValues as required service for AppThemeResourceExtension

### DIFF
--- a/src/CommunityToolkit.Maui/Extensions/AppThemeResourceExtension.shared.cs
+++ b/src/CommunityToolkit.Maui/Extensions/AppThemeResourceExtension.shared.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// A XAML markup extension that enables using <see cref="AppThemeColor"/> and <see cref="AppThemeObject"/> from XAML.
 /// </summary>
-[ContentProperty(nameof(Key)), RequireService([typeof(IServiceProvider)])]
+[ContentProperty(nameof(Key)), RequireService([typeof(IServiceProvider), typeof(IProvideParentValues)])]
 public sealed class AppThemeResourceExtension : IMarkupExtension<BindingBase>
 {
 	/// <summary>


### PR DESCRIPTION
 ### Description of Change ###

We forgot to add `IProvideParentValues` as a required service on `AppThemeResourceExtension`. Therefore it would break when used in release mode because it would be trimmed out and not available.

 ### Linked Issues ###

 - Fixes #2415

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->
