### PR TITLE
[Housekeeping] Fix Unit Test Failure: `Catastrophic failure: System.ArgumentOutOfRangeException`

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -190,7 +190,7 @@ jobs:
         run: dotnet build ${{ env.PathToLibrarySolution }} -c Release -p:PackageVersion=${{ env.NugetPackageVersion }} -p:Version=${{ env.NugetPackageVersion }} 
 
       - name: Run All Unit Tests
-        run: dotnet test -c Release ${{ env.PathToLibrarySolution }} --settings ".runsettings" --collect "XPlat code coverage" --logger trx --results-directory ${{ runner.temp }}
+        run: dotnet test -c Release ${{ env.PathToLibrarySolution }} --settings ".runsettings" --collect "XPlat code coverage" --logger trx --results-directory ${{ runner.temp }} --logger GitHubActions
 
       - name: Publish Test Results
         if: runner.os == 'Windows'

--- a/src/CommunityToolkit.Maui.Analyzers.UnitTests/CommunityToolkit.Maui.Analyzers.UnitTests.csproj
+++ b/src/CommunityToolkit.Maui.Analyzers.UnitTests/CommunityToolkit.Maui.Analyzers.UnitTests.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiPackageVersion)" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CommunityToolkit.Maui.UnitTests/CommunityToolkit.Maui.UnitTests.csproj
+++ b/src/CommunityToolkit.Maui.UnitTests/CommunityToolkit.Maui.UnitTests.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" PrivateAssets="All" />
     <PackageReference Include="coverlet.collector" Version="6.0.4" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiPackageVersion)"/>
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CommunityToolkit.Maui.UnitTests/Mocks/MockPopupHandler.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Mocks/MockPopupHandler.cs
@@ -36,6 +36,6 @@ public class MockPopupHandler : ElementHandler<IPopup, object>
 
 	static void MapOnClosed(MockPopupHandler handler, IPopup view, object? result)
 	{
-		view.HandlerCompleteTCS.SetResult();
+		view.HandlerCompleteTCS.TrySetResult();
 	}
 }

--- a/src/CommunityToolkit.Maui.UnitTests/Mocks/MockPopupHandler.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Mocks/MockPopupHandler.cs
@@ -36,6 +36,6 @@ public class MockPopupHandler : ElementHandler<IPopup, object>
 
 	static void MapOnClosed(MockPopupHandler handler, IPopup view, object? result)
 	{
-		view.HandlerCompleteTCS.TrySetResult();
+		view.HandlerCompleteTCS.SetResult();
 	}
 }

--- a/src/CommunityToolkit.Maui.UnitTests/Views/Popup/PopupTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/Popup/PopupTests.cs
@@ -57,7 +57,7 @@ public class PopupTests : BaseHandlerTest
 		// Ensure CancellationToken Has Expired
 		await Task.Delay(100, CancellationToken.None);
 
-		await Assert.ThrowsAsync<OperationCanceledException>(() => page.ShowPopupAsync(popup, cts.Token));
+		await Assert.ThrowsAnyAsync<OperationCanceledException>(() => page.ShowPopupAsync(popup, cts.Token));
 	}
 
 	[Fact(Timeout = (int)TestDuration.Short)]
@@ -86,7 +86,7 @@ public class PopupTests : BaseHandlerTest
 		// Ensure CancellationToken Has Expired
 		await cts.CancelAsync();
 
-		await Assert.ThrowsAsync<OperationCanceledException>(() => page.ShowPopupAsync(popup, cts.Token));
+		await Assert.ThrowsAnyAsync<OperationCanceledException>(() => page.ShowPopupAsync(popup, cts.Token));
 	}
 
 	[Fact(Timeout = (int)TestDuration.Short)]
@@ -115,7 +115,7 @@ public class PopupTests : BaseHandlerTest
 		// Ensure CancellationToken Has Expired
 		await Task.Delay(100, CancellationToken.None);
 
-		await Assert.ThrowsAsync<OperationCanceledException>(() => popup.CloseAsync(token: cts.Token));
+		await Assert.ThrowsAnyAsync<OperationCanceledException>(() => popup.CloseAsync(token: cts.Token));
 	}
 
 	[Fact(Timeout = (int)TestDuration.Short)]
@@ -144,7 +144,7 @@ public class PopupTests : BaseHandlerTest
 		// Ensure CancellationToken Has Expired
 		await cts.CancelAsync();
 
-		await Assert.ThrowsAsync<OperationCanceledException>(() => popup.CloseAsync(token: cts.Token));
+		await Assert.ThrowsAnyAsync<OperationCanceledException>(() => popup.CloseAsync(token: cts.Token));
 	}
 
 	[Fact(Timeout = (int)TestDuration.Short)]

--- a/src/CommunityToolkit.Maui/Views/Popup/Popup.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/Popup.shared.cs
@@ -343,6 +343,8 @@ public partial class Popup : Element, IPopup, IWindowController, IPropertyPropag
 	/// <param name="token"><see cref="CancellationToken"/></param>
 	protected virtual async Task OnClosed(object? result, bool wasDismissedByTappingOutsideOfPopup, CancellationToken token = default)
 	{
+		token.ThrowIfCancellationRequested();
+
 		((IPopup)this).OnClosed(result);
 		((IResourceDictionary)resources).ValuesChanged -= OnResourcesChanged;
 


### PR DESCRIPTION
 ### Description of Change ###

This PR fixes the [`ArgumentOutOfRangeException` occurring in  the `Run All Unit Tests` step of our `Build Library (windows-latest)` pipeline](https://github.com/CommunityToolkit/Maui/actions/runs/13037793620/job/36372408491): 
> [xUnit.net 00:00:29.07] Catastrophic failure: System.ArgumentOutOfRangeException : Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')

The exception was happening because both `MockPopup` and `MockPopupHandler` were both calling `HandlerCompleteTCS.SetResult();` in `OnClosed` causing a race condition where our test would sometimes fail and sometimes pass. 


 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has tests (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)


 ### Additional information ###

This PR updates the PopupTests to use `Assert.ThrowsAnyAsync<OperationCanceledException>()` which will pass when either an `OperationCanceledException` is thrown or an `TaskCanceledException` is thrown since `TaskCanceledException` derives from `OperationCanceledException`; `Assert.ThrowsAnyAsync<T>()` allows for derived types, whereas `Assert.ThrowsAsync<T>()` does not allow derived types.

This PR fixes an edge case where `await popupDismissedTaskCompletionSource.Task.WaitAsync(token)` does not throw a `TaskCanceledException` despite the token being canceled when `HandlerCompleteTCS.Task` had already completed; the fix is to manually add ` token.ThrowIfCancellationRequested();` in `Popup.OnClosed()`.
 
This PR changes `readonly IPopup poup` -> `readonly MockPopup popup` because of the discrepancy between `void IPopup.OnDismissedByTappingOutsideOfPopup()` and the awaitable `Task MockPopup.OnDismissedByTappingOutsideOfPopup()`. I also added the missing `await` keyword when the tests call `MockPopup.OnDismissedByTappingOutsideOfPopup()`.

This PR adds `readonly MockPopupHandler popupHandler` to `PopupTests`, and assigns this handler to `readonly MockPopup popup` in the constructor: `popupHandler = CreateElementHandler<MockPopupHandler>(popup);`

This PR also adds [GitHubActionsTestLogger](https://github.com/Tyrrrz/GitHubActionsTestLogger) to provide us with more comprehensive logs when tests fail. This will help us solve test errors in the future.