### PR TITLE
Add `<InternalsVisibleTo Include="CommunityToolkit.Maui"/>` to `CommunityToolkit.Maui.Core.csproj`

### DIFF
--- a/src/CommunityToolkit.Maui.Core/CommunityToolkit.Maui.Core.csproj
+++ b/src/CommunityToolkit.Maui.Core/CommunityToolkit.Maui.Core.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <None Include="..\..\build\nuget.png" PackagePath="icon.png" Pack="true" />
     <None Include="ReadMe.txt" pack="true" PackagePath="." />
+    <InternalsVisibleTo Include="CommunityToolkit.Maui"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CommunityToolkit.Maui.Core/Primitives/Defaults/AlertDefaults.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Primitives/Defaults/AlertDefaults.shared.cs
@@ -1,40 +1,32 @@
-﻿using System.ComponentModel;
-
-namespace CommunityToolkit.Maui.Core;
+﻿namespace CommunityToolkit.Maui.Core;
 
 /// <summary>
 /// Default Values for <see cref="IAlert"/>
 /// </summary>
-[EditorBrowsable(EditorBrowsableState.Never)]
-public static class AlertDefaults
+static class AlertDefaults
 {
 	/// <summary>
 	/// Default Font Size
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double FontSize = 14;
 
 	/// <summary>
 	/// Default Character Spacing
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double CharacterSpacing = 0.0d;
 
 	/// <summary>
 	/// Default Character Spacing
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const string ActionButtonText = "OK";
 
 	/// <summary>
 	/// Default Text Color
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static Color TextColor { get; } = Colors.Black;
 
 	/// <summary>
 	/// Default Background Color
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static Color BackgroundColor { get; } = Colors.LightGray;
 }

--- a/src/CommunityToolkit.Maui.Core/Primitives/Defaults/AvatarViewDefaults.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Primitives/Defaults/AvatarViewDefaults.shared.cs
@@ -3,34 +3,26 @@
 namespace CommunityToolkit.Maui.Core;
 
 /// <summary>Default Values for <see cref="IAvatarView"/></summary>
-[EditorBrowsable(EditorBrowsableState.Never)]
-public static class AvatarViewDefaults
+static class AvatarViewDefaults
 {
 	/// <summary>Default avatar border width.</summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double DefaultBorderWidth = 1;
 
 	/// <summary>Default height request.</summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double DefaultHeightRequest = 48;
 
 	/// <summary>Default avatar text.</summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const string DefaultText = "?";
 
 	/// <summary>Default width request.</summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double DefaultWidthRequest = 48;
 
 	/// <summary>default avatar border colour.</summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static Color DefaultBorderColor { get; } = Colors.White;
 
 	/// <summary>Default corner radius.</summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static CornerRadius DefaultCornerRadius { get; } = new(24, 24, 24, 24);
 
 	/// <summary>Default padding.</summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static Thickness DefaultPadding { get; } = new(1);
 }

--- a/src/CommunityToolkit.Maui.Core/Primitives/Defaults/DrawingViewDefaults.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Primitives/Defaults/DrawingViewDefaults.shared.cs
@@ -5,48 +5,40 @@ namespace CommunityToolkit.Maui.Core;
 /// <summary>
 /// Default Values for <see cref="IDrawingView"/>
 /// </summary>
-[EditorBrowsable(EditorBrowsableState.Never)]
-public static class DrawingViewDefaults
+static class DrawingViewDefaults
 {
 	/// <summary>
 	/// Minimum Granularity
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const int MinimumGranularity = 5;
 
 	/// <summary>
 	/// Default Line Width
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const float LineWidth = 5;
 
 	/// <summary>
 	/// Default Value for ShouldSmoothPathWhenDrawn
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const bool ShouldSmoothPathWhenDrawn = true;
 
 	/// <summary>
 	/// Default Value for IsMultiLineModeEnabled
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const bool IsMultiLineModeEnabled = false;
 
 	/// <summary>
 	/// Default Value for ShouldClearOnFinish
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const bool ShouldClearOnFinish = false;
 
 	/// <summary>
 	/// Default Line Color
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static Color LineColor { get; } = Colors.Black;
 
 	/// <summary>
 	/// Default Background Color
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static Color BackgroundColor { get; } = Colors.LightGray;
 }

--- a/src/CommunityToolkit.Maui.Core/Primitives/Defaults/ImageTouchBehaviorDefaults.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Primitives/Defaults/ImageTouchBehaviorDefaults.shared.cs
@@ -5,47 +5,40 @@ namespace CommunityToolkit.Maui.Core;
 /// <summary>
 /// Default Values for ImageTouchBehavior/>
 /// </summary>
-public static class ImageTouchBehaviorDefaults
+static class ImageTouchBehaviorDefaults
 {
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="DefaultBackgroundImageSource"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const object? DefaultBackgroundImageSource = null;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="HoveredBackgroundImageSource"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const object? HoveredBackgroundImageSource = null;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="PressedBackgroundImageSource"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const object? PressedBackgroundImageSource = null;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="DefaultBackgroundImageAspect"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const Aspect DefaultBackgroundImageAspect = Aspect.AspectFit;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="HoveredBackgroundImageAspect"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const Aspect HoveredBackgroundImageAspect = Aspect.AspectFit;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="PressedBackgroundImageAspect"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const Aspect PressedBackgroundImageAspect = Aspect.AspectFit;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="ShouldSetImageOnAnimationEnd"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const bool ShouldSetImageOnAnimationEnd = false;
 }

--- a/src/CommunityToolkit.Maui.Core/Primitives/Defaults/RatingViewDefaults.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Primitives/Defaults/RatingViewDefaults.shared.cs
@@ -5,54 +5,41 @@ using System.ComponentModel;
 namespace CommunityToolkit.Maui.Core;
 
 /// <summary>Default Values for RatingView</summary>
