### PR TITLE
Change parts of Expander implementation to support animation

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/Expander/ExpanderPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/Expander/ExpanderPage.xaml
@@ -17,7 +17,7 @@
 
             <Label Text="Simple expander" FontSize="24" FontAttributes="Bold"/>
 
-            <mct:Expander>
+            <mct:Expander PropertyChanged="AnimateExpander">
                 <mct:Expander.Header>
                     <Label Text="Simple Expander (Tap Me)" FontSize="16" FontAttributes="Bold"/>
                 </mct:Expander.Header>
@@ -32,12 +32,12 @@
 
             <Label Text="Multi-level expander" FontSize="24" FontAttributes="Bold"/>
 
-            <mct:Expander Direction="Up">
+            <mct:Expander Direction="Up" PropertyChanged="AnimateExpander">
                 <mct:Expander.Header>
                     <Label Text="Multi-Level Expander (Tap Me)" FontSize="16" FontAttributes="Bold"/>
                 </mct:Expander.Header>
                 <mct:Expander.Content>
-                    <mct:Expander Direction="Down" BackgroundColor="LightGray">
+                    <mct:Expander Direction="Down" BackgroundColor="LightGray" PropertyChanged="AnimateExpander">
                         <mct:Expander.Header>
                             <Label Text="Nested Expander (Tap Me)" FontSize="14" FontAttributes="Bold"/>
                         </mct:Expander.Header>
@@ -56,7 +56,8 @@
                     <DataTemplate>
                         <ViewCell>
                             <mct:Expander x:DataType="sample:ContentCreator"
-                                          ExpandedChanged="Expander_ExpandedChanged">
+                                          ExpandedChanged="Expander_ExpandedChanged"
+                                          PropertyChanged="AnimateExpander">
                                 <mct:Expander.Header>
                                     <Label Text="{Binding Name}"/>
                                 </mct:Expander.Header>
@@ -80,7 +81,8 @@
                 <CollectionView.ItemTemplate>
                     <DataTemplate>
                         <mct:Expander x:DataType="sample:ContentCreator"
-                                      ExpandedChanged="Expander_ExpandedChanged">
+                                      ExpandedChanged="Expander_ExpandedChanged"
+                                      PropertyChanged="AnimateExpander">
                             <mct:Expander.Header>
                                 <Label Text="{Binding Name}"/>
                             </mct:Expander.Header>
@@ -109,7 +111,8 @@
                 <CollectionView.ItemTemplate>
                     <DataTemplate>
                         <mct:Expander x:DataType="sample:ContentCreator"
-                                      ExpandedChanged="Expander_ExpandedChanged">
+                                      ExpandedChanged="Expander_ExpandedChanged"
+                                      PropertyChanged="AnimateExpander">
                             <mct:Expander.Header>
                                 <Label Text="{Binding Name}"/>
                             </mct:Expander.Header>

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/Expander/ExpanderPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/Expander/ExpanderPage.xaml.cs
@@ -16,11 +16,22 @@ public partial class ExpanderPage : BasePage<ExpanderViewModel>
 	async void Expander_ExpandedChanged(object sender, Core.ExpandedChangedEventArgs e)
 	{
 		var collapsedText = e.IsExpanded ? "expanded" : "collapsed";
+
 		await Toast.Make($"Expander is {collapsedText}").Show(CancellationToken.None);
 	}
 
 	async void GoToCSharpSampleClicked(object sender, EventArgs e)
 	{
 		await Navigation.PushAsync(new ExpanderPageCS());
+	}
+
+	async void AnimateExpander(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+	{
+		if (e.PropertyName == CommunityToolkit.Maui.Views.Expander.IsExpandedProperty.PropertyName)
+		{
+			CommunityToolkit.Maui.Views.Expander expander = (CommunityToolkit.Maui.Views.Expander)sender;
+			expander.ContentHeight = expander.IsExpanded ? expander.MinimumContentHeight : expander.MaximumContentHeight;
+			await expander.ContentHeightTo(expander.IsExpanded ? expander.MaximumContentHeight : expander.MinimumContentHeight, 250, Easing.CubicInOut);
+		}
 	}
 }

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/Expander/ExpanderPageCS.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/Expander/ExpanderPageCS.cs
@@ -16,6 +16,8 @@ public partial class ExpanderPageCS : ContentPage
 
 		Title = "Expander Page, C# UI";
 
+		Expander expander;
+
 		Content = new VerticalStackLayout()
 		{
 			Spacing = 12,
@@ -31,7 +33,7 @@ public partial class ExpanderPageCS : ContentPage
 					.CenterHorizontal().TextCenter()
 					.Assign(out Picker picker),
 
-				new Expander
+				(expander = new Expander
 				{
 					Header = new Label()
 								.Text("Expander\n(Tap Me)")
@@ -60,7 +62,17 @@ public partial class ExpanderPageCS : ContentPage
 						static (Picker picker) => picker.SelectedIndex,
 						source: picker,
 						convert: (int selectedIndex) => Enum.IsDefined(typeof(ExpandDirection), selectedIndex) ? (ExpandDirection)selectedIndex : default)
+				 )
 			 }
+		};
+
+		expander.PropertyChanged += async (s, e) =>
+		{
+			if (e.PropertyName == Expander.IsExpandedProperty.PropertyName)
+			{
+				expander.ContentHeight = expander.IsExpanded ? expander.MinimumContentHeight : expander.MaximumContentHeight;
+				await expander.ContentHeightTo(expander.IsExpanded ? expander.MaximumContentHeight : expander.MinimumContentHeight, 250, Easing.CubicInOut);
+			}
 		};
 	}
 }


### PR DESCRIPTION
 ### Description of Change ###

Change the way how Expander implements expanding and collapsing from an Content.IsVisibile changed to a VerticalStackLayout.HeightRequest change so that animations can be applied to the HeightRequest property.

Updates where made to the sample to demonstrate how the animation may work.

No changes were made to the unit tests as it was felt that the core Expander component was kept at feature parity.

 ### Linked Issues ###

https://github.com/CommunityToolkit/Maui/issues/2521

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->

 ### Additional information ###

This PR was created to solicit suggestions from the team.