### PR TITLE
Pin WindowsSdkPackageVersion

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,6 +22,12 @@
     <SkipValidateMauiImplicitPackageReferences>true</SkipValidateMauiImplicitPackageReferences>
     <MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
 
+    <!-- WindowsAppSDK
+      We should keep this in sync with .NET MAUI https://github.com/dotnet/maui/blob/8ee00e00f603cd8a420a3467daddaf3935c8c587/Directory.Build.props#L142 
+      This will prevent transitive dependencies from causing conflicts when they're not aligned.
+    -->
+    <WindowsSdkPackageVersion>10.0.19041.44</WindowsSdkPackageVersion>
+
     <!-- https://learn.microsoft.com/dotnet/core/deploying/native-aot/?tabs=net8plus%2Cwindows -->
     <StripSymbols>false</StripSymbols>
     <TrimmerSingleWarn>false</TrimmerSingleWarn>


### PR DESCRIPTION
 ### Description of Change ###

Also see #2612, but this one should be merged to main.

This change pins the `WindowsSdkPackageVersion` in the `Directory.Build.props` file to `10.0.19041.44`. Additionally, it adds a note about keeping this in sync with .NET MAUI.

When we don't do that, depending on what is installed on the build agent or local machines or how the stars are aligned, we can get different versions of the WindowsAppSDK. That in turn might bring in different versions of transitive packages like WinRT.Runtime.

This was the case I was hitting. I tried to update the Toolkit dependency for the .NET MAUI templates, but it wouldn't build because the Toolkit was (transitively) referencing WinRT.Runtime 2.2.0 (because we were building against a newer WindowsAppSDK) and the templates were referencing WinRT.Runtime 2.1.0, because .NET MAUI pins the WindowsAppSDK to 10.0.19041.44 (at time of writing).

To overcome this happening by surprise lets pin the WindowsSdkPackageVersion in the Toolkit to the same version as .NET MAUI.

I'm doing this on a weirdish branch that is branched of the 11.1.0 tag and will be released as a 11.1.1 version. This is needed because 11.2.0 has a minimum dependency on .NET MAUI 9.0.50. The templates will be inserted in Visual Studio together with version 9.0.40, so I will need a version of the Toolkit with this bug fixed _and_ that is able to be used with 9.0.40, hence this extra release.

This change also needs to be ported to the main branch so that we also do this moving forward.
 
