### PR TITLE
Increase `Microsoft.Maui.*` Dependencies to v9.0.40

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -22,7 +22,7 @@ env:
   NugetPackageVersionCamera: '99.0.0-preview${{ github.run_number }}'
   NugetPackageVersionMediaElement: '99.0.0-preview${{ github.run_number }}'
   NugetPackageVersionMaps: '99.0.0-preview${{ github.run_number }}'
-  TOOLKIT_NET_VERSION: '9.0.102'
+  TOOLKIT_NET_VERSION: '9.0.200'
   LATEST_NET_VERSION: '9.0.x'
   PathToLibrarySolution: 'src/CommunityToolkit.Maui.sln'
   PathToSamplesSolution: 'samples/CommunityToolkit.Maui.Sample.sln'

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
     <NuGetAuditMode>all</NuGetAuditMode>
 
     <!-- MAUI Specific -->
-    <MauiPackageVersion>9.0.30</MauiPackageVersion>
+    <MauiPackageVersion>9.0.40</MauiPackageVersion>
     <NextMauiPackageVersion>10.0.0</NextMauiPackageVersion>
     <MauiStrictXamlCompilation>true</MauiStrictXamlCompilation>
     <SkipValidateMauiImplicitPackageReferences>true</SkipValidateMauiImplicitPackageReferences>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ variables:
   NugetPackageVersionCamera: '$(CurrentSemanticVersion)'
   NugetPackageVersionMediaElement: '$(CurrentSemanticVersion)'
   NugetPackageVersionMaps: '$(CurrentSemanticVersion)'
-  TOOLKIT_NET_VERSION: '9.0.102'
+  TOOLKIT_NET_VERSION: '9.0.200'
   LATEST_NET_VERSION: '9.0.x'
   PathToLibrarySolution: 'src/CommunityToolkit.Maui.sln'
   PathToSamplesSolution: 'samples/CommunityToolkit.Maui.Sample.sln'

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.102",
+    "version": "9.0.200",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/src/CommunityToolkit.Maui.Camera/CommunityToolkit.Maui.Camera.csproj
+++ b/src/CommunityToolkit.Maui.Camera/CommunityToolkit.Maui.Camera.csproj
@@ -55,15 +55,6 @@
     <PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.4.1" />
     <PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.4.1" />
 
-    <!-- Increase Minimum Version of Transient Dependencies For Xamarin.AndroidX.Camera.Camera2 and Xamarin.AndroidX.Camera.View -->
-    <PackageReference Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.8.5.1" />
-    <PackageReference Include="Xamarin.AndroidX.Activity.Ktx" Version="1.9.3.1" />
-    <PackageReference Include="Xamarin.AndroidX.Collection.Jvm" Version="1.4.5.1" />
-    <PackageReference Include="Xamarin.AndroidX.Collection.Ktx" Version="1.4.5.1" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.8.7.1" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" Version="2.8.7.1" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.8.7.1" />
-
     <!--  Ensure Linker does not remove required libraries -->
     <None Include="linker.xml" Pack="true" PackagePath="build\$(PackageId).LinkerConfigurationFile.xml" />
   </ItemGroup>

--- a/src/CommunityToolkit.Maui.MediaElement/CommunityToolkit.Maui.MediaElement.csproj
+++ b/src/CommunityToolkit.Maui.MediaElement/CommunityToolkit.Maui.MediaElement.csproj
@@ -63,17 +63,7 @@
     <PackageReference Include="Xamarin.AndroidX.Media3.ExoPlayer.Rtsp" Version="1.5.0" />
     <PackageReference Include="Xamarin.AndroidX.Media3.ExoPlayer.Hls" Version="1.5.0" />
     <PackageReference Include="Xamarin.AndroidX.Media3.ExoPlayer.Dash" Version="1.5.0" />
-    <PackageReference Include="Xamarin.AndroidX.Media3.Session" Version="1.5.0" />
-    
-    <!-- Resolve Transient Dependancies -->
-    <PackageReference Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.8.5.1" />
-    <PackageReference Include="Xamarin.AndroidX.Activity.Ktx" Version="1.9.3.1" />
-    <PackageReference Include="Xamarin.AndroidX.Collection.Jvm" Version="1.4.5.1" />
-    <PackageReference Include="Xamarin.AndroidX.Collection.Ktx" Version="1.4.5.1" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.8.7.1" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Runtime" Version="2.8.7.1" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.Process" Version="2.8.7.1" />
-    
+    <PackageReference Include="Xamarin.AndroidX.Media3.Session" Version="1.5.0" />    
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
 ### Description of Change ###

This PR bumps `MauiPackageVersion` to `9.0.40` and bumps the minimum .NET SDK version to `9.0.200`.

Thanks to the updated Android Dependencies in the `Microsoft.Maui.Controls` NuGet Package, we can remove the transient Android dependencies in `CommunityToolkit.Maui.Camera` and `CommunityToolkit.Maui.MediaElement`.

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)


 ### Additional information ###

The `MauiPackageVersion` property is used to define the version number for every `Microsoft.Maui.*` dependency used in each .NET MAUI Community Toolkit, e.g. `Microsoft.Maui.Controls`, `Microsoft.Maui.Essentials`, etc.

This update requires users to install the latest .NET SDK and the latest MAUI Workloads installed on their local environment. I've added the https://github.com/CommunityToolkit/Maui/labels/requirements%20updated label.

Here is the updated requirements we will need to include in the Release Notes:

```md
## Requirements

The following tools are now required for CommunityToolkit.Maui:
- [ ] Download/install [.NET SDK v9.0.200](https://dotnet.microsoft.com/download/dotnet/)
- [ ] Install Xcode 16.2.0 (or higher)
  - Read the [latest .NET MAUI Release wiki](https://github.com/dotnet/maui/wiki/Release-Versions) to always find the latest-supported version) of Xcode for .NET MAUI 
  - We HIGHLY recommend using the open-source tool [Xcodes](https://github.com/XcodesOrg/XcodesApp) to easily manage your installed Xcode versions
- [ ] Update to the latest stable version of Visual Studio (or Jet Brains Rider)
- [ ] After installing the latest stable .NET SDK, update to the latest stable version of the .NET MAUI workload:
  - On macOS, open the Terminal and enter the following command: `sudo dotnet workload install maui; sudo dotnet workload update`
  - On Windows, open the command prompt (or Powershell) and enter the following command: `dotnet workload install maui;dotnet workload update`
- [ ] Add a [`global.json`](https://learn.microsoft.com/dotnet/core/tools/global-json) file to your application with the following parameters to ensure you're not using a unsupported preview version of .NET (example below)
  - The .NET MAUI Community Toolkit does not support preview releases of .NET 

### global.json
    ```
    {
      "sdk": {
        "version": "9.0.200", 
        "rollForward": "latestFeature",
        "allowPrerelease": false
      }
    }
    ```
```

 
