### PR TITLE
Remove MediaElement Handler disconnect in popups

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml.cs
@@ -250,6 +250,7 @@ public partial class MediaElementPage : BasePage<MediaElementViewModel>
 		{
 			AndroidViewType = AndroidViewType.SurfaceView,
 			Source = MediaSource.FromResource("AppleVideo.mp4"),
+			MetadataArtworkUrl = botImageUrl,
 			HeightRequest = 600,
 			WidthRequest = 600,
 			ShouldAutoPlay = true,
@@ -272,7 +273,6 @@ public partial class MediaElementPage : BasePage<MediaElementViewModel>
 		popup.Closed += (s, e) =>
 		{
 			popupMediaElement.Stop();
-			popupMediaElement.Handler?.DisconnectHandler();
 		};
 	}
 }


### PR DESCRIPTION
 - Bug fix

 ### Description of Change ###
This change is for something that was missed when migrating to dotnet 9.x. The manual disconnect of media element is no longer needed. It was removed from sample app but was missed in popup. This removes it from sample app. An update to docs is going to be required.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #2653

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [x] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/548


 ### Additional information ###

This fix will remove manually disconnecting the handler which is not longer needed. It is now handled by dotnet maui directly.
 
