### PR TITLE
Add support to make AndroidForegroundService optional to MediaElement

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml
@@ -30,6 +30,7 @@
             <toolkit:MediaElement
                 x:Name="MediaElement"
                 ShouldAutoPlay="True"
+                AndroidForegroundServiceEnabled="True"
                 Source="{x:Static constants:StreamingVideoUrls.BuckBunny}"
                 MetadataArtworkUrl="https://lh3.googleusercontent.com/pw/AP1GczNRrebWCJvfdIau1EbsyyYiwAfwHS0JXjbioXvHqEwYIIdCzuLodQCZmA57GADIo5iB3yMMx3t_vsefbfoHwSg0jfUjIXaI83xpiih6d-oT7qD_slR0VgNtfAwJhDBU09kS5V2T5ZML-WWZn8IrjD4J-g=w1792-h1024-s-no-gm"
                 MetadataTitle="Big Buck Bunny"

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml.cs
@@ -250,7 +250,7 @@ public partial class MediaElementPage : BasePage<MediaElementViewModel>
 		{
 			AndroidViewType = AndroidViewType.SurfaceView,
 			Source = MediaSource.FromResource("AppleVideo.mp4"),
-			MetadataArtworkUrl = botImageUrl,
+			AndroidForegroundServiceEnabled = false,
 			HeightRequest = 600,
 			WidthRequest = 600,
 			ShouldAutoPlay = true,

--- a/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Handlers/MediaElementHandler.android.cs
@@ -24,7 +24,7 @@ public partial class MediaElementHandler : ViewHandler<MediaElement, MauiMediaEl
 								VirtualView,
 								Dispatcher.GetForCurrentThread() ?? throw new InvalidOperationException($"{nameof(IDispatcher)} cannot be null"));
 
-		var (_, playerView) = MediaManager.CreatePlatformView(VirtualView.AndroidViewType);
+		var (_, playerView) = MediaManager.CreatePlatformView(VirtualView.AndroidViewType, VirtualView.AndroidForegroundServiceEnabled);
 		return new(Context, playerView);
 	}
 

--- a/src/CommunityToolkit.Maui.MediaElement/MediaElement.shared.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/MediaElement.shared.cs
@@ -226,6 +226,11 @@ public partial class MediaElement : View, IMediaElement, IDisposable
 	public AndroidViewType AndroidViewType { get; init; } = MediaElementOptions.DefaultAndroidViewType;
 
 	/// <summary>
+	/// Gets or sets whether the Android Foreground Service is enabled.
+	/// </summary>
+	public bool AndroidForegroundServiceEnabled { get; init; } = MediaElementOptions.AndroidForeServiceEnabled;
+
+	/// <summary>
 	/// Gets or sets whether the media should start playing as soon as it's loaded.
 	/// Default is <see langword="false"/>. This is a bindable property.
 	/// </summary>

--- a/src/CommunityToolkit.Maui.MediaElement/MediaElementOptions.shared.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/MediaElementOptions.shared.cs
@@ -18,7 +18,18 @@ public class MediaElementOptions()
 	internal static AndroidViewType DefaultAndroidViewType { get; private set; } = AndroidViewType.SurfaceView;
 
 	/// <summary>
+	/// Set Android Foreground Service for MediaElement on construction
+	/// </summary>
+	internal static bool AndroidForeServiceEnabled { get; private set; } = true;
+
+	/// <summary>
 	/// Set Android View type for MediaElement as SurfaceView or TextureView on construction
 	/// </summary>
 	public void SetDefaultAndroidViewType(AndroidViewType androidViewType) => DefaultAndroidViewType = androidViewType;
+
+	/// <summary>
+	/// Set Android Foreground Service for MediaElement on construction
+	/// </summary>
+	/// <param name="androidForegroundServiceEnabled"></param>
+	public void SetDefaultAndroidForegroundService(bool androidForegroundServiceEnabled) => AndroidForeServiceEnabled = androidForegroundServiceEnabled;
 }

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.android.cs
@@ -20,6 +20,7 @@ namespace CommunityToolkit.Maui.Core.Views;
 
 public partial class MediaManager : Java.Lang.Object, IPlayerListener
 {
+	bool androidForegroundServiceEnabled;
 	const int bufferState = 2;
 	const int readyState = 3;
 	const int endedState = 4;
@@ -129,11 +130,11 @@ public partial class MediaManager : Java.Lang.Object, IPlayerListener
 	/// <returns>The platform native counterpart of <see cref="MediaElement"/>.</returns>
 	/// <exception cref="NullReferenceException">Thrown when <see cref="Context"/> is <see langword="null"/> or when the platform view could not be created.</exception>
 	[MemberNotNull(nameof(Player), nameof(PlayerView), nameof(session))]
-	public (PlatformMediaElement platformView, PlayerView PlayerView) CreatePlatformView(AndroidViewType androidViewType)
+	public (PlatformMediaElement platformView, PlayerView PlayerView) CreatePlatformView(AndroidViewType androidViewType, bool androidForegroundServiceEnabled)
 	{
 		Player = new ExoPlayerBuilder(MauiContext.Context).Build() ?? throw new InvalidOperationException("Player cannot be null");
 		Player.AddListener(this);
-
+		this.androidForegroundServiceEnabled = androidForegroundServiceEnabled;
 		if (androidViewType is AndroidViewType.SurfaceView)
 		{
 			PlayerView = new PlayerView(MauiContext.Context)
@@ -352,7 +353,7 @@ public partial class MediaManager : Java.Lang.Object, IPlayerListener
 			return;
 		}
 
-		if (connection is null)
+		if (connection is null && androidForegroundServiceEnabled)
 		{
 			StartService();
 		}


### PR DESCRIPTION
 - Feature/Proposal

 ### Description of Change ###

Updated `MediaElement` to include `AndroidForegroundServiceEnabled` property for better control over media playback on Android. Adjusted related methods and classes to handle this new property, ensuring the foreground service is utilized appropriately during media playback. Removed unnecessary properties and streamlined the popup media element configuration.
 ### Linked Issues ###

 - Fixes #2225
 - Fixes #2657

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

This PR is for the community to see how making android service optional could be implemented.

`MediaElement.shared.cs`

```csharp
/// <summary>
/// Read the MediaElementOptions set in on construction, cannot be changed after construction
/// </summary>
public AndroidViewType AndroidViewType { get; init; } = MediaElementOptions.DefaultAndroidViewType;
```

`MediaElementOptions`
```csharp
/// <summary>
/// Set Android Foreground Service for MediaElement on construction
/// </summary>
internal static bool AndroidForeServiceEnabled { get; private set; } = true;

/// <summary>
/// Set Android Foreground Service for MediaElement on construction
/// </summary>
/// <param name="androidForegroundServiceEnabled"></param>
public void SetDefaultAndroidForegroundService(bool androidForegroundServiceEnabled) => AndroidForeServiceEnabled = androidForegroundServiceEnabled;
```

 
