### PR TITLE
Fix Media Element Popup crash when switching to Full Screen mode

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml.cs
@@ -249,13 +249,12 @@ public partial class MediaElementPage : BasePage<MediaElementViewModel>
 		var popupMediaElement = new MediaElement
 		{
 			Source = MediaSource.FromResource("AppleVideo.mp4"),
-			HeightRequest = 600,
-			WidthRequest = 600,
 			ShouldAutoPlay = true,
 			ShouldShowPlaybackControls = true,
 		};
 		var popup = new Popup
 		{
+			Size = new Size(900, 600),
 			VerticalOptions = LayoutAlignment.Center,
 			HorizontalOptions = LayoutAlignment.Center,
 			Content = new StackLayout
@@ -268,10 +267,5 @@ public partial class MediaElementPage : BasePage<MediaElementViewModel>
 		};
 
 		this.ShowPopup(popup);
-		popup.Closed += (s, e) =>
-		{
-			popupMediaElement.Stop();
-			popupMediaElement.Handler?.DisconnectHandler();
-		};
 	}
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml.cs
@@ -248,13 +248,25 @@ public partial class MediaElementPage : BasePage<MediaElementViewModel>
 		MediaElement.Pause();
 		var popupMediaElement = new MediaElement
 		{
+			// Sizing differences between windows and iOS
+#if IOS || MACCATALYST
+			WidthRequest = 500,
+			HeightRequest = 250,
+#else
+			WidthRequest = 800,
+			HeightRequest = 300,
+#endif
 			Source = MediaSource.FromResource("AppleVideo.mp4"),
 			ShouldAutoPlay = true,
 			ShouldShowPlaybackControls = true,
 		};
 		var popup = new Popup
 		{
-			Size = new Size(900, 600),
+#if IOS || MACCATALYST
+			Size = new Size(500, 250),
+#else
+			Size = new Size(800, 300),
+#endif
 			VerticalOptions = LayoutAlignment.Center,
 			HorizontalOptions = LayoutAlignment.Center,
 			Content = new StackLayout


### PR DESCRIPTION
 - Bug fix

 ### Description of Change ###

Remove Close method for Media Element Popup in Sample app. We had a handler disconnect that is no longer required that was crashing the popup. Removing it and allowing Maui to automatically control the handler removal fixes the issue.

 ### Linked Issues ###

 - Fixes #1869
 - Fixes #2250

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->
 
Video:



https://github.com/user-attachments/assets/baea6778-28d8-43c1-a838-c9f9a9817bf2

