### PR TITLE
Fix MediaElement not working on FlyoutPage in IOS/MAC Catalyst

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.macios.cs
@@ -168,6 +168,11 @@ public class MauiMediaElement : UIView
 			currentPage = modalPage;
 			return true;
 		}
+		if (window.Page is FlyoutPage flyoutPage)
+		{
+			currentPage = flyoutPage;
+			return true;
+		}
 
 		// If not using Shell or a Modal Page, return the visible page in the (non-modal) NavigationStack
 		if (window.Navigation.NavigationStack[^1] is Page page)


### PR DESCRIPTION
 - Bug fix

 ### Description of Change ###

 Support for Media Element on a `FlyoutPage` does not currently work on IOS. This adds support for it on IOS and Mac Catalyst.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #2517

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###
Windows and android already support playback on a FlyoutPage.

 
