### PR TITLE
Add UnconditionalSuppressMessage to fix IL2092

### DIFF
--- a/src/CommunityToolkit.Maui/Converters/ICommunityToolkitValueConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/ICommunityToolkitValueConverter.shared.cs
@@ -52,12 +52,12 @@ public interface ICommunityToolkitValueConverter : IValueConverter
 
 
 	/// <inheritdoc />
-#pragma warning disable IL2092
+	[UnconditionalSuppressMessage("TrimAnalysis", "IL2092", Justification = "The ToType and FromType properties are attributed with the appropriate DynamicallyAccessedMembers attributes.")]
 	object? IValueConverter.Convert(object? value, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type targetType, object? parameter, CultureInfo culture) =>
 		Convert(value, targetType, parameter, culture);
 
 	/// <inheritdoc />
+	[UnconditionalSuppressMessage("TrimAnalysis", "IL2092", Justification = "The ToType and FromType properties are attributed with the appropriate DynamicallyAccessedMembers attributes.")]
 	object? IValueConverter.ConvertBack(object? value, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] Type targetType, object? parameter, CultureInfo culture) =>
 		ConvertBack(value, targetType, parameter, culture);
-#pragma warning restore IL2092
 }


### PR DESCRIPTION
 ### Description of Change ###

Adds a `UnconditionalSuppressMessage` attribute to `ICommunityToolkitValueConverter.Convert` and `ICommunityToolkitValueConverter.ConvertBack` to fix the IL2092 warnings that are currently emitted when using AOT on iOS.

 ### Linked Issues ###

 - Fixes #2447

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

See https://github.com/CommunityToolkit/Maui/issues/2447#issuecomment-2602449055