-[EditorBrowsable(EditorBrowsableState.Never)]
-public static class RatingViewDefaults
+static class RatingViewDefaults
 {
 	/// <summary>Default rating value.</summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double DefaultRating = 0.0;
 
 	/// <summary>Default view element read only.</summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const bool IsReadOnly = false;
 
 	/// <summary>Default size of a rating item shape.</summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double ItemShapeSize = 20.0;
 
 	/// <summary>Default maximum value for the rating.</summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const int MaximumRating = 5;
 
 	/// <summary>Maximum number of ratings.</summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const int MaximumRatingLimit = 10;
 
 	/// <summary>Default border thickness for a rating shape.</summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double ShapeBorderThickness = 1.0;
 
 	/// <summary>Default spacing between ratings.</summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double Spacing = 10.0;
 
 	/// <summary>Default color for an empty rating.</summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static Color EmptyShapeColor { get; } = Colors.Transparent;
 
 	/// <summary>Default filled color for a rating.</summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static Color FillColor { get; } = Colors.Yellow;
 
 	/// <summary>Default rating item padding.</summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static Thickness ShapePadding { get; } = new(0);
 
 	/// <summary>Default rating shape.</summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static RatingViewShape Shape { get; } = RatingViewShape.Star;
 
 	/// <summary>Default border color for a rating shape.</summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static Color ShapeBorderColor { get; } = Colors.Grey;
 }

--- a/src/CommunityToolkit.Maui.Core/Primitives/Defaults/TouchBehaviorDefaults.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Primitives/Defaults/TouchBehaviorDefaults.shared.cs
@@ -5,240 +5,200 @@ namespace CommunityToolkit.Maui.Core;
 /// <summary>
 /// Default Values for TouchBehavior/>
 /// </summary>
-[EditorBrowsable(EditorBrowsableState.Never)]
-public static class TouchBehaviorDefaults
+static class TouchBehaviorDefaults
 {
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="HoveredOpacity"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double HoveredOpacity = 1;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="PressedOpacity"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double PressedOpacity = 1;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="DefaultOpacity"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double DefaultOpacity = 1;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="HoveredScale"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double HoveredScale = 1;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="PressedScale"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double PressedScale = 1;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="DefaultScale"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double DefaultScale = 1;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="HoveredTranslationX"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double HoveredTranslationX = 0;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="PressedTranslationX"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double PressedTranslationX = 0;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="DefaultTranslationX"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double DefaultTranslationX = 0;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="HoveredTranslationY"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double HoveredTranslationY = 0;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="PressedTranslationY"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double PressedTranslationY = 0;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="DefaultTranslationY"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double DefaultTranslationY = 0;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="HoveredRotation"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double HoveredRotation = 0;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="PressedRotation"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double PressedRotation = 0;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="DefaultRotation"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double DefaultRotation = 0;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="HoveredRotationX"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double HoveredRotationX = 0;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="PressedRotationX"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double PressedRotationX = 0;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="DefaultRotationX"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double DefaultRotationX = 0;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="HoveredRotationY"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double HoveredRotationY = 0;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="PressedRotationY"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double PressedRotationY = 0;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="DefaultRotationY"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const double DefaultRotationY = 0;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="DefaultAnimationDuration"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const int DefaultAnimationDuration = 0;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="HoveredAnimationDuration"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const int HoveredAnimationDuration = 0;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="PressedAnimationDuration"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const int PressedAnimationDuration = 0;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="DefaultAnimationEasing"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const Easing? DefaultAnimationEasing = null;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="HoveredAnimationEasing"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const Easing? HoveredAnimationEasing = null;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="PressedAnimationEasing"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const Easing? PressedAnimationEasing = null;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="LongPressDuration"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const int LongPressDuration = 500;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="IsEnabled"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const bool IsEnabled = true;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="DisallowTouchThreshold"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const int DisallowTouchThreshold = 0;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="ShouldMakeChildrenInputTransparent"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const bool ShouldMakeChildrenInputTransparent = true;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="CurrentTouchState"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const TouchState CurrentTouchState = TouchState.Default;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="CurrentTouchStatus"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const TouchStatus CurrentTouchStatus = TouchStatus.Completed;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="CurrentHoverState"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const HoverState CurrentHoverState = HoverState.Default;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="CurrentHoverStatus"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const HoverStatus CurrentHoverStatus = HoverStatus.Exited;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="CurrentInteractionStatus"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const TouchInteractionStatus CurrentInteractionStatus = TouchInteractionStatus.Completed;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="DefaultBackgroundColor"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const Color? DefaultBackgroundColor = null;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="HoveredBackgroundColor"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const Color? HoveredBackgroundColor = null;
 
 	/// <summary>
 	/// Default Value for TouchBehavior <see cref="PressedBackgroundColor"/>
 	/// </summary>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public const Color? PressedBackgroundColor = null;
 }


### PR DESCRIPTION
 ### Description of Change ###

This PR adds `<InternalsVisibleTo Include="CommunityToolkit.Maui"/>` to `CommunityToolkit.Maui.Core.csproj`

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

This PR was created in support of #1581 to allow us to avoid duplicating internal code in both `CommunityToolkit.Maui` and `CommunityToolkit.Maui.Core`.

Direct link to code review conversation: https://github.com/CommunityToolkit/Maui/pull/1581/files/d6be9aa2a69235b93c767950320d672801381f72#diff-cf2cf0700afaffb4d539f76209659b6a99b97459af586d68507410fd166a1a99

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)


 ### Additional information ###

This PR also removes the `[EditorBrowsable(EditorBrowsableState.Never)]` from unsupported/undocumented `Defaults` constants and reduces each class's scope from `public` to `internal`
