### PR TITLE
Fix options not working for Core

### DIFF
--- a/src/CommunityToolkit.Maui.Core/AppBuilderExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/AppBuilderExtensions.shared.cs
@@ -36,8 +36,8 @@ public static class AppBuilderExtensions
 	{
 		options?.Invoke(new Options());
 
-        if (Options.ShouldUseStatusBarBehaviorOnAndroidModalPage)
-        {
+		if (Options.ShouldUseStatusBarBehaviorOnAndroidModalPage)
+		{
 
 #if ANDROID
             builder.Services.AddSingleton<IDialogFragmentService, DialogFragmentService>();

--- a/src/CommunityToolkit.Maui.Core/AppBuilderExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/AppBuilderExtensions.shared.cs
@@ -17,6 +17,15 @@ namespace CommunityToolkit.Maui.Core;
 [SupportedOSPlatform("Tizen6.5")]
 public static class AppBuilderExtensions
 {
+	static readonly WeakEventManager weakEventManager = new();
+
+	// This is an internal event used by Unit Tests to confirm when the code enters the `if (Options.ShouldUseStatusBarBehaviorOnAndroidModalPage)` block
+	internal static event EventHandler ShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted
+	{
+		add => weakEventManager.AddEventHandler(value);
+		remove => weakEventManager.RemoveEventHandler(value);
+	}
+
 	/// <summary>
 	/// Initializes the .NET MAUI Community Toolkit Core Library
 	/// </summary>
@@ -27,9 +36,10 @@ public static class AppBuilderExtensions
 	{
 		options?.Invoke(new Options());
 
-#if ANDROID
         if (Options.ShouldUseStatusBarBehaviorOnAndroidModalPage)
         {
+
+#if ANDROID
             builder.Services.AddSingleton<IDialogFragmentService, DialogFragmentService>();
 
 			builder.ConfigureLifecycleEvents(static lifecycleBuilder =>
@@ -58,8 +68,10 @@ public static class AppBuilderExtensions
 					});
 				});
 			});
-        }
 #endif
+
+			weakEventManager.HandleEvent(null, EventArgs.Empty, nameof(ShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted));
+		}
 
 		return builder;
 	}

--- a/src/CommunityToolkit.Maui.Core/Services/DialogFragmentService.android.cs
+++ b/src/CommunityToolkit.Maui.Core/Services/DialogFragmentService.android.cs
@@ -94,7 +94,7 @@ sealed partial class DialogFragmentService : IDialogFragmentService
 		dialogFragment = dialog;
 		return true;
 	}
