### PR TITLE
Fix for camera crash when in use on Windows

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/CameraView/CameraViewPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/CameraView/CameraViewPage.xaml.cs
@@ -16,6 +16,7 @@ public partial class CameraViewPage : BasePage<CameraViewViewModel>
 		imagePath = Path.Combine(fileSystem.CacheDirectory, "camera-view-image.jpg");
 
 		Camera.MediaCaptured += OnMediaCaptured;
+		Camera.MediaCaptureFailed += OnMediaCaptureFailed;
 
 		Loaded += (s, e) =>
 		{
@@ -56,6 +57,7 @@ public partial class CameraViewPage : BasePage<CameraViewViewModel>
 
 	void Cleanup()
 	{
+		Camera.MediaCaptureFailed -= OnMediaCaptureFailed;
 		Camera.MediaCaptured -= OnMediaCaptured;
 		Camera.Handler?.DisconnectHandler();
 	}
@@ -83,6 +85,11 @@ public partial class CameraViewPage : BasePage<CameraViewViewModel>
 			debugText.Text = $"Image saved to {imagePath}";
 		});
 
+	}
+
+	void OnMediaCaptureFailed(object? sender, MediaCaptureFailedEventArgs e)
+	{
+		debugText.Text = $"Exception: {e.FailureReason}";
 	}
 
 	void ZoomIn(object? sender, EventArgs e)

--- a/src/CommunityToolkit.Maui.Camera/CameraManager.windows.cs
+++ b/src/CommunityToolkit.Maui.Camera/CameraManager.windows.cs
@@ -106,7 +106,6 @@ partial class CameraManager
 		catch (Exception ex)
 		{
 			cameraView.OnMediaCapturedFailed(ex.Message);
-			throw;
 		}
 	}
 


### PR DESCRIPTION
 ### Description of Change ###

Fixes windows app crash by not rethrowing an exception that is already handled by the `MediaCapturedFailed` event. The exception can't be caught by the user as the code is run as part of a handler update.

The PR also adds a `MediaCapturedFailed` event handler to the sample app.

 ### Linked Issues ###

 - Fixes #2520

 ### PR Checklist ###
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->

I extended the sample app to display the error from the `MediaCapturedFailed` event instead of creating a unit test, as the issue can only be reproduced manually.

 ### Additional information ###

When checking the code for places where the `MediaCapturedFailed` event is called and then the exception is re-thrown, I found another code place, but I couldn't reproduce the error here. Might be worth investigating and also applying the fix:

(https://github.com/CommunityToolkit/Maui/blob/0a4dd43e14c07c4df6ed2241ac600d5f972f90f9/src/CommunityToolkit.Maui.Camera/CameraManager.android.cs#L299)