### PR TITLE
Move UseMicrosoftTestingPlatformRunner to Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -199,6 +199,13 @@
       IL3050,IL3051,IL3052,IL3053,IL3054,IL3055,IL3056,
       RS2007
     </WarningsAsErrors>
+
+    <!--
+      Once the repo moves to .NET 10 SDK, TestingPlatformDotnetTestSupport should be
+      replaced by dotnet.config that opts in the new dotnet test experience for Microsoft.Testing.Platform
+    -->
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
   <!-- Required for NuGet Source Link -->

--- a/src/CommunityToolkit.Maui.Analyzers.UnitTests/CommunityToolkit.Maui.Analyzers.UnitTests.csproj
+++ b/src/CommunityToolkit.Maui.Analyzers.UnitTests/CommunityToolkit.Maui.Analyzers.UnitTests.csproj
@@ -9,9 +9,6 @@
 
     <OutputType>Exe</OutputType>
     <RootNamespace>CommunityToolkit.Maui.Analyzers.UnitTests</RootNamespace>
-
-    <TestingPlatformDotnetTestSupport>false</TestingPlatformDotnetTestSupport>
-    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2" />
-    <PackageReference Include="xunit.v3" Version="1.1.0" />
+    <PackageReference Include="xunit.v3" Version="2.0.0" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.13.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />
   </ItemGroup>

--- a/src/CommunityToolkit.Maui.UnitTests/CommunityToolkit.Maui.UnitTests.csproj
+++ b/src/CommunityToolkit.Maui.UnitTests/CommunityToolkit.Maui.UnitTests.csproj
@@ -7,16 +7,13 @@
 
     <OutputType>Exe</OutputType>
     <RootNamespace>CommunityToolkit.Maui.UnitTests</RootNamespace>
-
-    <TestingPlatformDotnetTestSupport>false</TestingPlatformDotnetTestSupport>
-    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="8.0.1" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.34.1" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
-    <PackageReference Include="xunit.v3" Version="1.1.0" />
+    <PackageReference Include="xunit.v3" Version="2.0.0" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.13.1" />
   </ItemGroup>
 


### PR DESCRIPTION
- Adding `UseMicrosoftTestingPlatformRunner` in individual projects is discouraged. It's much better to have it in a centralized place like `Directory.Build.props`.
- I don't see a good reason to not set `TestingPlatformDotnetTestSupport` to true as well. So I changed it from false to true.
- Also updated xunit.v3 to 2.0.0