### PR TITLE
[Housekeeping] Increase minimum .NET SDK dependency to v9.0.202

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -22,7 +22,7 @@ env:
   NugetPackageVersionCamera: '99.0.0-preview${{ github.run_number }}'
   NugetPackageVersionMediaElement: '99.0.0-preview${{ github.run_number }}'
   NugetPackageVersionMaps: '99.0.0-preview${{ github.run_number }}'
-  TOOLKIT_NET_VERSION: '9.0.200'
+  TOOLKIT_NET_VERSION: '9.0.202'
   LATEST_NET_VERSION: '9.0.x'
   PathToLibrarySolution: 'src/CommunityToolkit.Maui.sln'
   PathToSamplesSolution: 'samples/CommunityToolkit.Maui.Sample.sln'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ variables:
   NugetPackageVersionCamera: '$(CurrentSemanticVersion)'
   NugetPackageVersionMediaElement: '$(CurrentSemanticVersion)'
   NugetPackageVersionMaps: '$(CurrentSemanticVersion)'
-  TOOLKIT_NET_VERSION: '9.0.200'
+  TOOLKIT_NET_VERSION: '9.0.202'
   LATEST_NET_VERSION: '9.0.x'
   PathToLibrarySolution: 'src/CommunityToolkit.Maui.sln'
   PathToSamplesSolution: 'samples/CommunityToolkit.Maui.Sample.sln'

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.200",
+    "version": "9.0.202",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }


### PR DESCRIPTION
 # Description of Change 

This PR increases our minimum .NET SDK version to v9.0.2.02 to coincide with [increasing our `Microsoft.Maui.*` dependency to v9.0.50](https://github.com/CommunityToolkit/Maui/pull/2584).

Increasing the minimum .NET SDK version ensures that users are required to install the latest .NET MAUI workloads to correspond with the `Microsoft.Maui.*` v9.0.50 libraries.

 # Additional information

We will need to include the following in our next release notes:

## Requirements

The following tools are now required for CommunityToolkit.Maui:
- [ ] Download/install [.NET SDK v9.0.202](https://dotnet.microsoft.com/download/dotnet/)
- [ ] Install Xcode 16.2.0 (or higher)
  - Read the [latest .NET MAUI Release wiki](https://github.com/dotnet/maui/wiki/Release-Versions) to always find the latest-supported version) of Xcode for .NET MAUI 
  - We HIGHLY recommend using the open-source tool [Xcodes](https://github.com/XcodesOrg/XcodesApp) to easily manage your installed Xcode versions
- [ ] Update to the latest stable version of Visual Studio (or Jet Brains Rider)
- [ ] After installing the latest stable .NET SDK, update to the latest stable version of the .NET MAUI workload:
  - On macOS, open the Terminal and enter the following command: `sudo dotnet workload install maui; sudo dotnet workload update`
  - On Windows, open the command prompt (or Powershell) and enter the following command: `dotnet workload install maui;dotnet workload update`
- [ ] Add a [`global.json`](https://learn.microsoft.com/dotnet/core/tools/global-json) file to your application with the following parameters to ensure you're not using a unsupported preview version of .NET (example below)
  - The .NET MAUI Community Toolkit does not support preview releases of .NET 

### global.json
```
{
  "sdk": {
    "version": "9.0.202", 
    "rollForward": "latestFeature",
    "allowPrerelease": false
  }
}
```