-	
+
 	static void HandleStatusBarColor(DialogFragment dialogFragment, AppCompatActivity activity)
 	{
 		if (activity.Window is null)

--- a/src/CommunityToolkit.Maui.UnitTests/BaseTest.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/BaseTest.cs
@@ -57,7 +57,10 @@ public abstract class BaseTest : IDisposable
 		DeviceDisplay.SetCurrent(null);
 		DispatcherProvider.SetCurrent(null);
 
+		// Restore default options
 		var options = new Options();
+		options.SetShouldUseStatusBarBehaviorOnAndroidModalPage(true);
+		options.SetShouldEnableSnackbarOnWindows(false);
 		options.SetShouldSuppressExceptionsInAnimations(false);
 		options.SetShouldSuppressExceptionsInBehaviors(false);
 		options.SetShouldSuppressExceptionsInConverters(false);

--- a/src/CommunityToolkit.Maui.UnitTests/Extensions/AppBuilderExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Extensions/AppBuilderExtensionsTests.cs
@@ -3,52 +3,101 @@ using Xunit;
 
 namespace CommunityToolkit.Maui.UnitTests.Extensions;
 
+#pragma warning disable CA1416
 public class AppBuilderExtensionsTests : BaseTest
 {
     [Fact]
     public void ConfirmOptionsDefaultValue()
     {
+		// Arrange
+		bool isAndroidDialogFragmentServiceInitialized = false;
+		Core.AppBuilderExtensions.ShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted += HandleShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted;
+
 		// Assert
 		Assert.True(Core.Options.ShouldUseStatusBarBehaviorOnAndroidModalPage);
         Assert.False(Options.ShouldEnableSnackbarOnWindows);
         Assert.False(Options.ShouldSuppressExceptionsInAnimations);
         Assert.False(Options.ShouldSuppressExceptionsInBehaviors);
         Assert.False(Options.ShouldSuppressExceptionsInConverters);
-    }
-    
-    [Fact]
+		Assert.False(isAndroidDialogFragmentServiceInitialized);
+
+		Core.AppBuilderExtensions.ShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted -= HandleShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted;
+
+		void HandleShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted(object? sender, EventArgs e)
+		{
+			Core.AppBuilderExtensions.ShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted -= HandleShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted;
+			isAndroidDialogFragmentServiceInitialized = true;
+		}
+	}
+
+	[Fact]
+	public void ConfirmDefaultValueRemainWhenOptionsNull()
+	{
+		// Arrange
+		var builder = MauiApp.CreateBuilder();
+		bool isAndroidDialogFragmentServiceInitialized = false;
+
+		Core.AppBuilderExtensions.ShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted += HandleShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted;
+
+		// Act
+		builder.UseMauiCommunityToolkit(null);
+
+		// Assert
+		Assert.True(Core.Options.ShouldUseStatusBarBehaviorOnAndroidModalPage);
+		Assert.False(Options.ShouldEnableSnackbarOnWindows);
+		Assert.False(Options.ShouldSuppressExceptionsInAnimations);
+		Assert.False(Options.ShouldSuppressExceptionsInBehaviors);
+		Assert.False(Options.ShouldSuppressExceptionsInConverters);
+		Assert.True(isAndroidDialogFragmentServiceInitialized);
+
+		void HandleShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted(object? sender, EventArgs e)
+		{
+			Core.AppBuilderExtensions.ShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted -= HandleShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted;
+			isAndroidDialogFragmentServiceInitialized = true;
+		}
+	}
+
+
+	[Fact]
     public void UseMauiCommunityToolkit_ShouldRegisterServices()
     {
         // Arrange
         var builder = MauiApp.CreateBuilder();
+		bool isAndroidDialogFragmentServiceInitialized = false;
+		Core.AppBuilderExtensions.ShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted += HandleShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted;
 
-        // Act
-#pragma warning disable CA1416
-        builder.UseMauiCommunityToolkit();
-#pragma warning restore CA1416
+		// Act
+		builder.UseMauiCommunityToolkit();
 
         // Assert
         var serviceProvider = builder.Services.BuildServiceProvider();
         Assert.NotNull(serviceProvider.GetService<IPopupService>());
-    }
+		Assert.True(isAndroidDialogFragmentServiceInitialized);
+
+		void HandleShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted(object? sender, EventArgs e)
+		{
+			Core.AppBuilderExtensions.ShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted -= HandleShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted;
+			isAndroidDialogFragmentServiceInitialized = true;
+		}
+	}
     
     [Fact]
     public void UseMauiCommunityToolkit_ShouldAssignValues()
     {
         // Arrange
         var builder = MauiApp.CreateBuilder();
+		bool isAndroidDialogFragmentServiceInitialized = false;
+		Core.AppBuilderExtensions.ShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted += HandleShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted;
 
-        // Act
-#pragma warning disable CA1416
-        builder.UseMauiCommunityToolkit(options =>
+		// Act
+		builder.UseMauiCommunityToolkit(options =>
         {
             options.SetShouldEnableSnackbarOnWindows(!Options.ShouldEnableSnackbarOnWindows);
-            options.SetShouldUseStatusBarBehaviorOnAndroidModalPage(!Core.Options.ShouldUseStatusBarBehaviorOnAndroidModalPage);
             options.SetShouldSuppressExceptionsInAnimations(!Options.ShouldSuppressExceptionsInAnimations);
             options.SetShouldSuppressExceptionsInBehaviors(!Options.ShouldSuppressExceptionsInBehaviors);
             options.SetShouldSuppressExceptionsInConverters(!Options.ShouldSuppressExceptionsInConverters);
+            options.SetShouldUseStatusBarBehaviorOnAndroidModalPage(!Core.Options.ShouldUseStatusBarBehaviorOnAndroidModalPage);
         });
-#pragma warning restore CA1416
 
         // Assert
         Assert.False(Core.Options.ShouldUseStatusBarBehaviorOnAndroidModalPage);
@@ -56,5 +105,15 @@ public class AppBuilderExtensionsTests : BaseTest
         Assert.True(Options.ShouldSuppressExceptionsInAnimations);
         Assert.True(Options.ShouldSuppressExceptionsInBehaviors);
         Assert.True(Options.ShouldSuppressExceptionsInConverters);
-    }
+		Assert.False(isAndroidDialogFragmentServiceInitialized);
+
+		Core.AppBuilderExtensions.ShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted -= HandleShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted;
+
+		void HandleShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted(object? sender, EventArgs e)
+		{
+			Core.AppBuilderExtensions.ShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted -= HandleShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted;
+			isAndroidDialogFragmentServiceInitialized = true;
+		}
+	}
 }
