### PR TITLE
Fix XamlRoot being set incorrectly in Popup Handler

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Models/PopupSize.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Models/PopupSize.cs
@@ -6,8 +6,8 @@ public class PopupSizeConstants
 	{
 		Tiny = new(100, 100);
 		Small = new(300, 300);
-		Medium = new(0.7 * (deviceDisplay.MainDisplayInfo.Width / deviceDisplay.MainDisplayInfo.Density), 0.6 * (deviceDisplay.MainDisplayInfo.Height / deviceDisplay.MainDisplayInfo.Density));
-		Large = new(0.9 * (deviceDisplay.MainDisplayInfo.Width / deviceDisplay.MainDisplayInfo.Density), 0.8 * (deviceDisplay.MainDisplayInfo.Height / deviceDisplay.MainDisplayInfo.Density));
+		Medium = new(0.4 * (deviceDisplay.MainDisplayInfo.Width / deviceDisplay.MainDisplayInfo.Density), 0.6 * (deviceDisplay.MainDisplayInfo.Height / deviceDisplay.MainDisplayInfo.Density));
+		Large = new(0.5 * (deviceDisplay.MainDisplayInfo.Width / deviceDisplay.MainDisplayInfo.Density), 0.8 * (deviceDisplay.MainDisplayInfo.Height / deviceDisplay.MainDisplayInfo.Density));
 	}
 
 	// examples for fixed sizes

--- a/src/CommunityToolkit.Maui.Core/Handlers/Popup/PopUpHandler.windows.cs
+++ b/src/CommunityToolkit.Maui.Core/Handlers/Popup/PopUpHandler.windows.cs
@@ -41,9 +41,8 @@ public partial class PopupHandler : ElementHandler<IPopup, Popup>
 		ArgumentNullException.ThrowIfNull(handler.MauiContext);
 
 		var parent = view.Parent.ToPlatform(handler.MauiContext);
-
 		parent.IsHitTestVisible = false;
-		handler.PlatformView.XamlRoot = parent.XamlRoot;
+		handler.PlatformView.XamlRoot = view.GetWindow().Content?.Handler?.MauiContext?.GetPlatformWindow().Content.XamlRoot ?? throw new InvalidOperationException("Window Content cannot be null");
 		handler.PlatformView.IsHitTestVisible = true;
 		handler.PlatformView.IsOpen = true;
 


### PR DESCRIPTION
 ### Description of Change ###

This fixes incorrect XamlRoot being set when application uses modal navigation and opens a popup. The current behavior results in application crashing. This sets the `XamlRoot` correctly and the app does not crash. Additionally made a cosmetic size change to sizing for large popup as it is too large and covers the whole window in some situations in `Multiple Popups Page`.

 ### Linked Issues ###

 - Fixes #2459

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [ ] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

 Currently the windows implementation of `Popup` has the xaml root set incorrectly. I updated the `XamlRoot` in the handler for Popup to fix the issue. The linked issue has a CTD when using modal navigation and opening a `Popup`. This fix prevents the crash and the popup works as expected. The behavior before changes results in `PopupPositionPage` only setting the popup once and having to leave and enter page again before setting the postion anywhere else. This is fixed now. On the Custom Popup Size and Postion Page the same behavior is fixed. You do not need to leave the page before trying to set the popup to a new position.
 