+#pragma warning restore CA1416

--- a/src/CommunityToolkit.Maui.UnitTests/Extensions/AppBuilderExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Extensions/AppBuilderExtensionsTests.cs
@@ -1,0 +1,60 @@
+using CommunityToolkit.Maui.Core;
+using Xunit;
+
+namespace CommunityToolkit.Maui.UnitTests.Extensions;
+
+public class AppBuilderExtensionsTests : BaseTest
+{
+    [Fact]
+    public void ConfirmOptionsDefaultValue()
+    {
+        // Assert
+        Assert.True(Core.Options.ShouldUseStatusBarBehaviorOnAndroidModalPage);
+        Assert.False(Options.ShouldEnableSnackbarOnWindows);
+        Assert.False(Options.ShouldSuppressExceptionsInAnimations);
+        Assert.False(Options.ShouldSuppressExceptionsInBehaviors);
+        Assert.False(Options.ShouldSuppressExceptionsInConverters);
+    }
+    
+    [Fact]
+    public void UseMauiCommunityToolkit_ShouldRegisterServices()
+    {
+        // Arrange
+        var builder = MauiApp.CreateBuilder();
+
+        // Act
+#pragma warning disable CA1416
+        builder.UseMauiCommunityToolkit();
+#pragma warning restore CA1416
+
+        // Assert
+        var serviceProvider = builder.Services.BuildServiceProvider();
+        Assert.NotNull(serviceProvider.GetService<IPopupService>());
+    }
+    
+    [Fact]
+    public void UseMauiCommunityToolkit_ShouldAssignValues()
+    {
+        // Arrange
+        var builder = MauiApp.CreateBuilder();
+
+        // Act
+#pragma warning disable CA1416
+        builder.UseMauiCommunityToolkit(options =>
+        {
+            options.SetShouldEnableSnackbarOnWindows(!Options.ShouldEnableSnackbarOnWindows);
+            options.SetShouldUseStatusBarBehaviorOnAndroidModalPage(!Core.Options.ShouldUseStatusBarBehaviorOnAndroidModalPage);
+            options.SetShouldSuppressExceptionsInAnimations(!Options.ShouldSuppressExceptionsInAnimations);
+            options.SetShouldSuppressExceptionsInBehaviors(!Options.ShouldSuppressExceptionsInBehaviors);
+            options.SetShouldSuppressExceptionsInConverters(!Options.ShouldSuppressExceptionsInConverters);
+        });
+#pragma warning restore CA1416
+
+        // Assert
+        Assert.False(Core.Options.ShouldUseStatusBarBehaviorOnAndroidModalPage);
+        Assert.True(Options.ShouldEnableSnackbarOnWindows);
+        Assert.True(Options.ShouldSuppressExceptionsInAnimations);
+        Assert.True(Options.ShouldSuppressExceptionsInBehaviors);
+        Assert.True(Options.ShouldSuppressExceptionsInConverters);
+    }
+}

--- a/src/CommunityToolkit.Maui.UnitTests/Extensions/AppBuilderExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Extensions/AppBuilderExtensionsTests.cs
@@ -8,8 +8,8 @@ public class AppBuilderExtensionsTests : BaseTest
     [Fact]
     public void ConfirmOptionsDefaultValue()
     {
-        // Assert
-        Assert.True(Core.Options.ShouldUseStatusBarBehaviorOnAndroidModalPage);
+		// Assert
+		Assert.True(Core.Options.ShouldUseStatusBarBehaviorOnAndroidModalPage);
         Assert.False(Options.ShouldEnableSnackbarOnWindows);
         Assert.False(Options.ShouldSuppressExceptionsInAnimations);
         Assert.False(Options.ShouldSuppressExceptionsInBehaviors);

--- a/src/CommunityToolkit.Maui.UnitTests/Extensions/AppBuilderExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Extensions/AppBuilderExtensionsTests.cs
@@ -6,19 +6,19 @@ namespace CommunityToolkit.Maui.UnitTests.Extensions;
 #pragma warning disable CA1416
 public class AppBuilderExtensionsTests : BaseTest
 {
-    [Fact]
-    public void ConfirmOptionsDefaultValue()
-    {
+	[Fact]
+	public void ConfirmOptionsDefaultValue()
+	{
 		// Arrange
 		bool isAndroidDialogFragmentServiceInitialized = false;
 		Core.AppBuilderExtensions.ShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted += HandleShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted;
 
 		// Assert
 		Assert.True(Core.Options.ShouldUseStatusBarBehaviorOnAndroidModalPage);
-        Assert.False(Options.ShouldEnableSnackbarOnWindows);
-        Assert.False(Options.ShouldSuppressExceptionsInAnimations);
-        Assert.False(Options.ShouldSuppressExceptionsInBehaviors);
-        Assert.False(Options.ShouldSuppressExceptionsInConverters);
+		Assert.False(Options.ShouldEnableSnackbarOnWindows);
+		Assert.False(Options.ShouldSuppressExceptionsInAnimations);
+		Assert.False(Options.ShouldSuppressExceptionsInBehaviors);
+		Assert.False(Options.ShouldSuppressExceptionsInConverters);
 		Assert.False(isAndroidDialogFragmentServiceInitialized);
 
 		Core.AppBuilderExtensions.ShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted -= HandleShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted;
@@ -59,19 +59,19 @@ public class AppBuilderExtensionsTests : BaseTest
 
 
 	[Fact]
-    public void UseMauiCommunityToolkit_ShouldRegisterServices()
-    {
-        // Arrange
-        var builder = MauiApp.CreateBuilder();
+	public void UseMauiCommunityToolkit_ShouldRegisterServices()
+	{
+		// Arrange
+		var builder = MauiApp.CreateBuilder();
 		bool isAndroidDialogFragmentServiceInitialized = false;
 		Core.AppBuilderExtensions.ShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted += HandleShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted;
 
 		// Act
 		builder.UseMauiCommunityToolkit();
 
-        // Assert
-        var serviceProvider = builder.Services.BuildServiceProvider();
-        Assert.NotNull(serviceProvider.GetService<IPopupService>());
+		// Assert
+		var serviceProvider = builder.Services.BuildServiceProvider();
+		Assert.NotNull(serviceProvider.GetService<IPopupService>());
 		Assert.True(isAndroidDialogFragmentServiceInitialized);
 
 		void HandleShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted(object? sender, EventArgs e)
@@ -80,31 +80,31 @@ public class AppBuilderExtensionsTests : BaseTest
 			isAndroidDialogFragmentServiceInitialized = true;
 		}
 	}
-    
-    [Fact]
-    public void UseMauiCommunityToolkit_ShouldAssignValues()
-    {
-        // Arrange
-        var builder = MauiApp.CreateBuilder();
+
+	[Fact]
+	public void UseMauiCommunityToolkit_ShouldAssignValues()
+	{
+		// Arrange
+		var builder = MauiApp.CreateBuilder();
 		bool isAndroidDialogFragmentServiceInitialized = false;
 		Core.AppBuilderExtensions.ShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted += HandleShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted;
 
 		// Act
 		builder.UseMauiCommunityToolkit(options =>
-        {
-            options.SetShouldEnableSnackbarOnWindows(!Options.ShouldEnableSnackbarOnWindows);
-            options.SetShouldSuppressExceptionsInAnimations(!Options.ShouldSuppressExceptionsInAnimations);
-            options.SetShouldSuppressExceptionsInBehaviors(!Options.ShouldSuppressExceptionsInBehaviors);
-            options.SetShouldSuppressExceptionsInConverters(!Options.ShouldSuppressExceptionsInConverters);
-            options.SetShouldUseStatusBarBehaviorOnAndroidModalPage(!Core.Options.ShouldUseStatusBarBehaviorOnAndroidModalPage);
-        });
+		{
+			options.SetShouldEnableSnackbarOnWindows(!Options.ShouldEnableSnackbarOnWindows);
+			options.SetShouldSuppressExceptionsInAnimations(!Options.ShouldSuppressExceptionsInAnimations);
+			options.SetShouldSuppressExceptionsInBehaviors(!Options.ShouldSuppressExceptionsInBehaviors);
+			options.SetShouldSuppressExceptionsInConverters(!Options.ShouldSuppressExceptionsInConverters);
+			options.SetShouldUseStatusBarBehaviorOnAndroidModalPage(!Core.Options.ShouldUseStatusBarBehaviorOnAndroidModalPage);
+		});
 
-        // Assert
-        Assert.False(Core.Options.ShouldUseStatusBarBehaviorOnAndroidModalPage);
-        Assert.True(Options.ShouldEnableSnackbarOnWindows);
-        Assert.True(Options.ShouldSuppressExceptionsInAnimations);
-        Assert.True(Options.ShouldSuppressExceptionsInBehaviors);
-        Assert.True(Options.ShouldSuppressExceptionsInConverters);
+		// Assert
+		Assert.False(Core.Options.ShouldUseStatusBarBehaviorOnAndroidModalPage);
+		Assert.True(Options.ShouldEnableSnackbarOnWindows);
+		Assert.True(Options.ShouldSuppressExceptionsInAnimations);
+		Assert.True(Options.ShouldSuppressExceptionsInBehaviors);
+		Assert.True(Options.ShouldSuppressExceptionsInConverters);
 		Assert.False(isAndroidDialogFragmentServiceInitialized);
 
 		Core.AppBuilderExtensions.ShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted -= HandleShouldUseStatusBarBehaviorOnAndroidModalPageOptionCompleted;

--- a/src/CommunityToolkit.Maui/AppBuilderExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui/AppBuilderExtensions.shared.cs
@@ -28,6 +28,7 @@ public static class AppBuilderExtensions
 		options?.Invoke(new Options(builder));
 
 		// Pass `null` because `options?.Invoke()` will set options on both `CommunityToolkit.Maui` and `CommunityToolkit.Maui.Core`
+		// Be sure to call `.UseMauiCommunityToolkitCore(null)` after `options.Invoke(new Options(builder))` to ensure `CommunityToolkit.Maui.Core.Options` have already been set
 		builder.UseMauiCommunityToolkitCore(null);
 
 		builder.Services.AddSingleton<IPopupService, PopupService>();

--- a/src/CommunityToolkit.Maui/AppBuilderExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui/AppBuilderExtensions.shared.cs
@@ -24,11 +24,11 @@ public static class AppBuilderExtensions
 	/// <returns><see cref="MauiAppBuilder"/> initialized for <see cref="CommunityToolkit.Maui"/></returns>
 	public static MauiAppBuilder UseMauiCommunityToolkit(this MauiAppBuilder builder, Action<Options>? options = null)
 	{
-		// Pass `null` because `options?.Invoke()` will set options on both `CommunityToolkit.Maui` and `CommunityToolkit.Maui.Core`
-		builder.UseMauiCommunityToolkitCore(null);
-
 		// Invokes options for both `CommunityToolkit.Maui` and `CommunityToolkit.Maui.Core`
 		options?.Invoke(new Options(builder));
+
+		// Pass `null` because `options?.Invoke()` will set options on both `CommunityToolkit.Maui` and `CommunityToolkit.Maui.Core`
+		builder.UseMauiCommunityToolkitCore(null);
 
 		builder.Services.AddSingleton<IPopupService, PopupService>();
 


### PR DESCRIPTION
 - Bug fix

 ### Description of Change ###

Currently you cannot opt out of using new functionality for dialogue fragments on android. Setting the option to do so does not work with core. This PR fixes that issue by placing setting options earlier in build order. 

 ### Linked Issues ###

 - Fixes #2490

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

This will allow ppl to opt out of using the new dialogue fragment in recent PR. Atm if you try to navigate to any page in sample app the app crashes to android desktop. This PR will fix that issue by allowing you to opt out. Current the opt out is not working. This PR addresses that issue only. It fixes options so that they work by placing options above core in build order.
 
