### PR TITLE
Add Support for Shell + `IQueryAttributable` for PopupV2

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/Popup/PopupsPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/Popup/PopupsPage.xaml.cs
@@ -21,7 +21,7 @@ public partial class PopupsPage : BasePage<PopupsViewModel>
 	{
 		var queryAttributes = new Dictionary<string, object>
 		{
-			["DescriptionLabel"] = "This is a popup with a .NET MAUI View being rendered. "
+			["DescriptionLabel"] = "This is a popup where this text is being passed in using IQueryAttributable"
 		};
 
 		await popupService.ShowPopupAsync<SimplePopup>(Shell.Current, new PopupOptions

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/Popup/PopupsPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/Popup/PopupsPage.xaml.cs
@@ -19,14 +19,20 @@ public partial class PopupsPage : BasePage<PopupsViewModel>
 
 	async void HandleSimplePopupButtonClicked(object sender, EventArgs e)
 	{
-		await popupService.ShowPopupAsync<SimplePopup>(Navigation, new PopupOptions
+		var queryAttributes = new Dictionary<string, object>
 		{
-			Shape = new RoundRectangle
+			["DescriptionLabel"] = "This is a popup with a .NET MAUI View being rendered. "
+		};
+
+		await popupService.ShowPopupAsync<SimplePopup>(Shell.Current, new PopupOptions
 			{
-				CornerRadius = new CornerRadius(4),
-				Stroke = Colors.White
-			},
-		}, CancellationToken.None);
+				Shape = new RoundRectangle
+				{
+					CornerRadius = new CornerRadius(4),
+					Stroke = Colors.White
+				}
+			}, queryAttributes
+			, CancellationToken.None);
 	}
 
 	async void HandleButtonPopupButtonClicked(object sender, EventArgs e)

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Views/Popup/CsharpBindingPopupViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Views/Popup/CsharpBindingPopupViewModel.cs
@@ -3,13 +3,19 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace CommunityToolkit.Maui.Sample.ViewModels.Views;
 
-public sealed partial class CsharpBindingPopupViewModel : BaseViewModel
+public sealed partial class CsharpBindingPopupViewModel : BaseViewModel, IQueryAttributable
 {
 	[ObservableProperty]
-	public partial string Title { get; set; } = "C# Binding Popup";
+	public partial string Title { get; private set; } = string.Empty;
 
 	[ObservableProperty]
-	public partial string Message { get; set; } = "This message uses a ViewModel binding";
+	public partial string Message { get; private set; } = string.Empty;
 
 	public TaskCompletionSource<IPopupResult>? PopupResultManager { get; set; }
+	
+	void IQueryAttributable.ApplyQueryAttributes(IDictionary<string, object> query)
+	{
+		Title = (string)query[nameof(Title)];
+		Message = (string)query[nameof(Message)];
+	}
 }

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Views/Popup/PopupsViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Views/Popup/PopupsViewModel.cs
@@ -9,7 +9,12 @@ public partial class PopupsViewModel(IPopupService popupService) : BaseViewModel
 	[RelayCommand]
 	void OnCsharpBindingPopup()
 	{
-		popupService.ShowPopup<CsharpBindingPopupViewModel>(currentNavigation);
+		var queryAttributes = new Dictionary<string, object>
+		{
+			[nameof(CsharpBindingPopupViewModel.Title)] = "C# Binding Popup",
+			[nameof(CsharpBindingPopupViewModel.Message)] = "This message uses a ViewModel binding that was set using IQueryAttributable"
+		};
+		popupService.ShowPopup<CsharpBindingPopupViewModel>(Shell.Current, null, queryAttributes);
 	}
 
 	[RelayCommand]

--- a/samples/CommunityToolkit.Maui.Sample/Views/Popups/SimplePopup.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Views/Popups/SimplePopup.xaml
@@ -33,7 +33,7 @@
 
         <Label Style="{StaticResource Title}" Text="Simple Popup"/>
         <BoxView Style="{StaticResource Divider}" />
-        <Label x:Name="DescriptionLabel" Style="{StaticResource Content}" />
+        <Label x:Name="DescriptionLabel" Style="{StaticResource Content}" HorizontalOptions="Center"/>
         <Image Source="shield.png"
 			   Margin="0,10,0,10"
 			   WidthRequest="30"

--- a/samples/CommunityToolkit.Maui.Sample/Views/Popups/SimplePopup.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Views/Popups/SimplePopup.xaml
@@ -33,7 +33,7 @@
 
         <Label Style="{StaticResource Title}" Text="Simple Popup"/>
         <BoxView Style="{StaticResource Divider}" />
-        <Label Style="{StaticResource Content}" Text="This is a platform specific popup with a .NET MAUI View being rendered. " />
+        <Label x:Name="DescriptionLabel" Style="{StaticResource Content}" />
         <Image Source="shield.png"
 			   Margin="0,10,0,10"
 			   WidthRequest="30"

--- a/samples/CommunityToolkit.Maui.Sample/Views/Popups/SimplePopup.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Views/Popups/SimplePopup.xaml.cs
@@ -1,9 +1,14 @@
 namespace CommunityToolkit.Maui.Sample.Views.Popups;
 
-public partial class SimplePopup : ContentView
+public partial class SimplePopup : ContentView, IQueryAttributable
 {
 	public SimplePopup()
 	{
 		InitializeComponent();
+	}
+
+	void IQueryAttributable.ApplyQueryAttributes(IDictionary<string, object> query)
+	{
+		DescriptionLabel.Text = (string)query[nameof(DescriptionLabel)];
 	}
 }

--- a/src/CommunityToolkit.Maui.Core/Interfaces/IPopupResult.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Interfaces/IPopupResult.shared.cs
@@ -1,7 +1,7 @@
 ﻿namespace CommunityToolkit.Maui.Core;
 
 /// <inheritdoc/>
-public interface IPopupResult<T> : IPopupResult
+public interface IPopupResult<out T> : IPopupResult
 {
 	/// <summary>
 	/// PopupResult

--- a/src/CommunityToolkit.Maui.UnitTests/BaseHandlerTest.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/BaseHandlerTest.cs
@@ -85,10 +85,10 @@ public abstract class BaseHandlerTest : BaseTest
 		#endregion
 
 		var mauiApp = appBuilder.Build();
+		serviceProvider = mauiApp.Services;
 
 		var application = (MockApplication)mauiApp.Services.GetRequiredService<IApplication>();
 		application.AddWindow(new Window { Page = page });
-		serviceProvider = mauiApp.Services;
 
 		IPlatformApplication.Current = application;
 

--- a/src/CommunityToolkit.Maui.UnitTests/CommunityToolkit.Maui.UnitTests.csproj
+++ b/src/CommunityToolkit.Maui.UnitTests/CommunityToolkit.Maui.UnitTests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageReference Include="xunit.v3" Version="2.0.1" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CommunityToolkit.Maui.UnitTests/CommunityToolkit.Maui.UnitTests.csproj
+++ b/src/CommunityToolkit.Maui.UnitTests/CommunityToolkit.Maui.UnitTests.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageReference Include="xunit.v3" Version="2.0.1" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CommunityToolkit.Maui.UnitTests/Extensions/PopupExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Extensions/PopupExtensionsTests.cs
@@ -590,13 +590,14 @@ public class PopupExtensionsTests : BaseHandlerTest
 	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ShowPopupAsync_CancellationTokenExpired()
 	{
+		// Arrange
 		var selfClosingPopup = ServiceProvider.GetRequiredService<MockSelfClosingPopup>() ?? throw new InvalidOperationException();
-
 		var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(1));
 
-		// Ensure CancellationToken has expired
-		await Task.Delay(100, TestContext.Current.CancellationToken);
+		// Act
+		await Task.Delay(100, TestContext.Current.CancellationToken); // Ensure CancellationToken has expired
 
+		// Assert
 		await Assert.ThrowsAsync<OperationCanceledException>(() => navigation.ShowPopupAsync(selfClosingPopup, PopupOptions.Empty, cts.Token));
 	}
 
@@ -626,13 +627,14 @@ public class PopupExtensionsTests : BaseHandlerTest
 	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ShowPopupAsyncWithView_CancellationTokenExpired()
 	{
+		// Arrange
 		var view = new Grid();
-
 		var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(1));
 
-		// Ensure CancellationToken has expired
-		await Task.Delay(100, TestContext.Current.CancellationToken);
+		// Act
+		await Task.Delay(100, TestContext.Current.CancellationToken); // Ensure CancellationToken has expired
 
+		// Assert
 		await Assert.ThrowsAsync<OperationCanceledException>(() => navigation.ShowPopupAsync(view, PopupOptions.Empty, cts.Token));
 	}
 
@@ -651,9 +653,10 @@ public class PopupExtensionsTests : BaseHandlerTest
 
 		var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(1));
 
-		// Ensure CancellationToken has expired
-		await Task.Delay(100, TestContext.Current.CancellationToken);
+		// Act
+		await Task.Delay(100, TestContext.Current.CancellationToken); // Ensure CancellationToken has expired
 
+		// Assert
 		await Assert.ThrowsAsync<OperationCanceledException>(() => shell.ShowPopupAsync(view, PopupOptions.Empty, shellParameters, cts.Token));
 		Assert.NotEqual(shellParameterBackgroundColorValue, view.BackgroundColor);
 		Assert.NotEqual(shellParameterViewModelTextValue, view.BindingContext.Text);
@@ -662,13 +665,14 @@ public class PopupExtensionsTests : BaseHandlerTest
 	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ShowPopupAsync_CancellationTokenCanceled()
 	{
+		// Arrange
 		var selfClosingPopup = ServiceProvider.GetRequiredService<MockSelfClosingPopup>() ?? throw new InvalidOperationException();
-
 		var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(1));
 
-		// Ensure CancellationToken has expired
-		await cts.CancelAsync();
+		// Act
+		await cts.CancelAsync(); // Ensure CancellationToken has expired
 
+		// Assert
 		await Assert.ThrowsAsync<OperationCanceledException>(() => navigation.ShowPopupAsync(selfClosingPopup, PopupOptions.Empty, cts.Token));
 	}
 
@@ -698,13 +702,14 @@ public class PopupExtensionsTests : BaseHandlerTest
 	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ShowPopupAsyncWithView_CancellationTokenCanceled()
 	{
+		// Arrange
 		var view = new Grid();
-
 		var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(1));
 
-		// Ensure CancellationToken has expired
-		await cts.CancelAsync();
+		// Act
+		await cts.CancelAsync(); // Ensure CancellationToken has expired
 
+		// Assert
 		await Assert.ThrowsAsync<OperationCanceledException>(() => navigation.ShowPopupAsync(view, PopupOptions.Empty, cts.Token));
 	}
 
@@ -735,12 +740,15 @@ public class PopupExtensionsTests : BaseHandlerTest
 	[Fact(Timeout = (int)TestDuration.Medium)]
 	public async Task ShowPopupAsync_ShouldValidateProperBindingContext()
 	{
+		// Arrange
 		var selfClosingPopup = ServiceProvider.GetRequiredService<MockSelfClosingPopup>() ?? throw new InvalidOperationException();
 		var popupInstance = ServiceProvider.GetRequiredService<MockSelfClosingPopup>();
 		var popupViewModel = ServiceProvider.GetRequiredService<MockPageViewModel>();
 
+		// Act
 		await navigation.ShowPopupAsync<object?>(selfClosingPopup, PopupOptions.Empty, TestContext.Current.CancellationToken);
 
+		// Assert
 		Assert.Same(popupInstance.BindingContext, popupViewModel);
 	}
 
@@ -770,17 +778,20 @@ public class PopupExtensionsTests : BaseHandlerTest
 	[Fact(Timeout = (int)TestDuration.Medium)]
 	public async Task ShowPopupAsyncWithView_ShouldValidateProperBindingContext()
 	{
+		// Arrange
 		var view = new Grid();
 		var popupInstance = ServiceProvider.GetRequiredService<MockSelfClosingPopup>();
 		var popupViewModel = ServiceProvider.GetRequiredService<MockPageViewModel>();
 
+		// Act
 		var showPopupTask = navigation.ShowPopupAsync<object?>(view, PopupOptions.Empty, TestContext.Current.CancellationToken);
 
 		var popupPage = (PopupPage)navigation.ModalStack[0];
+		
 		await popupPage.Close(new PopupResult<object?>(null, false), TestContext.Current.CancellationToken);
-
 		await showPopupTask;
 
+		// Assert
 		Assert.Same(popupInstance.BindingContext, popupViewModel);
 	}
 
@@ -816,11 +827,14 @@ public class PopupExtensionsTests : BaseHandlerTest
 	[Fact(Timeout = (int)TestDuration.Medium)]
 	public async Task ShowPopupAsync_ShouldReturnResultOnceClosed()
 	{
+		// Arrange
 		var mockPopup = ServiceProvider.GetRequiredService<MockSelfClosingPopup>();
 		var selfClosingPopup = ServiceProvider.GetRequiredService<MockSelfClosingPopup>() ?? throw new InvalidOperationException();
 
+		// Act
 		var result = await navigation.ShowPopupAsync<object?>(selfClosingPopup, PopupOptions.Empty, TestContext.Current.CancellationToken);
 
+		// Assert
 		Assert.Same(mockPopup.Result, result.Result);
 		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
 	}
@@ -847,22 +861,25 @@ public class PopupExtensionsTests : BaseHandlerTest
 		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
 		Assert.Equal(shellParameterBackgroundColorValue, selfClosingPopup.BackgroundColor);
 	}
-	
+
 	[Fact(Timeout = (int)TestDuration.Medium)]
 	public async Task ShowPopupAsyncWithView_ShouldReturnResultOnceClosed()
 	{
+		// Arrange
 		const int popupResultValue = 2;
 
 		var view = new Grid();
 		var expectedPopupResult = new PopupResult<int>(popupResultValue, false);
 
+		// Act
 		var showPopupTask = navigation.ShowPopupAsync<int>(view, PopupOptions.Empty, TestContext.Current.CancellationToken);
 
 		var popupPage = (PopupPage)navigation.ModalStack[0];
+		
 		await popupPage.Close(expectedPopupResult, TestContext.Current.CancellationToken);
-
 		var actualPopupResult = await showPopupTask;
 
+		// Assert
 		Assert.Same(expectedPopupResult, actualPopupResult);
 		Assert.False(expectedPopupResult.WasDismissedByTappingOutsideOfPopup);
 		Assert.Equal(popupResultValue, expectedPopupResult.Result);
@@ -884,23 +901,25 @@ public class PopupExtensionsTests : BaseHandlerTest
 		var view = new ViewWithIQueryable(new ViewModelWithIQueryable());
 		var expectedPopupResult = new PopupResult<int>(popupResultValue, false);
 
+		// Act
 		var showPopupTask = shell.ShowPopupAsync<int>(view, PopupOptions.Empty, shellParameters, TestContext.Current.CancellationToken);
 
 		var popupPage = (PopupPage)shellNavigation.ModalStack[0];
+		
 		await popupPage.Close(expectedPopupResult, TestContext.Current.CancellationToken);
-
 		var actualPopupResult = await showPopupTask;
 
+		// Assert
 		Assert.Same(expectedPopupResult, actualPopupResult);
 		Assert.False(expectedPopupResult.WasDismissedByTappingOutsideOfPopup);
 		Assert.Equal(popupResultValue, expectedPopupResult.Result);
 	}
-	
+
 	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ShowPopupAsync_ShouldThrowArgumentNullException_WhenViewIsNull()
 	{
 		// Arrange
-		
+
 		// Act/Assert
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
 		await Assert.ThrowsAsync<ArgumentNullException>(() => navigation.ShowPopupAsync(null, PopupOptions.Empty, TestContext.Current.CancellationToken));
@@ -918,7 +937,7 @@ public class PopupExtensionsTests : BaseHandlerTest
 		Application.Current.Windows[0].Page = shell;
 
 		var shellNavigation = Shell.Current.Navigation;
-		
+
 		// Act/Assert
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
 		await Assert.ThrowsAsync<ArgumentNullException>(() => shell.ShowPopupAsync(null, PopupOptions.Empty, shellParameters, TestContext.Current.CancellationToken));
@@ -928,13 +947,15 @@ public class PopupExtensionsTests : BaseHandlerTest
 	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ShowPopupAsync_ShouldThrowArgumentNullException_WhenNavigationIsNull()
 	{
+		// Arrange
 		var selfClosingPopup = ServiceProvider.GetRequiredService<MockSelfClosingPopup>() ?? throw new InvalidOperationException();
 
+		// Act / Assert
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
 		await Assert.ThrowsAsync<ArgumentNullException>(() => PopupExtensions.ShowPopupAsync((INavigation?)null, selfClosingPopup, PopupOptions.Empty, TestContext.Current.CancellationToken));
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
-	
+
 	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ShowPopupAsync_Shell_ShouldThrowArgumentNullException_WhenNavigationIsNull()
 	{
@@ -958,19 +979,19 @@ public class PopupExtensionsTests : BaseHandlerTest
 	public async Task ShowPopupAsync_ShouldReturnNullResult_WhenPopupIsClosedWithoutResult()
 	{
 		// Arrange
-		
+
 		// Act
 		var showPopupTask = navigation.ShowPopupAsync<object?>(new Popup(), PopupOptions.Empty, TestContext.Current.CancellationToken);
 
 		var popupPage = (PopupPage)navigation.ModalStack.Last();
 		await popupPage.Close(new PopupResult(true), TestContext.Current.CancellationToken);
-		var result = await showPopupTask; 
+		var result = await showPopupTask;
 
 		// Assert
 		Assert.Null(result.Result);
 		Assert.True(result.WasDismissedByTappingOutsideOfPopup);
 	}
-	
+
 	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ShowPopupAsync_Shell_ShouldReturnNullResult_WhenPopupIsClosedWithoutResult()
 	{
@@ -982,13 +1003,13 @@ public class PopupExtensionsTests : BaseHandlerTest
 		Application.Current.Windows[0].Page = shell;
 
 		var shellNavigation = Shell.Current.Navigation;
-		
+
 		// Act
 		var showPopupTask = shell.ShowPopupAsync<object?>(new Popup(), PopupOptions.Empty, shellParameters, TestContext.Current.CancellationToken);
 
 		var popupPage = (PopupPage)shellNavigation.ModalStack.Last();
 		await popupPage.Close(new PopupResult(true), TestContext.Current.CancellationToken);
-		var result = await showPopupTask; 
+		var result = await showPopupTask;
 
 		// Assert
 		Assert.Null(result.Result);
@@ -998,8 +1019,10 @@ public class PopupExtensionsTests : BaseHandlerTest
 	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ShowPopupAsync_ReferenceTypeShouldReturnNull_WhenPopupTapGestureRecognizerCommandIsExecuted()
 	{
+		// Arrange
 		var popupClosedTCS = new TaskCompletionSource<IPopupResult>();
 
+		// Act
 		var showPopupTask = navigation.ShowPopupAsync<bool?>(new Popup<bool>(), token: TestContext.Current.CancellationToken);
 		var popupPage = (PopupPage)navigation.ModalStack[0];
 		popupPage.PopupClosed += HandlePopupClosed;
@@ -1010,6 +1033,7 @@ public class PopupExtensionsTests : BaseHandlerTest
 		var popupClosedResult = await popupClosedTCS.Task;
 		var showPopupResult = await showPopupTask;
 
+		// Assert
 		Assert.True(popupClosedResult.WasDismissedByTappingOutsideOfPopup);
 		Assert.Null(showPopupResult.Result);
 		Assert.True(showPopupResult.WasDismissedByTappingOutsideOfPopup);
@@ -1019,7 +1043,7 @@ public class PopupExtensionsTests : BaseHandlerTest
 			popupClosedTCS.SetResult(e);
 		}
 	}
-	
+
 	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ShowPopupAsync_Shell_ReferenceTypeShouldReturnNull_WhenPopupTapGestureRecognizerCommandIsExecuted()
 	{
@@ -1033,6 +1057,7 @@ public class PopupExtensionsTests : BaseHandlerTest
 		var shellNavigation = Shell.Current.Navigation;
 		var popupClosedTCS = new TaskCompletionSource<IPopupResult>();
 
+		// Act
 		var showPopupTask = shell.ShowPopupAsync<bool?>(new Popup<bool>(), token: TestContext.Current.CancellationToken);
 		var popupPage = (PopupPage)shellNavigation.ModalStack[0];
 		popupPage.PopupClosed += HandlePopupClosed;
@@ -1043,6 +1068,7 @@ public class PopupExtensionsTests : BaseHandlerTest
 		var popupClosedResult = await popupClosedTCS.Task;
 		var showPopupResult = await showPopupTask;
 
+		// Assert
 		Assert.True(popupClosedResult.WasDismissedByTappingOutsideOfPopup);
 		Assert.Null(showPopupResult.Result);
 		Assert.True(showPopupResult.WasDismissedByTappingOutsideOfPopup);
@@ -1056,8 +1082,10 @@ public class PopupExtensionsTests : BaseHandlerTest
 	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ShowPopupAsync_NullableValueTypeShouldReturnResult_WhenPopupIsClosedByTappingOutsidePopup()
 	{
+		// Arrange
 		var popupClosedTCS = new TaskCompletionSource<IPopupResult>();
 
+		// Act
 		var showPopupTask = navigation.ShowPopupAsync<bool?>(new Popup<bool>(), token: TestContext.Current.CancellationToken);
 		var popupPage = (PopupPage)navigation.ModalStack[0];
 		popupPage.PopupClosed += HandlePopupClosed;
@@ -1068,6 +1096,7 @@ public class PopupExtensionsTests : BaseHandlerTest
 		var popupClosedResult = await popupClosedTCS.Task;
 		var showPopupResult = await showPopupTask;
 
+		// Assert
 		Assert.True(popupClosedResult.WasDismissedByTappingOutsideOfPopup);
 		Assert.Null(showPopupResult.Result);
 		Assert.True(showPopupResult.WasDismissedByTappingOutsideOfPopup);
@@ -1077,7 +1106,7 @@ public class PopupExtensionsTests : BaseHandlerTest
 			popupClosedTCS.SetResult(e);
 		}
 	}
-	
+
 	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ShowPopupAsync_Shell_NullableValueTypeShouldReturnResult_WhenPopupIsClosedByTappingOutsidePopup()
 	{
@@ -1116,8 +1145,10 @@ public class PopupExtensionsTests : BaseHandlerTest
 	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ShowPopupAsync_ValueTypeShouldReturnResult_WhenPopupIsClosedByTappingOutsidePopup()
 	{
+		// Arrange
 		var popupClosedTCS = new TaskCompletionSource<IPopupResult>();
 
+		// Act
 		var showPopupTask = navigation.ShowPopupAsync<bool>(new Popup<bool>(), token: TestContext.Current.CancellationToken);
 		var popupPage = (PopupPage)navigation.ModalStack[0];
 		popupPage.PopupClosed += HandlePopupClosed;
@@ -1128,6 +1159,7 @@ public class PopupExtensionsTests : BaseHandlerTest
 		var popupClosedResult = await popupClosedTCS.Task;
 		var showPopupResult = await showPopupTask;
 
+		// Assert
 		Assert.True(popupClosedResult.WasDismissedByTappingOutsideOfPopup);
 		Assert.True(showPopupResult.WasDismissedByTappingOutsideOfPopup);
 		Assert.ThrowsAny<PopupResultException>(() => (bool?)showPopupResult.Result);
@@ -1138,7 +1170,7 @@ public class PopupExtensionsTests : BaseHandlerTest
 			popupClosedTCS.SetResult(e);
 		}
 	}
-	
+
 	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ShowPopupAsync_Shell_ValueTypeShouldReturnResult_WhenPopupIsClosedByTappingOutsidePopup()
 	{

--- a/src/CommunityToolkit.Maui.UnitTests/Extensions/PopupExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Extensions/PopupExtensionsTests.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using CommunityToolkit.Maui.Core;
 using CommunityToolkit.Maui.Extensions;
 using CommunityToolkit.Maui.UnitTests.Mocks;
@@ -10,7 +11,16 @@ namespace CommunityToolkit.Maui.UnitTests.Extensions;
 
 public class PopupExtensionsTests : BaseHandlerTest
 {
+	const string shellParameterViewModelTextValue = "Hello World";
+	static readonly Color shellParameterBackgroundColorValue = Colors.Green;
+
 	readonly INavigation navigation;
+
+	readonly IDictionary<string, object> shellParameters = new Dictionary<string, object>
+	{
+		{ nameof(View.BackgroundColor), shellParameterBackgroundColorValue },
+		{ nameof(ViewModelWithIQueryable.Text), shellParameterViewModelTextValue }
+	}.AsReadOnly();
 
 	public PopupExtensionsTests()
 	{
@@ -34,7 +44,27 @@ public class PopupExtensionsTests : BaseHandlerTest
 		Assert.Single(navigation.ModalStack);
 		Assert.IsType<PopupPage>(navigation.ModalStack[0]);
 	}
-	
+
+	[Fact]
+	public void ShowPopupAsync_Shell_WithPopupType_ShowsPopup()
+	{
+		// Arrange
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+
+		// Act
+		shell.ShowPopup(new Popup());
+
+		// Assert
+		Assert.Single(shellNavigation.ModalStack);
+		Assert.IsType<PopupPage>(shellNavigation.ModalStack[0]);
+	}
+
 	[Fact]
 	public void ShowPopupAsync_WithViewType_ShowsPopup()
 	{
@@ -49,6 +79,29 @@ public class PopupExtensionsTests : BaseHandlerTest
 		Assert.IsType<PopupPage>(navigation.ModalStack[0]);
 	}
 
+	[Fact]
+	public void ShowPopupAsync_Shell_WithViewType_ShowsPopup()
+	{
+		// Arrange
+		var viewWithQueryable = new ViewWithIQueryable(new ViewModelWithIQueryable());
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+
+		// Act
+		shell.ShowPopup(viewWithQueryable, shellParameters: shellParameters);
+
+		// Assert
+		Assert.Single(shellNavigation.ModalStack);
+		Assert.IsType<PopupPage>(shellNavigation.ModalStack[0]);
+		Assert.Equal(shellParameterBackgroundColorValue, viewWithQueryable.BackgroundColor);
+		Assert.Equal(shellParameterViewModelTextValue, viewWithQueryable.BindingContext.Text);
+	}
+
 	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ShowPopupAsync_AwaitingShowPopupAsync_EnsurePreviousPopupClosed()
 	{
@@ -56,13 +109,35 @@ public class PopupExtensionsTests : BaseHandlerTest
 		var selfClosingPopup = ServiceProvider.GetRequiredService<MockSelfClosingPopup>() ?? throw new InvalidOperationException();
 
 		// Act
-		await navigation.ShowPopupAsync<object?>(selfClosingPopup, PopupOptions.Empty, CancellationToken.None);
-		await navigation.ShowPopupAsync<object?>(selfClosingPopup, PopupOptions.Empty, CancellationToken.None);
+		await navigation.ShowPopupAsync<object?>(selfClosingPopup, PopupOptions.Empty, TestContext.Current.CancellationToken);
+		await navigation.ShowPopupAsync<object?>(selfClosingPopup, PopupOptions.Empty, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.Empty(navigation.ModalStack);
 	}
-	
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task qShowPopupAsync_Shell_AwaitingShowPopupAsync_EnsurePreviousPopupClosed()
+	{
+		// Arrange
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+		var selfClosingPopup = ServiceProvider.GetRequiredService<MockSelfClosingPopup>() ?? throw new InvalidOperationException();
+
+		// Act
+		await shell.ShowPopupAsync<object?>(selfClosingPopup, PopupOptions.Empty, shellParameters, TestContext.Current.CancellationToken);
+		await shell.ShowPopupAsync<object?>(selfClosingPopup, PopupOptions.Empty, shellParameters, TestContext.Current.CancellationToken);
+
+		// Assert
+		Assert.Empty(shellNavigation.ModalStack);
+		Assert.Equal(shellParameterBackgroundColorValue, selfClosingPopup.BackgroundColor);
+	}
+
 	[Fact]
 	public void ShowPopup_NavigationModalStackCountIncreases()
 	{
@@ -76,21 +151,74 @@ public class PopupExtensionsTests : BaseHandlerTest
 		// Assert
 		Assert.Single(navigation.ModalStack);
 	}
-	
+
+	[Fact]
+	public void ShowPopup_Shell_NavigationModalStackCountIncreases()
+	{
+		// Arrange
+		var viewWithQueryable = new ViewWithIQueryable(new ViewModelWithIQueryable());
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+		Assert.Empty(shellNavigation.ModalStack);
+
+		// Act
+		shell.ShowPopup(viewWithQueryable, shellParameters: shellParameters);
+
+		// Assert
+		Assert.Single(shellNavigation.ModalStack);
+		Assert.Equal(shellParameterBackgroundColorValue, viewWithQueryable.BackgroundColor);
+		Assert.Equal(shellParameterViewModelTextValue, viewWithQueryable.BindingContext.Text);
+	}
+
 	[Fact]
 	public void ShowPopupWithView_NavigationModalStackCountIncreases()
 	{
 		// Arrange
-		var view = new Grid();
-		Assert.Empty(navigation.ModalStack);
+		var viewWithQueryable = new ViewWithIQueryable(new ViewModelWithIQueryable());
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+		Assert.Empty(shellNavigation.ModalStack);
 
 		// Act
-		navigation.ShowPopup(view, PopupOptions.Empty);
+		navigation.ShowPopup(viewWithQueryable, PopupOptions.Empty);
 
 		// Assert
 		Assert.Single(navigation.ModalStack);
 	}
-	
+
+	[Fact]
+	public void ShowPopupWithView_Shell_NavigationModalStackCountIncreases()
+	{
+		// Arrange
+		var viewWithQueryable = new ViewWithIQueryable(new ViewModelWithIQueryable());
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+		Assert.Empty(shellNavigation.ModalStack);
+
+		// Act
+		shell.ShowPopup(viewWithQueryable, PopupOptions.Empty, shellParameters);
+
+		// Assert
+		Assert.Single(shellNavigation.ModalStack);
+		Assert.Equal(shellParameterBackgroundColorValue, viewWithQueryable.BackgroundColor);
+		Assert.Equal(shellParameterViewModelTextValue, viewWithQueryable.BindingContext.Text);
+	}
+
 	[Fact]
 	public void ShowPopup_MultiplePopupsDisplayed()
 	{
@@ -104,7 +232,29 @@ public class PopupExtensionsTests : BaseHandlerTest
 		// Assert
 		Assert.Equal(2, navigation.ModalStack.Count);
 	}
-	
+
+	[Fact]
+	public void ShowPopup_Shell_MultiplePopupsDisplayed()
+	{
+		// Arrange
+		var selfClosingPopup = ServiceProvider.GetRequiredService<MockSelfClosingPopup>() ?? throw new InvalidOperationException();
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+
+		// Act
+		shell.ShowPopup(selfClosingPopup, PopupOptions.Empty, shellParameters);
+		shell.ShowPopup(selfClosingPopup, PopupOptions.Empty, shellParameters);
+
+		// Assert
+		Assert.Equal(2, shellNavigation.ModalStack.Count);
+		Assert.Equal(shellParameterBackgroundColorValue, selfClosingPopup.BackgroundColor);
+	}
+
 	[Fact]
 	public void ShowPopupView_MultiplePopupsDisplayed()
 	{
@@ -118,6 +268,30 @@ public class PopupExtensionsTests : BaseHandlerTest
 		// Assert
 		Assert.Equal(2, navigation.ModalStack.Count);
 	}
+
+	[Fact]
+	public void ShowPopupView_Shell_MultiplePopupsDisplayed()
+	{
+		// Arrange
+		var viewWithQueryable = new ViewWithIQueryable(new ViewModelWithIQueryable());
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+
+		// Act
+		shell.ShowPopup(viewWithQueryable, PopupOptions.Empty, shellParameters);
+		shell.ShowPopup(viewWithQueryable, PopupOptions.Empty, shellParameters);
+
+		// Assert
+		Assert.Equal(2, shellNavigation.ModalStack.Count);
+		Assert.Equal(shellParameterBackgroundColorValue, viewWithQueryable.BackgroundColor);
+		Assert.Equal(shellParameterViewModelTextValue, viewWithQueryable.BindingContext.Text);
+	}
+
 
 	[Fact]
 	public void ShowPopupAsync_WithCustomOptions_AppliesOptions()
@@ -145,16 +319,120 @@ public class PopupExtensionsTests : BaseHandlerTest
 		// Assert
 		Assert.NotNull(popup);
 
-		Assert.Equal(options.PageOverlayColor, popupPage.BackgroundColor);
+		// Verify BindingContexts
+		Assert.Equal(selfClosingPopup.BindingContext, popupPage.BindingContext);
+		Assert.Equal(popup.BindingContext, popupPage.BindingContext);
+		Assert.Equal(popupPageContent.BindingContext, border.BindingContext);
+
+		// Verify View options Binding to Popup
+		Assert.Equal(selfClosingPopup.BindingContext, popup.BindingContext);
+		Assert.Equal(selfClosingPopup.Background, popup.Background);
+		Assert.Equal(selfClosingPopup.BackgroundColor, popup.BackgroundColor);
+		Assert.Equal(selfClosingPopup.Margin, popup.Margin);
+		Assert.Equal(selfClosingPopup.VerticalOptions, popup.VerticalOptions);
+		Assert.Equal(selfClosingPopup.HorizontalOptions, popup.HorizontalOptions);
+
+		// Verify View options Binding to Border
+		Assert.Equal(selfClosingPopup.BindingContext, border.BindingContext);
+		Assert.Equal(selfClosingPopup.Background, border.Background);
+		Assert.Equal(selfClosingPopup.BackgroundColor, border.BackgroundColor);
+		Assert.Equal(selfClosingPopup.Margin, border.Margin);
+		Assert.Equal(selfClosingPopup.VerticalOptions, border.VerticalOptions);
+		Assert.Equal(selfClosingPopup.HorizontalOptions, border.HorizontalOptions);
+
+		// Verify Border Bindings to Border
+		Assert.Equal(popup.BindingContext, border.BindingContext);
+		Assert.Equal(popup.Margin, border.Margin);
+		Assert.Equal(((IPaddingElement)popup).Padding, border.Padding);
+		Assert.Equal(popup.Background, border.Background);
+		Assert.Equal(popup.BackgroundColor, border.BackgroundColor);
 		Assert.Equal(popup.HorizontalOptions, border.HorizontalOptions);
 		Assert.Equal(popup.VerticalOptions, border.VerticalOptions);
+
+		// Verify Border Bindings to PopupOptions
+		Assert.Equal(options.Shadow, border.Shadow);
+		Assert.Equal(options.Shape.Stroke, border.Stroke);
 		Assert.Equal(options.Shape, border.StrokeShape);
-		Assert.Equal(popup.Margin, border.Margin);
-		Assert.Equal(border.Padding, border.Padding);
-		Assert.Equal(popup.BindingContext, border.BindingContext);
-		Assert.Equal(popupPageContent.BindingContext, border.BindingContext);
+
+		// Verify PopupPage Bindings to PopupOptions
+		Assert.Equal(options.PageOverlayColor, popupPage.BackgroundColor);
 	}
-	
+
+	[Fact]
+	public void ShowPopupAsync_Shell_WithCustomOptions_AppliesOptions()
+	{
+		// Arrange
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+		var onTappingOutsideOfPopup = () => { };
+
+		var selfClosingPopup = ServiceProvider.GetRequiredService<MockSelfClosingPopup>() ?? throw new InvalidOperationException();
+		var options = new PopupOptions
+		{
+			PageOverlayColor = Colors.Red,
+			CanBeDismissedByTappingOutsideOfPopup = false,
+			Shape = new Ellipse(),
+			OnTappingOutsideOfPopup = onTappingOutsideOfPopup
+		};
+
+		// Act
+		shell.ShowPopup(selfClosingPopup, options, shellParameters);
+
+		var popupPage = (PopupPage)shellNavigation.ModalStack[0];
+		var popupPageContent = popupPage.Content;
+		var border = (Border)popupPageContent.Children[0];
+		var popup = border.Content;
+
+		// Assert
+		Assert.NotNull(popup);
+
+		// Verify BindingContexts
+		Assert.Equal(selfClosingPopup.BindingContext, popupPage.BindingContext);
+		Assert.Equal(popup.BindingContext, popupPage.BindingContext);
+		Assert.Equal(popupPageContent.BindingContext, border.BindingContext);
+
+		// Verify View options Binding to Popup
+		Assert.Equal(selfClosingPopup.BindingContext, popup.BindingContext);
+		Assert.Equal(selfClosingPopup.Background, popup.Background);
+		Assert.Equal(selfClosingPopup.BackgroundColor, popup.BackgroundColor);
+		Assert.Equal(selfClosingPopup.Margin, popup.Margin);
+		Assert.Equal(selfClosingPopup.VerticalOptions, popup.VerticalOptions);
+		Assert.Equal(selfClosingPopup.HorizontalOptions, popup.HorizontalOptions);
+
+		// Verify View options Binding to Border
+		Assert.Equal(selfClosingPopup.BindingContext, border.BindingContext);
+		Assert.Equal(selfClosingPopup.Background, border.Background);
+		Assert.Equal(selfClosingPopup.BackgroundColor, border.BackgroundColor);
+		Assert.Equal(selfClosingPopup.Margin, border.Margin);
+		Assert.Equal(selfClosingPopup.VerticalOptions, border.VerticalOptions);
+		Assert.Equal(selfClosingPopup.HorizontalOptions, border.HorizontalOptions);
+
+		// Verify Border Bindings to Border
+		Assert.Equal(popup.BindingContext, border.BindingContext);
+		Assert.Equal(popup.Margin, border.Margin);
+		Assert.Equal(((IPaddingElement)popup).Padding, border.Padding);
+		Assert.Equal(popup.Background, border.Background);
+		Assert.Equal(popup.BackgroundColor, border.BackgroundColor);
+		Assert.Equal(popup.HorizontalOptions, border.HorizontalOptions);
+		Assert.Equal(popup.VerticalOptions, border.VerticalOptions);
+
+		// Verify Border Bindings to PopupOptions
+		Assert.Equal(options.Shadow, border.Shadow);
+		Assert.Equal(options.Shape.Stroke, border.Stroke);
+		Assert.Equal(options.Shape, border.StrokeShape);
+
+		// Verify PopupPage Bindings to PopupOptions
+		Assert.Equal(options.PageOverlayColor, popupPage.BackgroundColor);
+
+		// Verify IQueryAttributable Propagates through Popup
+		Assert.Equal(shellParameterBackgroundColorValue, selfClosingPopup.BackgroundColor);
+	}
+
 	[Fact]
 	public void ShowPopupAsyncWithView_WithCustomOptions_AppliesOptions()
 	{
@@ -185,18 +463,128 @@ public class PopupExtensionsTests : BaseHandlerTest
 		// Assert
 		Assert.NotNull(popup);
 
-		Assert.Equal(view.HorizontalOptions, border.HorizontalOptions);
-		Assert.Equal(view.VerticalOptions, border.VerticalOptions);
+		// Verify BindingContexts
+		Assert.Equal(view.BindingContext, popupPage.BindingContext);
+		Assert.Equal(popup.BindingContext, popupPage.BindingContext);
+		Assert.Equal(popupPageContent.BindingContext, border.BindingContext);
+
+		// Verify View options Binding to Popup
+		Assert.Equal(view.BindingContext, popup.BindingContext);
+		Assert.Equal(view.Background, popup.Background);
+		Assert.Equal(view.BackgroundColor, popup.BackgroundColor);
+		Assert.Equal(view.Margin, popup.Margin);
+		Assert.Equal(view.VerticalOptions, popup.VerticalOptions);
+		Assert.Equal(view.HorizontalOptions, popup.HorizontalOptions);
+
+		// Verify View options Binding to Border
+		Assert.Equal(view.BindingContext, border.BindingContext);
+		Assert.Equal(view.Background, border.Background);
+		Assert.Equal(view.BackgroundColor, border.BackgroundColor);
 		Assert.Equal(view.Margin, border.Margin);
-		Assert.Equal(view.Padding, border.Padding);
+		Assert.Equal(view.VerticalOptions, border.VerticalOptions);
+		Assert.Equal(view.HorizontalOptions, border.HorizontalOptions);
+
+		// Verify Border Bindings to Border
+		Assert.Equal(popup.BindingContext, border.BindingContext);
+		Assert.Equal(popup.Margin, border.Margin);
+		Assert.Equal(((IPaddingElement)popup).Padding, border.Padding);
+		Assert.Equal(popup.Background, border.Background);
+		Assert.Equal(popup.BackgroundColor, border.BackgroundColor);
 		Assert.Equal(popup.HorizontalOptions, border.HorizontalOptions);
 		Assert.Equal(popup.VerticalOptions, border.VerticalOptions);
-		Assert.Equal(popup.Margin, border.Margin);
-		Assert.Equal(popup.Padding, border.Padding);
-		Assert.Equal(popup.BindingContext, border.BindingContext);
+
+		// Verify Border Bindings to PopupOptions
+		Assert.Equal(options.Shadow, border.Shadow);
+		Assert.Equal(options.Shape.Stroke, border.Stroke);
 		Assert.Equal(options.Shape, border.StrokeShape);
+
+		// Verify PopupPage Bindings to PopupOptions
 		Assert.Equal(options.PageOverlayColor, popupPage.BackgroundColor);
+	}
+
+	[Fact]
+	public void ShowPopupAsyncWithView_Shell_WithCustomOptions_AppliesOptions()
+	{
+		// Arrange
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+		var onTappingOutsideOfPopup = () => { };
+
+		var viewWithQueryable = new ViewWithIQueryable(new ViewModelWithIQueryable())
+		{
+			HorizontalOptions = LayoutOptions.End,
+			VerticalOptions = LayoutOptions.Start,
+			BackgroundColor = Colors.Red,
+			Background = new LinearGradientBrush(),
+			Margin = 6,
+			Padding = 12
+		};
+
+		var options = new PopupOptions
+		{
+			PageOverlayColor = Colors.Red,
+			CanBeDismissedByTappingOutsideOfPopup = false,
+			Shape = new Ellipse(),
+			OnTappingOutsideOfPopup = onTappingOutsideOfPopup
+		};
+
+		// Act
+		shell.ShowPopup(viewWithQueryable, options, shellParameters);
+
+		var popupPage = (PopupPage)shellNavigation.ModalStack[0];
+		var popupPageContent = popupPage.Content;
+		var border = (Border)popupPageContent.Children[0];
+		var popup = (Popup)(border.Content ?? throw new InvalidCastException());
+
+		// Assert
+		Assert.NotNull(popup);
+
+		// Verify BindingContexts
+		Assert.Equal(viewWithQueryable.BindingContext, popupPage.BindingContext);
+		Assert.Equal(popup.BindingContext, popupPage.BindingContext);
 		Assert.Equal(popupPageContent.BindingContext, border.BindingContext);
+
+		// Verify View options Binding to Popup
+		Assert.Equal(viewWithQueryable.BindingContext, popup.BindingContext);
+		Assert.Equal(viewWithQueryable.Background, popup.Background);
+		Assert.Equal(viewWithQueryable.BackgroundColor, popup.BackgroundColor);
+		Assert.Equal(viewWithQueryable.Margin, popup.Margin);
+		Assert.Equal(viewWithQueryable.VerticalOptions, popup.VerticalOptions);
+		Assert.Equal(viewWithQueryable.HorizontalOptions, popup.HorizontalOptions);
+
+		// Verify View options Binding to Border
+		Assert.Equal(viewWithQueryable.BindingContext, border.BindingContext);
+		Assert.Equal(viewWithQueryable.Background, border.Background);
+		Assert.Equal(viewWithQueryable.BackgroundColor, border.BackgroundColor);
+		Assert.Equal(viewWithQueryable.Padding, border.Padding);
+		Assert.Equal(viewWithQueryable.Margin, border.Margin);
+		Assert.Equal(viewWithQueryable.VerticalOptions, border.VerticalOptions);
+		Assert.Equal(viewWithQueryable.HorizontalOptions, border.HorizontalOptions);
+
+		// Verify Border Bindings to Border
+		Assert.Equal(popup.BindingContext, border.BindingContext);
+		Assert.Equal(popup.Margin, border.Margin);
+		Assert.Equal(((IPaddingElement)popup).Padding, border.Padding);
+		Assert.Equal(popup.Background, border.Background);
+		Assert.Equal(popup.BackgroundColor, border.BackgroundColor);
+		Assert.Equal(popup.HorizontalOptions, border.HorizontalOptions);
+		Assert.Equal(popup.VerticalOptions, border.VerticalOptions);
+
+		// Verify Border Bindings to PopupOptions
+		Assert.Equal(options.Shadow, border.Shadow);
+		Assert.Equal(options.Shape.Stroke, border.Stroke);
+		Assert.Equal(options.Shape, border.StrokeShape);
+
+		// Verify PopupPage Bindings to PopupOptions
+		Assert.Equal(options.PageOverlayColor, popupPage.BackgroundColor);
+
+		// Verify IQueryAttributable Propagates through Popup
+		Assert.Equal(shellParameterBackgroundColorValue, viewWithQueryable.BackgroundColor);
 	}
 
 	[Fact(Timeout = (int)TestDuration.Short)]
@@ -207,11 +595,34 @@ public class PopupExtensionsTests : BaseHandlerTest
 		var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(1));
 
 		// Ensure CancellationToken has expired
-		await Task.Delay(100, CancellationToken.None);
+		await Task.Delay(100, TestContext.Current.CancellationToken);
 
 		await Assert.ThrowsAsync<OperationCanceledException>(() => navigation.ShowPopupAsync(selfClosingPopup, PopupOptions.Empty, cts.Token));
 	}
-	
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task ShowPopupAsync_Shell_CancellationTokenExpired()
+	{
+		// Arrange
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+		var selfClosingPopup = ServiceProvider.GetRequiredService<MockSelfClosingPopup>() ?? throw new InvalidOperationException();
+
+		var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(1));
+
+		// Act
+		await Task.Delay(100, TestContext.Current.CancellationToken); // Ensure CancellationToken has expired
+
+		// Assert
+		await Assert.ThrowsAsync<OperationCanceledException>(() => shell.ShowPopupAsync(selfClosingPopup, PopupOptions.Empty, shellParameters, cts.Token));
+		Assert.NotEqual(shellParameterBackgroundColorValue, selfClosingPopup.BackgroundColor);
+	}
+
 	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ShowPopupAsyncWithView_CancellationTokenExpired()
 	{
@@ -220,9 +631,32 @@ public class PopupExtensionsTests : BaseHandlerTest
 		var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(1));
 
 		// Ensure CancellationToken has expired
-		await Task.Delay(100, CancellationToken.None);
+		await Task.Delay(100, TestContext.Current.CancellationToken);
 
 		await Assert.ThrowsAsync<OperationCanceledException>(() => navigation.ShowPopupAsync(view, PopupOptions.Empty, cts.Token));
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task ShowPopupAsyncWithView_Shell_CancellationTokenExpired()
+	{
+		// Arrange
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+		var view = new ViewWithIQueryable(new ViewModelWithIQueryable());
+
+		var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(1));
+
+		// Ensure CancellationToken has expired
+		await Task.Delay(100, TestContext.Current.CancellationToken);
+
+		await Assert.ThrowsAsync<OperationCanceledException>(() => shell.ShowPopupAsync(view, PopupOptions.Empty, shellParameters, cts.Token));
+		Assert.NotEqual(shellParameterBackgroundColorValue, view.BackgroundColor);
+		Assert.NotEqual(shellParameterViewModelTextValue, view.BindingContext.Text);
 	}
 
 	[Fact(Timeout = (int)TestDuration.Short)]
@@ -237,7 +671,30 @@ public class PopupExtensionsTests : BaseHandlerTest
 
 		await Assert.ThrowsAsync<OperationCanceledException>(() => navigation.ShowPopupAsync(selfClosingPopup, PopupOptions.Empty, cts.Token));
 	}
-	
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task ShowPopupAsync_Shell_CancellationTokenCanceled()
+	{
+		// Arrange
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+		var selfClosingPopup = ServiceProvider.GetRequiredService<MockSelfClosingPopup>() ?? throw new InvalidOperationException();
+
+		var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(1));
+
+		// Act
+		await cts.CancelAsync();
+
+		// Assert
+		await Assert.ThrowsAsync<OperationCanceledException>(() => navigation.ShowPopupAsync(selfClosingPopup, PopupOptions.Empty, cts.Token));
+		Assert.NotEqual(shellParameterBackgroundColorValue, selfClosingPopup.BackgroundColor);
+	}
+
 	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ShowPopupAsyncWithView_CancellationTokenCanceled()
 	{
@@ -251,6 +708,30 @@ public class PopupExtensionsTests : BaseHandlerTest
 		await Assert.ThrowsAsync<OperationCanceledException>(() => navigation.ShowPopupAsync(view, PopupOptions.Empty, cts.Token));
 	}
 
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task ShowPopupAsyncWithView_Shell_CancellationTokenCanceled()
+	{
+		// Arrange
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+		var view = new ViewWithIQueryable(new ViewModelWithIQueryable());
+
+		var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(1));
+
+		// Act
+		await cts.CancelAsync();
+
+		// Assert
+		await Assert.ThrowsAsync<OperationCanceledException>(() => shell.ShowPopupAsync(view, PopupOptions.Empty, shellParameters, cts.Token));
+		Assert.NotEqual(shellParameterBackgroundColorValue, view.BackgroundColor);
+		Assert.NotEqual(shellParameterViewModelTextValue, view.BindingContext.Text);
+	}
+
 	[Fact(Timeout = (int)TestDuration.Medium)]
 	public async Task ShowPopupAsync_ShouldValidateProperBindingContext()
 	{
@@ -262,7 +743,30 @@ public class PopupExtensionsTests : BaseHandlerTest
 
 		Assert.Same(popupInstance.BindingContext, popupViewModel);
 	}
-	
+
+	[Fact(Timeout = (int)TestDuration.Medium)]
+	public async Task ShowPopupAsync_Shell_ShouldValidateProperBindingContext()
+	{
+		// Arrange
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+		var selfClosingPopup = ServiceProvider.GetRequiredService<MockSelfClosingPopup>() ?? throw new InvalidOperationException();
+		var popupInstance = ServiceProvider.GetRequiredService<MockSelfClosingPopup>();
+		var popupViewModel = ServiceProvider.GetRequiredService<MockPageViewModel>();
+
+		// Act
+		await shell.ShowPopupAsync<object?>(selfClosingPopup, PopupOptions.Empty, shellParameters, TestContext.Current.CancellationToken);
+
+		// Assert
+		Assert.Same(popupInstance.BindingContext, popupViewModel);
+		Assert.Equal(shellParameterBackgroundColorValue, selfClosingPopup.BackgroundColor);
+	}
+
 	[Fact(Timeout = (int)TestDuration.Medium)]
 	public async Task ShowPopupAsyncWithView_ShouldValidateProperBindingContext()
 	{
@@ -271,13 +775,42 @@ public class PopupExtensionsTests : BaseHandlerTest
 		var popupViewModel = ServiceProvider.GetRequiredService<MockPageViewModel>();
 
 		var showPopupTask = navigation.ShowPopupAsync<object?>(view, PopupOptions.Empty, TestContext.Current.CancellationToken);
-		
+
 		var popupPage = (PopupPage)navigation.ModalStack[0];
 		await popupPage.Close(new PopupResult<object?>(null, false), TestContext.Current.CancellationToken);
-		
+
 		await showPopupTask;
 
 		Assert.Same(popupInstance.BindingContext, popupViewModel);
+	}
+
+	[Fact(Timeout = (int)TestDuration.Medium)]
+	public async Task ShowPopupAsyncWithView_Shell_ShouldValidateProperBindingContext()
+	{
+		// Arrange
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+		var view = new ViewWithIQueryable(new ViewModelWithIQueryable());
+		var popupInstance = ServiceProvider.GetRequiredService<MockSelfClosingPopup>();
+		var popupViewModel = ServiceProvider.GetRequiredService<MockPageViewModel>();
+
+		// Act
+		var showPopupTask = shell.ShowPopupAsync<object?>(view, PopupOptions.Empty, shellParameters, TestContext.Current.CancellationToken);
+
+		var popupPage = (PopupPage)shellNavigation.ModalStack[0];
+		await popupPage.Close(new PopupResult<object?>(null, false), TestContext.Current.CancellationToken);
+
+		await showPopupTask;
+
+		// Assert
+		Assert.Same(popupInstance.BindingContext, popupViewModel);
+		Assert.Equal(shellParameterBackgroundColorValue, view.BackgroundColor);
+		Assert.Equal(shellParameterViewModelTextValue, view.BindingContext.Text);
 	}
 
 	[Fact(Timeout = (int)TestDuration.Medium)]
@@ -286,25 +819,48 @@ public class PopupExtensionsTests : BaseHandlerTest
 		var mockPopup = ServiceProvider.GetRequiredService<MockSelfClosingPopup>();
 		var selfClosingPopup = ServiceProvider.GetRequiredService<MockSelfClosingPopup>() ?? throw new InvalidOperationException();
 
-		var result = await navigation.ShowPopupAsync<object?>(selfClosingPopup, PopupOptions.Empty, CancellationToken.None);
+		var result = await navigation.ShowPopupAsync<object?>(selfClosingPopup, PopupOptions.Empty, TestContext.Current.CancellationToken);
 
 		Assert.Same(mockPopup.Result, result.Result);
 		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
+	}
+
+	[Fact(Timeout = (int)TestDuration.Medium)]
+	public async Task ShowPopupAsync_Shell_ShouldReturnResultOnceClosed()
+	{
+		// Arrange
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+		var mockPopup = ServiceProvider.GetRequiredService<MockSelfClosingPopup>();
+		var selfClosingPopup = ServiceProvider.GetRequiredService<MockSelfClosingPopup>() ?? throw new InvalidOperationException();
+
+		// Act
+		var result = await shell.ShowPopupAsync<object?>(selfClosingPopup, PopupOptions.Empty, shellParameters, TestContext.Current.CancellationToken);
+
+		// Assert
+		Assert.Same(mockPopup.Result, result.Result);
+		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
+		Assert.Equal(shellParameterBackgroundColorValue, selfClosingPopup.BackgroundColor);
 	}
 	
 	[Fact(Timeout = (int)TestDuration.Medium)]
 	public async Task ShowPopupAsyncWithView_ShouldReturnResultOnceClosed()
 	{
 		const int popupResultValue = 2;
-		
+
 		var view = new Grid();
 		var expectedPopupResult = new PopupResult<int>(popupResultValue, false);
 
-		var showPopupTask = navigation.ShowPopupAsync<int>(view, PopupOptions.Empty, CancellationToken.None);
+		var showPopupTask = navigation.ShowPopupAsync<int>(view, PopupOptions.Empty, TestContext.Current.CancellationToken);
 
 		var popupPage = (PopupPage)navigation.ModalStack[0];
 		await popupPage.Close(expectedPopupResult, TestContext.Current.CancellationToken);
-		
+
 		var actualPopupResult = await showPopupTask;
 
 		Assert.Same(expectedPopupResult, actualPopupResult);
@@ -312,50 +868,148 @@ public class PopupExtensionsTests : BaseHandlerTest
 		Assert.Equal(popupResultValue, expectedPopupResult.Result);
 	}
 
+	[Fact(Timeout = (int)TestDuration.Medium)]
+	public async Task ShowPopupAsyncWithView_Shell_ShouldReturnResultOnceClosed()
+	{
+		// Arrange
+		const int popupResultValue = 2;
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+
+		var view = new ViewWithIQueryable(new ViewModelWithIQueryable());
+		var expectedPopupResult = new PopupResult<int>(popupResultValue, false);
+
+		var showPopupTask = shell.ShowPopupAsync<int>(view, PopupOptions.Empty, shellParameters, TestContext.Current.CancellationToken);
+
+		var popupPage = (PopupPage)shellNavigation.ModalStack[0];
+		await popupPage.Close(expectedPopupResult, TestContext.Current.CancellationToken);
+
+		var actualPopupResult = await showPopupTask;
+
+		Assert.Same(expectedPopupResult, actualPopupResult);
+		Assert.False(expectedPopupResult.WasDismissedByTappingOutsideOfPopup);
+		Assert.Equal(popupResultValue, expectedPopupResult.Result);
+	}
+	
 	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ShowPopupAsync_ShouldThrowArgumentNullException_WhenViewIsNull()
 	{
+		// Arrange
+		
+		// Act/Assert
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-		await Assert.ThrowsAsync<ArgumentNullException>(() => navigation.ShowPopupAsync(null, PopupOptions.Empty, CancellationToken.None));
+		await Assert.ThrowsAsync<ArgumentNullException>(() => navigation.ShowPopupAsync(null, PopupOptions.Empty, TestContext.Current.CancellationToken));
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
-	
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task ShowPopupAsync_Shell_ShouldThrowArgumentNullException_WhenViewIsNull()
+	{
+		// Arrange
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+		
+		// Act/Assert
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		await Assert.ThrowsAsync<ArgumentNullException>(() => shell.ShowPopupAsync(null, PopupOptions.Empty, shellParameters, TestContext.Current.CancellationToken));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
 	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ShowPopupAsync_ShouldThrowArgumentNullException_WhenNavigationIsNull()
 	{
 		var selfClosingPopup = ServiceProvider.GetRequiredService<MockSelfClosingPopup>() ?? throw new InvalidOperationException();
-		
+
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-		await Assert.ThrowsAsync<ArgumentNullException>(() => PopupExtensions.ShowPopupAsync((INavigation?)null, selfClosingPopup, PopupOptions.Empty, CancellationToken.None));
+		await Assert.ThrowsAsync<ArgumentNullException>(() => PopupExtensions.ShowPopupAsync((INavigation?)null, selfClosingPopup, PopupOptions.Empty, TestContext.Current.CancellationToken));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+	
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task ShowPopupAsync_Shell_ShouldThrowArgumentNullException_WhenNavigationIsNull()
+	{
+		// Arrange
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+		var selfClosingPopup = ServiceProvider.GetRequiredService<MockSelfClosingPopup>() ?? throw new InvalidOperationException();
+
+		// Act/Assert
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		await Assert.ThrowsAsync<ArgumentNullException>(() => PopupExtensions.ShowPopupAsync((Shell?)null, selfClosingPopup, PopupOptions.Empty, shellParameters, TestContext.Current.CancellationToken));
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 
 	[Fact(Timeout = (int)TestDuration.Short)]
-	public async Task ShowPopupAsync_ShouldReturnDefaultResult_WhenPopupIsClosedWithoutResult()
+	public async Task ShowPopupAsync_ShouldReturnNullResult_WhenPopupIsClosedWithoutResult()
 	{
-		var selfClosingPopup = ServiceProvider.GetRequiredService<MockSelfClosingPopup>();
+		// Arrange
+		
+		// Act
+		var showPopupTask = navigation.ShowPopupAsync<object?>(new Popup(), PopupOptions.Empty, TestContext.Current.CancellationToken);
 
-		var result = await navigation.ShowPopupAsync<object?>(selfClosingPopup, PopupOptions.Empty, CancellationToken.None);
+		var popupPage = (PopupPage)navigation.ModalStack.Last();
+		await popupPage.Close(new PopupResult(true), TestContext.Current.CancellationToken);
+		var result = await showPopupTask; 
 
-		Assert.Equal(selfClosingPopup.Result, result.Result);
-		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
+		// Assert
+		Assert.Null(result.Result);
+		Assert.True(result.WasDismissedByTappingOutsideOfPopup);
 	}
 	
 	[Fact(Timeout = (int)TestDuration.Short)]
-	public async Task ShowPopupAsync_ReferenceTypeShouldReturnResult_WhenPopupIsClosedByTappingOutsidePopup()
+	public async Task ShowPopupAsync_Shell_ShouldReturnNullResult_WhenPopupIsClosedWithoutResult()
+	{
+		// Arrange
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+		
+		// Act
+		var showPopupTask = shell.ShowPopupAsync<object?>(new Popup(), PopupOptions.Empty, shellParameters, TestContext.Current.CancellationToken);
+
+		var popupPage = (PopupPage)shellNavigation.ModalStack.Last();
+		await popupPage.Close(new PopupResult(true), TestContext.Current.CancellationToken);
+		var result = await showPopupTask; 
+
+		// Assert
+		Assert.Null(result.Result);
+		Assert.True(result.WasDismissedByTappingOutsideOfPopup);
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task ShowPopupAsync_ReferenceTypeShouldReturnNull_WhenPopupTapGestureRecognizerCommandIsExecuted()
 	{
 		var popupClosedTCS = new TaskCompletionSource<IPopupResult>();
 
-		var showPopupTask = navigation.ShowPopupAsync<bool?>(new Popup<bool>(), token: CancellationToken.None);
+		var showPopupTask = navigation.ShowPopupAsync<bool?>(new Popup<bool>(), token: TestContext.Current.CancellationToken);
 		var popupPage = (PopupPage)navigation.ModalStack[0];
 		popupPage.PopupClosed += HandlePopupClosed;
-		
+
 		var tapGestureRecognizer = (TapGestureRecognizer)popupPage.Content.GestureRecognizers[0];
 		tapGestureRecognizer.Command?.Execute(null);
-		
+
 		var popupClosedResult = await popupClosedTCS.Task;
 		var showPopupResult = await showPopupTask;
-		
+
 		Assert.True(popupClosedResult.WasDismissedByTappingOutsideOfPopup);
 		Assert.Null(showPopupResult.Result);
 		Assert.True(showPopupResult.WasDismissedByTappingOutsideOfPopup);
@@ -367,20 +1021,88 @@ public class PopupExtensionsTests : BaseHandlerTest
 	}
 	
 	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task ShowPopupAsync_Shell_ReferenceTypeShouldReturnNull_WhenPopupTapGestureRecognizerCommandIsExecuted()
+	{
+		// Arrange
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+		var popupClosedTCS = new TaskCompletionSource<IPopupResult>();
+
+		var showPopupTask = shell.ShowPopupAsync<bool?>(new Popup<bool>(), token: TestContext.Current.CancellationToken);
+		var popupPage = (PopupPage)shellNavigation.ModalStack[0];
+		popupPage.PopupClosed += HandlePopupClosed;
+
+		var tapGestureRecognizer = (TapGestureRecognizer)popupPage.Content.GestureRecognizers[0];
+		tapGestureRecognizer.Command?.Execute(null);
+
+		var popupClosedResult = await popupClosedTCS.Task;
+		var showPopupResult = await showPopupTask;
+
+		Assert.True(popupClosedResult.WasDismissedByTappingOutsideOfPopup);
+		Assert.Null(showPopupResult.Result);
+		Assert.True(showPopupResult.WasDismissedByTappingOutsideOfPopup);
+
+		void HandlePopupClosed(object? sender, IPopupResult e)
+		{
+			popupClosedTCS.SetResult(e);
+		}
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ShowPopupAsync_NullableValueTypeShouldReturnResult_WhenPopupIsClosedByTappingOutsidePopup()
 	{
 		var popupClosedTCS = new TaskCompletionSource<IPopupResult>();
 
-		var showPopupTask = navigation.ShowPopupAsync<bool?>(new Popup<bool>(), token: CancellationToken.None);
+		var showPopupTask = navigation.ShowPopupAsync<bool?>(new Popup<bool>(), token: TestContext.Current.CancellationToken);
 		var popupPage = (PopupPage)navigation.ModalStack[0];
 		popupPage.PopupClosed += HandlePopupClosed;
-		
+
 		var tapGestureRecognizer = (TapGestureRecognizer)popupPage.Content.GestureRecognizers[0];
 		tapGestureRecognizer.Command?.Execute(null);
-		
+
 		var popupClosedResult = await popupClosedTCS.Task;
 		var showPopupResult = await showPopupTask;
-		
+
+		Assert.True(popupClosedResult.WasDismissedByTappingOutsideOfPopup);
+		Assert.Null(showPopupResult.Result);
+		Assert.True(showPopupResult.WasDismissedByTappingOutsideOfPopup);
+
+		void HandlePopupClosed(object? sender, IPopupResult e)
+		{
+			popupClosedTCS.SetResult(e);
+		}
+	}
+	
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task ShowPopupAsync_Shell_NullableValueTypeShouldReturnResult_WhenPopupIsClosedByTappingOutsidePopup()
+	{
+		// Arrange
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+		var popupClosedTCS = new TaskCompletionSource<IPopupResult>();
+
+		// Act
+		var showPopupTask = shell.ShowPopupAsync<bool?>(new Popup<bool>(), token: TestContext.Current.CancellationToken);
+		var popupPage = (PopupPage)shellNavigation.ModalStack[0];
+		popupPage.PopupClosed += HandlePopupClosed;
+
+		var tapGestureRecognizer = (TapGestureRecognizer)popupPage.Content.GestureRecognizers[0];
+		tapGestureRecognizer.Command?.Execute(null);
+
+		var popupClosedResult = await popupClosedTCS.Task;
+		var showPopupResult = await showPopupTask;
+
+		// Assert
 		Assert.True(popupClosedResult.WasDismissedByTappingOutsideOfPopup);
 		Assert.Null(showPopupResult.Result);
 		Assert.True(showPopupResult.WasDismissedByTappingOutsideOfPopup);
@@ -396,16 +1118,16 @@ public class PopupExtensionsTests : BaseHandlerTest
 	{
 		var popupClosedTCS = new TaskCompletionSource<IPopupResult>();
 
-		var showPopupTask = navigation.ShowPopupAsync<bool>(new Popup<bool>(), token: CancellationToken.None);
+		var showPopupTask = navigation.ShowPopupAsync<bool>(new Popup<bool>(), token: TestContext.Current.CancellationToken);
 		var popupPage = (PopupPage)navigation.ModalStack[0];
 		popupPage.PopupClosed += HandlePopupClosed;
-		
+
 		var tapGestureRecognizer = (TapGestureRecognizer)popupPage.Content.GestureRecognizers[0];
 		tapGestureRecognizer.Command?.Execute(null);
-		
+
 		var popupClosedResult = await popupClosedTCS.Task;
 		var showPopupResult = await showPopupTask;
-		
+
 		Assert.True(popupClosedResult.WasDismissedByTappingOutsideOfPopup);
 		Assert.True(showPopupResult.WasDismissedByTappingOutsideOfPopup);
 		Assert.ThrowsAny<PopupResultException>(() => (bool?)showPopupResult.Result);
@@ -414,6 +1136,67 @@ public class PopupExtensionsTests : BaseHandlerTest
 		void HandlePopupClosed(object? sender, IPopupResult e)
 		{
 			popupClosedTCS.SetResult(e);
+		}
+	}
+	
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task ShowPopupAsync_Shell_ValueTypeShouldReturnResult_WhenPopupIsClosedByTappingOutsidePopup()
+	{
+		// Arrange
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+		var popupClosedTCS = new TaskCompletionSource<IPopupResult>();
+
+		// Act
+		var showPopupTask = shell.ShowPopupAsync<bool>(new Popup<bool>(), token: TestContext.Current.CancellationToken);
+		var popupPage = (PopupPage)shellNavigation.ModalStack[0];
+		popupPage.PopupClosed += HandlePopupClosed;
+
+		var tapGestureRecognizer = (TapGestureRecognizer)popupPage.Content.GestureRecognizers[0];
+		tapGestureRecognizer.Command?.Execute(null);
+
+		var popupClosedResult = await popupClosedTCS.Task;
+		var showPopupResult = await showPopupTask;
+
+		// Assert
+		Assert.True(popupClosedResult.WasDismissedByTappingOutsideOfPopup);
+		Assert.True(showPopupResult.WasDismissedByTappingOutsideOfPopup);
+		Assert.ThrowsAny<PopupResultException>(() => (bool?)showPopupResult.Result);
+		Assert.ThrowsAny<InvalidCastException>(() => (bool?)showPopupResult.Result);
+
+		void HandlePopupClosed(object? sender, IPopupResult e)
+		{
+			popupClosedTCS.SetResult(e);
+		}
+	}
+
+	sealed class ViewWithIQueryable : Button, IQueryAttributable
+	{
+		public ViewWithIQueryable(ViewModelWithIQueryable viewModel)
+		{
+			base.BindingContext = viewModel;
+		}
+
+		public new ViewModelWithIQueryable BindingContext => (ViewModelWithIQueryable)base.BindingContext;
+
+		void IQueryAttributable.ApplyQueryAttributes(IDictionary<string, object> query)
+		{
+			BackgroundColor = (Color)query[nameof(BackgroundColor)];
+		}
+	}
+
+	sealed class ViewModelWithIQueryable : IQueryAttributable
+	{
+		public string? Text { get; set; }
+
+		void IQueryAttributable.ApplyQueryAttributes(IDictionary<string, object> query)
+		{
+			Text = (string)query[nameof(Text)];
 		}
 	}
 }

--- a/src/CommunityToolkit.Maui.UnitTests/Extensions/PopupExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Extensions/PopupExtensionsTests.cs
@@ -19,7 +19,7 @@ public class PopupExtensionsTests : BaseHandlerTest
 	readonly IDictionary<string, object> shellParameters = new Dictionary<string, object>
 	{
 		{ nameof(View.BackgroundColor), shellParameterBackgroundColorValue },
-		{ nameof(ViewModelWithIQueryable.Text), shellParameterViewModelTextValue }
+		{ nameof(ViewModelWithIQueryAttributable.Text), shellParameterViewModelTextValue }
 	}.AsReadOnly();
 
 	public PopupExtensionsTests()
@@ -83,7 +83,7 @@ public class PopupExtensionsTests : BaseHandlerTest
 	public void ShowPopupAsync_Shell_WithViewType_ShowsPopup()
 	{
 		// Arrange
-		var viewWithQueryable = new ViewWithIQueryable(new ViewModelWithIQueryable());
+		var viewWithQueryable = new ViewWithIQueryAttributable(new ViewModelWithIQueryAttributable());
 		var shell = new Shell();
 		shell.Items.Add(new MockPage(new MockPageViewModel()));
 
@@ -156,7 +156,7 @@ public class PopupExtensionsTests : BaseHandlerTest
 	public void ShowPopup_Shell_NavigationModalStackCountIncreases()
 	{
 		// Arrange
-		var viewWithQueryable = new ViewWithIQueryable(new ViewModelWithIQueryable());
+		var viewWithQueryable = new ViewWithIQueryAttributable(new ViewModelWithIQueryAttributable());
 		var shell = new Shell();
 		shell.Items.Add(new MockPage(new MockPageViewModel()));
 
@@ -179,7 +179,7 @@ public class PopupExtensionsTests : BaseHandlerTest
 	public void ShowPopupWithView_NavigationModalStackCountIncreases()
 	{
 		// Arrange
-		var viewWithQueryable = new ViewWithIQueryable(new ViewModelWithIQueryable());
+		var viewWithQueryable = new ViewWithIQueryAttributable(new ViewModelWithIQueryAttributable());
 		var shell = new Shell();
 		shell.Items.Add(new MockPage(new MockPageViewModel()));
 
@@ -200,7 +200,7 @@ public class PopupExtensionsTests : BaseHandlerTest
 	public void ShowPopupWithView_Shell_NavigationModalStackCountIncreases()
 	{
 		// Arrange
-		var viewWithQueryable = new ViewWithIQueryable(new ViewModelWithIQueryable());
+		var viewWithQueryable = new ViewWithIQueryAttributable(new ViewModelWithIQueryAttributable());
 		var shell = new Shell();
 		shell.Items.Add(new MockPage(new MockPageViewModel()));
 
@@ -273,7 +273,7 @@ public class PopupExtensionsTests : BaseHandlerTest
 	public void ShowPopupView_Shell_MultiplePopupsDisplayed()
 	{
 		// Arrange
-		var viewWithQueryable = new ViewWithIQueryable(new ViewModelWithIQueryable());
+		var viewWithQueryable = new ViewWithIQueryAttributable(new ViewModelWithIQueryAttributable());
 		var shell = new Shell();
 		shell.Items.Add(new MockPage(new MockPageViewModel()));
 
@@ -515,7 +515,7 @@ public class PopupExtensionsTests : BaseHandlerTest
 		var shellNavigation = Shell.Current.Navigation;
 		var onTappingOutsideOfPopup = () => { };
 
-		var viewWithQueryable = new ViewWithIQueryable(new ViewModelWithIQueryable())
+		var viewWithQueryable = new ViewWithIQueryAttributable(new ViewModelWithIQueryAttributable())
 		{
 			HorizontalOptions = LayoutOptions.End,
 			VerticalOptions = LayoutOptions.Start,
@@ -649,7 +649,7 @@ public class PopupExtensionsTests : BaseHandlerTest
 		Application.Current.Windows[0].Page = shell;
 
 		var shellNavigation = Shell.Current.Navigation;
-		var view = new ViewWithIQueryable(new ViewModelWithIQueryable());
+		var view = new ViewWithIQueryAttributable(new ViewModelWithIQueryAttributable());
 
 		var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(1));
 
@@ -724,7 +724,7 @@ public class PopupExtensionsTests : BaseHandlerTest
 		Application.Current.Windows[0].Page = shell;
 
 		var shellNavigation = Shell.Current.Navigation;
-		var view = new ViewWithIQueryable(new ViewModelWithIQueryable());
+		var view = new ViewWithIQueryAttributable(new ViewModelWithIQueryAttributable());
 
 		var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(1));
 
@@ -806,7 +806,7 @@ public class PopupExtensionsTests : BaseHandlerTest
 		Application.Current.Windows[0].Page = shell;
 
 		var shellNavigation = Shell.Current.Navigation;
-		var view = new ViewWithIQueryable(new ViewModelWithIQueryable());
+		var view = new ViewWithIQueryAttributable(new ViewModelWithIQueryAttributable());
 		var popupInstance = ServiceProvider.GetRequiredService<MockSelfClosingPopup>();
 		var popupViewModel = ServiceProvider.GetRequiredService<MockPageViewModel>();
 
@@ -898,7 +898,7 @@ public class PopupExtensionsTests : BaseHandlerTest
 
 		var shellNavigation = Shell.Current.Navigation;
 
-		var view = new ViewWithIQueryable(new ViewModelWithIQueryable());
+		var view = new ViewWithIQueryAttributable(new ViewModelWithIQueryAttributable());
 		var expectedPopupResult = new PopupResult<int>(popupResultValue, false);
 
 		// Act
@@ -1206,29 +1206,29 @@ public class PopupExtensionsTests : BaseHandlerTest
 			popupClosedTCS.SetResult(e);
 		}
 	}
+}
 
-	sealed class ViewWithIQueryable : Button, IQueryAttributable
+sealed class ViewWithIQueryAttributable : Button, IQueryAttributable
+{
+	public ViewWithIQueryAttributable(ViewModelWithIQueryAttributable viewModel)
 	{
-		public ViewWithIQueryable(ViewModelWithIQueryable viewModel)
-		{
-			base.BindingContext = viewModel;
-		}
-
-		public new ViewModelWithIQueryable BindingContext => (ViewModelWithIQueryable)base.BindingContext;
-
-		void IQueryAttributable.ApplyQueryAttributes(IDictionary<string, object> query)
-		{
-			BackgroundColor = (Color)query[nameof(BackgroundColor)];
-		}
+		base.BindingContext = viewModel;
 	}
 
-	sealed class ViewModelWithIQueryable : IQueryAttributable
-	{
-		public string? Text { get; set; }
+	public new ViewModelWithIQueryAttributable BindingContext => (ViewModelWithIQueryAttributable)base.BindingContext;
 
-		void IQueryAttributable.ApplyQueryAttributes(IDictionary<string, object> query)
-		{
-			Text = (string)query[nameof(Text)];
-		}
+	void IQueryAttributable.ApplyQueryAttributes(IDictionary<string, object> query)
+	{
+		BackgroundColor = (Color)query[nameof(BackgroundColor)];
+	}
+}
+
+sealed class ViewModelWithIQueryAttributable : IQueryAttributable
+{
+	public string? Text { get; set; }
+
+	void IQueryAttributable.ApplyQueryAttributes(IDictionary<string, object> query)
+	{
+		Text = (string)query[nameof(Text)];
 	}
 }

--- a/src/CommunityToolkit.Maui.UnitTests/Mocks/MockPage.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Mocks/MockPage.cs
@@ -1,6 +1,6 @@
 ﻿namespace CommunityToolkit.Maui.UnitTests.Mocks;
 
-class MockPage : Page
+class MockPage : ContentPage
 {
 	public MockPage(MockPageViewModel viewModel)
 	{

--- a/src/CommunityToolkit.Maui.UnitTests/Services/PopupServiceTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Services/PopupServiceTests.cs
@@ -277,8 +277,10 @@ public class PopupServiceTests : BaseHandlerTest
 	}
 }
 
-sealed class MockSelfClosingPopup : Popup<object?>
+sealed class MockSelfClosingPopup : Popup<object?>, IQueryAttributable
 {
+	public const int ExpectedResult = 2;
+	
 	public MockSelfClosingPopup(MockPageViewModel viewModel, object? result = null)
 	{
 		BackgroundColor = Colors.White;
@@ -309,7 +311,12 @@ sealed class MockSelfClosingPopup : Popup<object?>
 		}
 	}
 
-	public object? Result { get; }
+	public object? Result { get; } = ExpectedResult;
+	
+	void IQueryAttributable.ApplyQueryAttributes(IDictionary<string, object> query)
+	{
+		BackgroundColor = (Color)query[nameof(BackgroundColor)];
+	}
 }
 
 sealed file class MockPopup : Popup

--- a/src/CommunityToolkit.Maui.UnitTests/Services/PopupServiceTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Services/PopupServiceTests.cs
@@ -283,11 +283,13 @@ sealed class MockSelfClosingPopup : Popup<object?>, IQueryAttributable
 	
 	public MockSelfClosingPopup(MockPageViewModel viewModel, object? result = null)
 	{
-		BackgroundColor = Colors.White;
+		BackgroundColor = DefaultBackgroundColor;
 		BindingContext = viewModel;
 		Result = result;
 		Opened += HandlePopupOpened;
 	}
+
+	public static Color DefaultBackgroundColor { get; } = Colors.White; 
 
 	void HandlePopupOpened(object? sender, EventArgs e)
 	{

--- a/src/CommunityToolkit.Maui.UnitTests/Views/Popup/PopupPageTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/Popup/PopupPageTests.cs
@@ -22,7 +22,7 @@ public class PopupPageTests : BaseHandlerTest
 
 		// Act
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-		Action act = () => new PopupPage(null, popupOptions);
+		Action act = () => new PopupPage(null, popupOptions, null);
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
 		// Assert
@@ -38,7 +38,7 @@ public class PopupPageTests : BaseHandlerTest
 
 		// Act
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-		Action act = () => new PopupPage(view, null);
+		Action act = () => new PopupPage(view, null, null);
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
 		// Assert
@@ -51,7 +51,7 @@ public class PopupPageTests : BaseHandlerTest
 		// Arrange
 		var view = new ContentView();
 		var popupOptions = new MockPopupOptions();
-		var popupPage = new PopupPage<string>(view, popupOptions);
+		var popupPage = new PopupPage<string>(view, popupOptions, null);
 
 		// Act / Assert
 		await Assert.ThrowsAsync<PopupNotFoundException>(async () => await popupPage.Close(new PopupResult(false), CancellationToken.None));
@@ -65,7 +65,7 @@ public class PopupPageTests : BaseHandlerTest
 		var tcs = new TaskCompletionSource<IPopupResult>();
 		var view = new ContentView();
 		var popupOptions = new MockPopupOptions();
-		var popupPage = new PopupPage(view, popupOptions);
+		var popupPage = new PopupPage(view, popupOptions, null);
 		var expectedResult = new PopupResult(false);
 
 		popupPage.PopupClosed += HandlePopupClosed;
@@ -122,7 +122,7 @@ public class PopupPageTests : BaseHandlerTest
 
 		// Act
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-		Action act = () => new PopupPage<string>(null, popupOptions);
+		Action act = () => new PopupPage<string>(null, popupOptions, null);
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
 		// Assert
@@ -137,7 +137,7 @@ public class PopupPageTests : BaseHandlerTest
 
 		// Act
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-		Action act = () => new PopupPage<string>(view, null);
+		Action act = () => new PopupPage<string>(view, null, null);
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
 		// Assert
@@ -151,7 +151,7 @@ public class PopupPageTests : BaseHandlerTest
 		var view = new ContentView();
 		var popupOptions = new MockPopupOptions();
 		var taskCompletionSource = new TaskCompletionSource<PopupResult<string>>();
-		var popupPage = new PopupPage<string>(view, popupOptions);
+		var popupPage = new PopupPage<string>(view, popupOptions, null);
 		var expectedResult = new PopupResult<string>("Test", false);
 
 		popupPage.PopupClosed += HandlePopupClosed;
@@ -182,7 +182,7 @@ public class PopupPageTests : BaseHandlerTest
 		// Arrange
 		var view = new ContentView();
 		var popupOptions = new MockPopupOptions();
-		var popupPage = new PopupPage<string>(view, popupOptions);
+		var popupPage = new PopupPage<string>(view, popupOptions, null);
 
 		// Act
 		if (Application.Current?.Windows[0].Page?.Navigation is not INavigation navigation)
@@ -204,7 +204,7 @@ public class PopupPageTests : BaseHandlerTest
 		// Arrange
 		var view = new ContentView();
 		var popupOptions = new MockPopupOptions();
-		var popupPage = new PopupPage<string>(view, popupOptions);
+		var popupPage = new PopupPage<string>(view, popupOptions, null);
 		var result = new PopupResult<string>("Test", false);
 		var cts = new CancellationTokenSource();
 		cts.Cancel();
@@ -233,7 +233,7 @@ public class PopupPageTests : BaseHandlerTest
 		};
 
 		// Act
-		var popupPage = new PopupPage(view, popupOptions);
+		var popupPage = new PopupPage(view, popupOptions, null);
 
 		// Assert
 		Assert.NotNull(popupPage.Content);
@@ -264,7 +264,7 @@ public class PopupPageTests : BaseHandlerTest
 
 		// Act & Assert
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-		Assert.Throws<ArgumentNullException>(() => new PopupPage((View?)null, popupOptions));
+		Assert.Throws<ArgumentNullException>(() => new PopupPage((View?)null, popupOptions, null));
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 
@@ -276,7 +276,7 @@ public class PopupPageTests : BaseHandlerTest
 
 		// Act & Assert
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-		Assert.Throws<ArgumentNullException>(() => new PopupPage((Popup?)null, popupOptions));
+		Assert.Throws<ArgumentNullException>(() => new PopupPage((Popup?)null, popupOptions, null));
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 
@@ -288,7 +288,7 @@ public class PopupPageTests : BaseHandlerTest
 		IPopupOptions popupOptions = null!;
 
 		// Act & Assert
-		Assert.Throws<ArgumentNullException>(() => new PopupPage(view, popupOptions));
+		Assert.Throws<ArgumentNullException>(() => new PopupPage(view, popupOptions, null));
 	}
 
 	[Fact]
@@ -308,7 +308,7 @@ public class PopupPageTests : BaseHandlerTest
 			}
 		};
 
-		var popupPage = new PopupPage(view, popupOptions);
+		var popupPage = new PopupPage(view, popupOptions, null);
 
 		var tapGestureRecognizer = (TapGestureRecognizer)popupPage.Content.GestureRecognizers[0];
 		var command = tapGestureRecognizer.Command;
@@ -334,7 +334,7 @@ public class PopupPageTests : BaseHandlerTest
 			CanBeDismissedByTappingOutsideOfPopup = false
 		};
 
-		var popupPage = new PopupPage(view, popupOptions);
+		var popupPage = new PopupPage(view, popupOptions, null);
 		var tapGestureRecognizer = (TapGestureRecognizer)popupPage.Content.GestureRecognizers[0];
 		var command = tapGestureRecognizer.Command;
 
@@ -363,7 +363,7 @@ public class PopupPageTests : BaseHandlerTest
 	}
 
 	// Helper class for testing protected methods
-	sealed class TestablePopupPage(View view, IPopupOptions popupOptions) : PopupPage(view, popupOptions)
+	sealed class TestablePopupPage(View view, IPopupOptions popupOptions) : PopupPage(view, popupOptions, null)
 	{
 		public bool TestOnBackButtonPressed()
 		{

--- a/src/CommunityToolkit.Maui.UnitTests/Views/Popup/PopupPageTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/Popup/PopupPageTests.cs
@@ -514,6 +514,46 @@ public class PopupPageTests : BaseHandlerTest
 		Assert.Equal(expectedBackgroundColor, view.BackgroundColor);
 		Assert.NotEqual(expectedBackgroundColor, initialBackgroundColor);
 	}
+	
+	[Fact]
+	public void PopupPageT_ShellParametersShouldBePassedToViewWithIQueryAttributable()
+	{
+		// Arrange
+		var view = new ViewWithIQueryAttributable(new ViewModelWithIQueryAttributable());
+		var initialBackgroundColor = view.BackgroundColor;
+		var expectedBackgroundColor = Colors.Red;
+
+		// Act
+		var popupPage = new PopupPage<object?>(view, PopupOptions.Empty, new Dictionary<string, object>
+		{
+			{ nameof(ViewWithIQueryAttributable.BackgroundColor), expectedBackgroundColor },
+		});
+
+		// Assert
+		Assert.Null(initialBackgroundColor);
+		Assert.Equal(expectedBackgroundColor, view.BackgroundColor);
+		Assert.NotEqual(expectedBackgroundColor, initialBackgroundColor);
+	}
+	
+	[Fact]
+	public void PopupPageT_ShellParametersShouldBePassedToPopupWithIQueryAttributable()
+	{
+		// Arrange
+		var mockPopup = ServiceProvider.GetRequiredService<MockSelfClosingPopup>();
+		var initialBackgroundColor = mockPopup.BackgroundColor;
+		var expectedBackgroundColor = Colors.Red;
+
+		// Act
+		var popupPage = new PopupPage<object?>(mockPopup, PopupOptions.Empty, new Dictionary<string, object>
+		{
+			{ nameof(ViewWithIQueryAttributable.BackgroundColor), expectedBackgroundColor },
+		});
+
+		// Assert
+		Assert.Equal(MockSelfClosingPopup.DefaultBackgroundColor, initialBackgroundColor);
+		Assert.Equal(expectedBackgroundColor, mockPopup.BackgroundColor);
+		Assert.NotEqual(expectedBackgroundColor, initialBackgroundColor);
+	}
 
 	// Helper class for testing protected methods
 	sealed class TestablePopupPage(View view, IPopupOptions popupOptions) : PopupPage(view, popupOptions, null)

--- a/src/CommunityToolkit.Maui.UnitTests/Views/Popup/PopupPageTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/Popup/PopupPageTests.cs
@@ -1,5 +1,7 @@
 ﻿using CommunityToolkit.Maui.Core;
 using CommunityToolkit.Maui.Extensions;
+using CommunityToolkit.Maui.UnitTests.Extensions;
+using CommunityToolkit.Maui.UnitTests.Services;
 using CommunityToolkit.Maui.Views;
 using FluentAssertions;
 using Microsoft.Maui.Controls.PlatformConfiguration;
@@ -474,6 +476,43 @@ public class PopupPageTests : BaseHandlerTest
 		// Assert
 		Assert.Equal(LayoutOptions.Start, border.VerticalOptions);
 		Assert.Equal(LayoutOptions.End, border.HorizontalOptions);
+	}
+
+	[Fact]
+	public void PopupPage_ShellParametersShouldBePassedToPopupWithIQueryable()
+	{
+		// Arrange
+		var selfClosingPopup = ServiceProvider.GetRequiredService<MockSelfClosingPopup>() ?? throw new InvalidOperationException();
+		var initialBackgroundColor = selfClosingPopup.BackgroundColor;
+		var expectedBackgroundColor = Colors.Red;
+
+		// Act
+		var popupPage = new PopupPage(selfClosingPopup, PopupOptions.Empty, new Dictionary<string, object> { { nameof(MockSelfClosingPopup.BackgroundColor), expectedBackgroundColor } });
+
+		// Assert
+		Assert.Equal(MockSelfClosingPopup.DefaultBackgroundColor, initialBackgroundColor);
+		Assert.Equal(expectedBackgroundColor, selfClosingPopup.BackgroundColor);
+		Assert.NotEqual(expectedBackgroundColor, initialBackgroundColor);
+	}
+
+	[Fact]
+	public void PopupPage_ShellParametersShouldBePassedToViewWithIQueryable()
+	{
+		// Arrange
+		var view = new ViewWithIQueryAttributable(new ViewModelWithIQueryAttributable());
+		var initialBackgroundColor = view.BackgroundColor;
+		var expectedBackgroundColor = Colors.Red;
+
+		// Act
+		var popupPage = new PopupPage(view, PopupOptions.Empty, new Dictionary<string, object>
+		{
+			{ nameof(ViewWithIQueryAttributable.BackgroundColor), expectedBackgroundColor },
+		});
+
+		// Assert
+		Assert.Null(initialBackgroundColor);
+		Assert.Equal(expectedBackgroundColor, view.BackgroundColor);
+		Assert.NotEqual(expectedBackgroundColor, initialBackgroundColor);
 	}
 
 	// Helper class for testing protected methods

--- a/src/CommunityToolkit.Maui.UnitTests/Views/Popup/PopupPageTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/Popup/PopupPageTests.cs
@@ -24,7 +24,7 @@ public class PopupPageTests : BaseHandlerTest
 
 		// Act
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-		Action act = () => new PopupPage(null, popupOptions, null);
+		Action act = () => new PopupPage(null, popupOptions);
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
 		// Assert
@@ -40,7 +40,7 @@ public class PopupPageTests : BaseHandlerTest
 
 		// Act
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-		Action act = () => new PopupPage(view, null, null);
+		Action act = () => new PopupPage(view, null);
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
 		// Assert
@@ -53,7 +53,7 @@ public class PopupPageTests : BaseHandlerTest
 		// Arrange
 		var view = new ContentView();
 		var popupOptions = new MockPopupOptions();
-		var popupPage = new PopupPage<string>(view, popupOptions, null);
+		var popupPage = new PopupPage<string>(view, popupOptions);
 
 		// Act / Assert
 		await Assert.ThrowsAsync<PopupNotFoundException>(async () => await popupPage.Close(new PopupResult(false), CancellationToken.None));
@@ -67,7 +67,7 @@ public class PopupPageTests : BaseHandlerTest
 		var tcs = new TaskCompletionSource<IPopupResult>();
 		var view = new ContentView();
 		var popupOptions = new MockPopupOptions();
-		var popupPage = new PopupPage(view, popupOptions, null);
+		var popupPage = new PopupPage(view, popupOptions);
 		var expectedResult = new PopupResult(false);
 
 		popupPage.PopupClosed += HandlePopupClosed;
@@ -124,7 +124,7 @@ public class PopupPageTests : BaseHandlerTest
 
 		// Act
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-		Action act = () => new PopupPage<string>(null, popupOptions, null);
+		Action act = () => new PopupPage<string>(null, popupOptions);
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
 		// Assert
@@ -139,7 +139,7 @@ public class PopupPageTests : BaseHandlerTest
 
 		// Act
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-		Action act = () => new PopupPage<string>(view, null, null);
+		Action act = () => new PopupPage<string>(view, null);
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
 		// Assert
@@ -153,7 +153,7 @@ public class PopupPageTests : BaseHandlerTest
 		var view = new ContentView();
 		var popupOptions = new MockPopupOptions();
 		var taskCompletionSource = new TaskCompletionSource<PopupResult<string>>();
-		var popupPage = new PopupPage<string>(view, popupOptions, null);
+		var popupPage = new PopupPage<string>(view, popupOptions);
 		var expectedResult = new PopupResult<string>("Test", false);
 
 		popupPage.PopupClosed += HandlePopupClosed;
@@ -184,7 +184,7 @@ public class PopupPageTests : BaseHandlerTest
 		// Arrange
 		var view = new ContentView();
 		var popupOptions = new MockPopupOptions();
-		var popupPage = new PopupPage<string>(view, popupOptions, null);
+		var popupPage = new PopupPage<string>(view, popupOptions);
 
 		// Act
 		if (Application.Current?.Windows[0].Page?.Navigation is not INavigation navigation)
@@ -206,7 +206,7 @@ public class PopupPageTests : BaseHandlerTest
 		// Arrange
 		var view = new ContentView();
 		var popupOptions = new MockPopupOptions();
-		var popupPage = new PopupPage<string>(view, popupOptions, null);
+		var popupPage = new PopupPage<string>(view, popupOptions);
 		var result = new PopupResult<string>("Test", false);
 		var cts = new CancellationTokenSource();
 		cts.Cancel();
@@ -238,7 +238,7 @@ public class PopupPageTests : BaseHandlerTest
 		};
 
 		// Act
-		var popupPage = new PopupPage(view, popupOptions, null);
+		var popupPage = new PopupPage(view, popupOptions);
 
 		// Assert
 		Assert.NotNull(popupPage.Content);
@@ -269,7 +269,7 @@ public class PopupPageTests : BaseHandlerTest
 
 		// Act & Assert
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-		Assert.Throws<ArgumentNullException>(() => new PopupPage((View?)null, popupOptions, null));
+		Assert.Throws<ArgumentNullException>(() => new PopupPage((View?)null, popupOptions));
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 
@@ -281,7 +281,7 @@ public class PopupPageTests : BaseHandlerTest
 
 		// Act & Assert
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-		Assert.Throws<ArgumentNullException>(() => new PopupPage((Popup?)null, popupOptions, null));
+		Assert.Throws<ArgumentNullException>(() => new PopupPage((Popup?)null, popupOptions));
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 	}
 
@@ -293,7 +293,7 @@ public class PopupPageTests : BaseHandlerTest
 		IPopupOptions popupOptions = null!;
 
 		// Act & Assert
-		Assert.Throws<ArgumentNullException>(() => new PopupPage(view, popupOptions, null));
+		Assert.Throws<ArgumentNullException>(() => new PopupPage(view, popupOptions));
 	}
 
 	[Fact]
@@ -313,7 +313,7 @@ public class PopupPageTests : BaseHandlerTest
 			}
 		};
 
-		var popupPage = new PopupPage(view, popupOptions, null);
+		var popupPage = new PopupPage(view, popupOptions);
 
 		var tapGestureRecognizer = (TapGestureRecognizer)popupPage.Content.GestureRecognizers[0];
 		var command = tapGestureRecognizer.Command;
@@ -339,7 +339,7 @@ public class PopupPageTests : BaseHandlerTest
 			CanBeDismissedByTappingOutsideOfPopup = false
 		};
 
-		var popupPage = new PopupPage(view, popupOptions, null);
+		var popupPage = new PopupPage(view, popupOptions);
 		var tapGestureRecognizer = (TapGestureRecognizer)popupPage.Content.GestureRecognizers[0];
 		var command = tapGestureRecognizer.Command;
 
@@ -379,7 +379,7 @@ public class PopupPageTests : BaseHandlerTest
 		};
 
 		// Act
-		var popupPage = new PopupPage(view, popupOptions, null);
+		var popupPage = new PopupPage(view, popupOptions);
 
 		// Assert
 		Assert.NotNull(popupPage.Content);
@@ -417,7 +417,7 @@ public class PopupPageTests : BaseHandlerTest
 		{
 			CanBeDismissedByTappingOutsideOfPopup = false
 		};
-		var popupPage = new PopupPage(view, popupOptions, null);
+		var popupPage = new PopupPage(view, popupOptions);
 
 		// Act
 		var tapGestureRecognizer = (TapGestureRecognizer)popupPage.Content.GestureRecognizers[0];
@@ -452,7 +452,7 @@ public class PopupPageTests : BaseHandlerTest
 		// Arrange
 		var view = new Label { Text = "Test Popup Content" };
 		var popupOptions = new MockPopupOptions();
-		var popupPage = new PopupPage(view, popupOptions, null);
+		var popupPage = new PopupPage(view, popupOptions);
 
 		// Act & Assert
 		await Assert.ThrowsAsync<PopupNotFoundException>(async () => await popupPage.Close(new PopupResult(false), CancellationToken.None));
@@ -470,93 +470,16 @@ public class PopupPageTests : BaseHandlerTest
 		};
 
 		// Act
-		var popupPage = new PopupPage(view, PopupOptions.Empty, null);
+		var popupPage = new PopupPage(view, PopupOptions.Empty);
 		var border = (Border)popupPage.Content.Children[0];
 
 		// Assert
 		Assert.Equal(LayoutOptions.Start, border.VerticalOptions);
 		Assert.Equal(LayoutOptions.End, border.HorizontalOptions);
 	}
-
-	[Fact]
-	public void PopupPage_ShellParametersShouldBePassedToPopupWithIQueryable()
-	{
-		// Arrange
-		var selfClosingPopup = ServiceProvider.GetRequiredService<MockSelfClosingPopup>() ?? throw new InvalidOperationException();
-		var initialBackgroundColor = selfClosingPopup.BackgroundColor;
-		var expectedBackgroundColor = Colors.Red;
-
-		// Act
-		var popupPage = new PopupPage(selfClosingPopup, PopupOptions.Empty, new Dictionary<string, object> { { nameof(MockSelfClosingPopup.BackgroundColor), expectedBackgroundColor } });
-
-		// Assert
-		Assert.Equal(MockSelfClosingPopup.DefaultBackgroundColor, initialBackgroundColor);
-		Assert.Equal(expectedBackgroundColor, selfClosingPopup.BackgroundColor);
-		Assert.NotEqual(expectedBackgroundColor, initialBackgroundColor);
-	}
-
-	[Fact]
-	public void PopupPage_ShellParametersShouldBePassedToViewWithIQueryable()
-	{
-		// Arrange
-		var view = new ViewWithIQueryAttributable(new ViewModelWithIQueryAttributable());
-		var initialBackgroundColor = view.BackgroundColor;
-		var expectedBackgroundColor = Colors.Red;
-
-		// Act
-		var popupPage = new PopupPage(view, PopupOptions.Empty, new Dictionary<string, object>
-		{
-			{ nameof(ViewWithIQueryAttributable.BackgroundColor), expectedBackgroundColor },
-		});
-
-		// Assert
-		Assert.Null(initialBackgroundColor);
-		Assert.Equal(expectedBackgroundColor, view.BackgroundColor);
-		Assert.NotEqual(expectedBackgroundColor, initialBackgroundColor);
-	}
 	
-	[Fact]
-	public void PopupPageT_ShellParametersShouldBePassedToViewWithIQueryAttributable()
-	{
-		// Arrange
-		var view = new ViewWithIQueryAttributable(new ViewModelWithIQueryAttributable());
-		var initialBackgroundColor = view.BackgroundColor;
-		var expectedBackgroundColor = Colors.Red;
-
-		// Act
-		var popupPage = new PopupPage<object?>(view, PopupOptions.Empty, new Dictionary<string, object>
-		{
-			{ nameof(ViewWithIQueryAttributable.BackgroundColor), expectedBackgroundColor },
-		});
-
-		// Assert
-		Assert.Null(initialBackgroundColor);
-		Assert.Equal(expectedBackgroundColor, view.BackgroundColor);
-		Assert.NotEqual(expectedBackgroundColor, initialBackgroundColor);
-	}
-	
-	[Fact]
-	public void PopupPageT_ShellParametersShouldBePassedToPopupWithIQueryAttributable()
-	{
-		// Arrange
-		var mockPopup = ServiceProvider.GetRequiredService<MockSelfClosingPopup>();
-		var initialBackgroundColor = mockPopup.BackgroundColor;
-		var expectedBackgroundColor = Colors.Red;
-
-		// Act
-		var popupPage = new PopupPage<object?>(mockPopup, PopupOptions.Empty, new Dictionary<string, object>
-		{
-			{ nameof(ViewWithIQueryAttributable.BackgroundColor), expectedBackgroundColor },
-		});
-
-		// Assert
-		Assert.Equal(MockSelfClosingPopup.DefaultBackgroundColor, initialBackgroundColor);
-		Assert.Equal(expectedBackgroundColor, mockPopup.BackgroundColor);
-		Assert.NotEqual(expectedBackgroundColor, initialBackgroundColor);
-	}
-
 	// Helper class for testing protected methods
-	sealed class TestablePopupPage(View view, IPopupOptions popupOptions) : PopupPage(view, popupOptions, null)
+	sealed class TestablePopupPage(View view, IPopupOptions popupOptions) : PopupPage(view, popupOptions)
 	{
 		public bool TestOnBackButtonPressed()
 		{

--- a/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
@@ -62,7 +62,7 @@ public static class PopupExtensions
 	/// <param name="view">The <see cref="View"/> that will be displayed as the content in the popup.</param>
 	/// <param name="options">The <see cref="IPopupOptions"/> that enable support for customizing the display and behavior of the presented popup.</param>
 	/// <param name="token">A <see cref="CancellationToken"/> providing support for canceling the wait for a result to be returned. This will <b>not</b> close the popup.</param>
-	/// <returns>An <see cref="IPopupResult"/> when the popup is closed or the <see cref="token"/> is cancelled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup" value to determine how the popup was closed.</returns>
+	/// <returns>An <see cref="IPopupResult"/> when the popup is closed or the <paramref name="token"/> is canceled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup"/> value to determine how the popup was closed.</returns>
 	public static Task<IPopupResult<TResult>> ShowPopupAsync<TResult>(this Page page, View view, IPopupOptions? options = null, CancellationToken token = default)
 	{
 		ArgumentNullException.ThrowIfNull(page);
@@ -77,7 +77,7 @@ public static class PopupExtensions
 	/// <param name="view">The <see cref="View"/> that will be displayed as the content in the popup.</param>
 	/// <param name="options">The <see cref="IPopupOptions"/> that enable support for customizing the display and behavior of the presented popup.</param>
 	/// <param name="token">A <see cref="CancellationToken"/> providing support for canceling the wait for a result to be returned. This will <b>not</b> close the popup.</param>
-	/// <returns>An <see cref="IPopupResult{T}"/> when the popup is closed or the <see cref="token"/> is cancelled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup" value to determine how the popup was closed.</returns>
+	/// <returns>An <see cref="IPopupResult{T}"/> when the popup is closed or the <paramref name="token"/> is canceled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup"/> value to determine how the popup was closed.</returns>
 	public static async Task<IPopupResult<TResult>> ShowPopupAsync<TResult>(this INavigation navigation, View view, IPopupOptions? options = null, CancellationToken token = default)
 	{
 		var result = await ShowPopupAsync(navigation, view, options, token);
@@ -93,7 +93,7 @@ public static class PopupExtensions
 	/// <param name="options">The <see cref="IPopupOptions"/> that enable support for customizing the display and behavior of the presented popup.</param>
 	/// <param name="shellParameters">Parameters that will be passed into the <paramref name="view"/> or its associated BindingContext if they implement <see cref="IQueryAttributable"/>.</param>
 	/// <param name="token">A <see cref="CancellationToken"/> providing support for canceling the wait for a result to be returned. This will <b>not</b> close the popup.</param>
-	/// <returns>An <see cref="IPopupResult{T}"/> when the popup is closed or the <see cref="token"/> is cancelled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup" value to determine how the popup was closed.</returns>
+	/// <returns>An <see cref="IPopupResult{T}"/> when the popup is closed or the <paramref name="token"/> is canceled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup"/> value to determine how the popup was closed.</returns>
 	public static async Task<IPopupResult<TResult>> ShowPopupAsync<TResult>(this Shell shell, View view, IPopupOptions? options = null, IDictionary<string, object>? shellParameters = null, CancellationToken token = default)
 	{
 		var result = await ShowPopupAsync(shell, view, options, shellParameters, token);
@@ -108,7 +108,7 @@ public static class PopupExtensions
 	/// <param name="view">The <see cref="View"/> that will be displayed as the content in the popup.</param>
 	/// <param name="options">The <see cref="IPopupOptions"/> that enable support for customizing the display and behavior of the presented popup.</param>
 	/// <param name="token">A <see cref="CancellationToken"/> providing support for canceling the wait for a result to be returned. This will <b>not</b> close the popup.</param>
-	/// <returns>An <see cref="IPopupResult"/> when the popup is closed or the <see cref="token"/> is cancelled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup" value to determine how the popup was closed.</returns>
+	/// <returns>An <see cref="IPopupResult"/> when the popup is closed or the <paramref name="token"/> is canceled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup"/> value to determine how the popup was closed.</returns>
 	public static Task<IPopupResult> ShowPopupAsync(this Page page, View view, IPopupOptions? options = null, CancellationToken token = default)
 	{
 		ArgumentNullException.ThrowIfNull(page);
@@ -123,7 +123,7 @@ public static class PopupExtensions
 	/// <param name="view">The <see cref="View"/> that will be displayed as the content in the popup.</param>
 	/// <param name="options">The <see cref="IPopupOptions"/> that enable support for customizing the display and behavior of the presented popup.</param>
 	/// <param name="token">A <see cref="CancellationToken"/> providing support for canceling the wait for a result to be returned. This will <b>not</b> close the popup.</param>
-	/// <returns>An <see cref="IPopupResult"/> when the popup is closed or the <see cref="token"/> is cancelled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup" value to determine how the popup was closed.</returns>
+	/// <returns>An <see cref="IPopupResult"/> when the popup is closed or the <paramref name="token"/> is canceled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup"/> value to determine how the popup was closed.</returns>
 	public static async Task<IPopupResult> ShowPopupAsync(this INavigation navigation, View view, IPopupOptions? options, CancellationToken token = default)
 	{
 		ArgumentNullException.ThrowIfNull(navigation);
@@ -154,7 +154,7 @@ public static class PopupExtensions
 	/// <param name="options">The <see cref="IPopupOptions"/> that enable support for customizing the display and behavior of the presented popup.</param>
 	/// <param name="shellParameters">Parameters that will be passed into the <paramref name="view"/> or its associated BindingContext if they implement <see cref="IQueryAttributable"/>.</param>
 	/// <param name="token">A <see cref="CancellationToken"/> providing support for canceling the wait for a result to be returned. This will <b>not</b> close the popup.</param>
-	/// <returns>An <see cref="IPopupResult"/> when the popup is closed or the <see cref="token"/> is cancelled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup"/> value to determine how the popup was closed.</returns>
+	/// <returns>An <see cref="IPopupResult"/> when the popup is closed or the <paramref name="token"/> is cancelled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup"/> value to determine how the popup was closed.</returns>
 	public static async Task<IPopupResult> ShowPopupAsync(this Shell shell, View view, IPopupOptions? options, IDictionary<string, object>? shellParameters = null, CancellationToken token = default)
 	{
 		ArgumentNullException.ThrowIfNull(shell);

--- a/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
@@ -34,7 +34,7 @@ public static class PopupExtensions
 		ArgumentNullException.ThrowIfNull(navigation);
 		ArgumentNullException.ThrowIfNull(view);
 
-		var popupPage = new PopupPage(view, options ?? PopupOptions.Empty, null);
+		var popupPage = new PopupPage(view, options ?? PopupOptions.Empty);
 
 		await navigation.PushModalAsync(popupPage, false);
 	}
@@ -133,7 +133,7 @@ public static class PopupExtensions
 
 		TaskCompletionSource<IPopupResult> taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-		var popupPage = new PopupPage(view, options ?? PopupOptions.Empty, null);
+		var popupPage = new PopupPage(view, options ?? PopupOptions.Empty);
 		popupPage.PopupClosed += HandlePopupClosed;
 
 		await navigation.PushModalAsync(popupPage, false).WaitAsync(token);
@@ -166,7 +166,7 @@ public static class PopupExtensions
 
 		TaskCompletionSource<IPopupResult> taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-		var popupPage = new PopupPage(view, options ?? PopupOptions.Empty, shellParameters);
+		var popupPage = new PopupPage(view, options ?? PopupOptions.Empty);
 		popupPage.PopupClosed += HandlePopupClosed;
 
 		Routing.RegisterRoute(popupPageRoute, new PopupPageRouteFactory(popupPage));

--- a/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
@@ -4,16 +4,16 @@ using CommunityToolkit.Maui.Views;
 namespace CommunityToolkit.Maui.Extensions;
 
 /// <summary>
-/// Popup extensions.
+/// Extension methods that provide support for the display of a popup.
 /// </summary>
 public static class PopupExtensions
 {
 	/// <summary>
 	/// Shows a popup with the specified options.
 	/// </summary>
-	/// <param name="page">Current page</param>
-	/// <param name="view">Popup content</param>
-	/// <param name="options"><see cref="IPopupOptions"/></param>
+	/// <param name="page">The current page that provides access to the <see cref="INavigation"/> implementation.</param>
+	/// <param name="view">The <see cref="View"/> that will be displayed as the content in the popup.</param>
+	/// <param name="options">The <see cref="IPopupOptions"/> that enable support for customizing the display and behavior of the presented popup.</param>
 	/// <remarks>This is an <see langword="async"/> <see langword="void"/> method. Use <see cref="ShowPopupAsync(Page,View,CommunityToolkit.Maui.IPopupOptions?,CancellationToken)"/> to <see langword="await"/> this method and return <see cref="PopupResult{T}"/> </remarks>
 	public static void ShowPopup(this Page page, View view, IPopupOptions? options = null)
 	{
@@ -25,9 +25,9 @@ public static class PopupExtensions
 	/// <summary>
 	/// Shows a popup with the specified options.
 	/// </summary>
-	/// <param name="navigation">Popup parent</param>
-	/// <param name="view">Popup content</param>
-	/// <param name="options"><see cref="IPopupOptions"/></param>
+	/// <param name="navigation">The <see cref="INavigation"/> implementation responsible for displaying the popup. Make sure to use the one associated with the <see cref="Window"/> that you wish the popup to be displayed on.</param>
+	/// <param name="view">The <see cref="View"/> that will be displayed as the content in the popup.</param>
+	/// <param name="options">The <see cref="IPopupOptions"/> that enable support for customizing the display and behavior of the presented popup.</param>
 	/// <remarks>This is an <see langword="async"/> <see langword="void"/> method. Use <see cref="ShowPopupAsync(Page,View,CommunityToolkit.Maui.IPopupOptions?,CancellationToken)"/> to <see langword="await"/> this method</remarks>
 	public static async void ShowPopup(this INavigation navigation, View view, IPopupOptions? options = null)
 	{
@@ -43,9 +43,9 @@ public static class PopupExtensions
 	/// Shows a popup with the specified options.
 	/// </summary>
 	/// <param name="shell">Current <see cref="Shell"/></param>
-	/// <param name="view">Popup content</param>
-	/// <param name="options"><see cref="IPopupOptions"/></param>
-	/// <param name="shellParameters">Parameters used by <see cref="IQueryAttributable"/></param>
+	/// <param name="view">The <see cref="View"/> that will be displayed as the content in the popup.</param>
+	/// <param name="options">The <see cref="IPopupOptions"/> that enable support for customizing the display and behavior of the presented popup.</param>
+	/// <param name="shellParameters">Parameters that will be passed into the <paramref name="view"/> or its associated BindingContext if they implement <see cref="IQueryAttributable"/>.</param>
 	/// <remarks>This is an <see langword="async"/> <see langword="void"/> method. Use <see cref="ShowPopupAsync(Page,View,CommunityToolkit.Maui.IPopupOptions?,CancellationToken)"/> to <see langword="await"/> this method</remarks>
 	public static async void ShowPopup(this Shell shell, View view, IPopupOptions? options = null, IDictionary<string, object>? shellParameters = null)
 	{
@@ -56,13 +56,13 @@ public static class PopupExtensions
 	}
 
 	/// <summary>
-	/// Opens a popup with the specified options.
+	/// Shows a popup with the specified options.
 	/// </summary>
-	/// <param name="page">Current page</param>
-	/// <param name="view">Popup content</param>
-	/// <param name="options"><see cref="IPopupOptions"/></param>
-	/// <param name="token"><see cref="CancellationToken"/></param>
-	/// <returns><see cref="IPopupResult"/></returns>
+	/// <param name="page">The current page that provides access to the <see cref="INavigation"/> implementation.</param>
+	/// <param name="view">The <see cref="View"/> that will be displayed as the content in the popup.</param>
+	/// <param name="options">The <see cref="IPopupOptions"/> that enable support for customizing the display and behavior of the presented popup.</param>
+	/// <param name="token">A <see cref="CancellationToken"/> providing support for canceling the wait for a result to be returned. This will <b>not</b> close the popup.</param>
+	/// <returns>An <see cref="IPopupResult"/> when the popup is closed or the <see cref="token"/> is cancelled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup" value to determine how the popup was closed.</returns>
 	public static Task<IPopupResult<TResult>> ShowPopupAsync<TResult>(this Page page, View view, IPopupOptions? options = null, CancellationToken token = default)
 	{
 		ArgumentNullException.ThrowIfNull(page);
@@ -71,13 +71,13 @@ public static class PopupExtensions
 	}
 
 	/// <summary>
-	/// Opens a popup with the specified options.
+	/// Shows a popup with the specified options.
 	/// </summary>
-	/// <param name="navigation">Popup parent</param>
-	/// <param name="view">Popup content</param>
-	/// <param name="options"><see cref="IPopupOptions"/></param>
-	/// <param name="token"><see cref="CancellationToken"/></param>
-	/// <returns><see cref="IPopupResult{T}"/></returns>
+	/// <param name="navigation">The <see cref="INavigation"/> implementation responsible for displaying the popup. Make sure to use the one associated with the <see cref="Window"/> that you wish the popup to be displayed on.</param>
+	/// <param name="view">The <see cref="View"/> that will be displayed as the content in the popup.</param>
+	/// <param name="options">The <see cref="IPopupOptions"/> that enable support for customizing the display and behavior of the presented popup.</param>
+	/// <param name="token">A <see cref="CancellationToken"/> providing support for canceling the wait for a result to be returned. This will <b>not</b> close the popup.</param>
+	/// <returns>An <see cref="IPopupResult{T}"/> when the popup is closed or the <see cref="token"/> is cancelled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup" value to determine how the popup was closed.</returns>
 	public static async Task<IPopupResult<TResult>> ShowPopupAsync<TResult>(this INavigation navigation, View view, IPopupOptions? options = null, CancellationToken token = default)
 	{
 		var result = await ShowPopupAsync(navigation, view, options, token);
@@ -86,14 +86,14 @@ public static class PopupExtensions
 	}
 	
 	/// <summary>
-	/// Opens a popup with the specified options.
+	/// Shows a popup with the specified options.
 	/// </summary>
 	/// <param name="shell">Current <see cref="Shell"/></param>
-	/// <param name="view">Popup content</param>
-	/// <param name="options"><see cref="IPopupOptions"/></param>
-	/// <param name="shellParameters">Parameters used by <see cref="IQueryAttributable"/></param>
-	/// <param name="token"><see cref="CancellationToken"/></param>
-	/// <returns><see cref="IPopupResult{T}"/></returns>
+	/// <param name="view">The <see cref="View"/> that will be displayed as the content in the popup.</param>
+	/// <param name="options">The <see cref="IPopupOptions"/> that enable support for customizing the display and behavior of the presented popup.</param>
+	/// <param name="shellParameters">Parameters that will be passed into the <paramref name="view"/> or its associated BindingContext if they implement <see cref="IQueryAttributable"/>.</param>
+	/// <param name="token">A <see cref="CancellationToken"/> providing support for canceling the wait for a result to be returned. This will <b>not</b> close the popup.</param>
+	/// <returns>An <see cref="IPopupResult{T}"/> when the popup is closed or the <see cref="token"/> is cancelled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup" value to determine how the popup was closed.</returns>
 	public static async Task<IPopupResult<TResult>> ShowPopupAsync<TResult>(this Shell shell, View view, IPopupOptions? options = null, IDictionary<string, object>? shellParameters = null, CancellationToken token = default)
 	{
 		var result = await ShowPopupAsync(shell, view, options, shellParameters, token);
@@ -104,11 +104,11 @@ public static class PopupExtensions
 	/// <summary>
 	/// Shows a popup with the specified options.
 	/// </summary>
-	/// <param name="page">Current page</param>
-	/// <param name="view">Popup content</param>
-	/// <param name="options"><see cref="IPopupOptions"/></param>
-	/// <param name="token"><see cref="CancellationToken"/></param>
-	/// <returns><see cref="IPopupResult"/></returns>
+	/// <param name="page">The current page that provides access to the <see cref="INavigation"/> implementation.</param>
+	/// <param name="view">The <see cref="View"/> that will be displayed as the content in the popup.</param>
+	/// <param name="options">The <see cref="IPopupOptions"/> that enable support for customizing the display and behavior of the presented popup.</param>
+	/// <param name="token">A <see cref="CancellationToken"/> providing support for canceling the wait for a result to be returned. This will <b>not</b> close the popup.</param>
+	/// <returns>An <see cref="IPopupResult"/> when the popup is closed or the <see cref="token"/> is cancelled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup" value to determine how the popup was closed.</returns>
 	public static Task<IPopupResult> ShowPopupAsync(this Page page, View view, IPopupOptions? options = null, CancellationToken token = default)
 	{
 		ArgumentNullException.ThrowIfNull(page);
@@ -119,11 +119,11 @@ public static class PopupExtensions
 	/// <summary>
 	/// Shows a popup with the specified options.
 	/// </summary>
-	/// <param name="navigation">Popup parent</param>
-	/// <param name="view">Popup content</param>
-	/// <param name="options"><see cref="IPopupOptions"/></param>
-	/// <param name="token"><see cref="CancellationToken"/></param>
-	/// <returns><see cref="IPopupResult"/></returns>
+	/// <param name="navigation">The <see cref="INavigation"/> implementation responsible for displaying the popup. Make sure to use the one associated with the <see cref="Window"/> that you wish the popup to be displayed on.</param>
+	/// <param name="view">The <see cref="View"/> that will be displayed as the content in the popup.</param>
+	/// <param name="options">The <see cref="IPopupOptions"/> that enable support for customizing the display and behavior of the presented popup.</param>
+	/// <param name="token">A <see cref="CancellationToken"/> providing support for canceling the wait for a result to be returned. This will <b>not</b> close the popup.</param>
+	/// <returns>An <see cref="IPopupResult"/> when the popup is closed or the <see cref="token"/> is cancelled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup" value to determine how the popup was closed.</returns>
 	public static async Task<IPopupResult> ShowPopupAsync(this INavigation navigation, View view, IPopupOptions? options, CancellationToken token = default)
 	{
 		ArgumentNullException.ThrowIfNull(navigation);
@@ -150,11 +150,11 @@ public static class PopupExtensions
 	/// Shows a popup with the specified options.
 	/// </summary>
 	/// <param name="shell">Current <see cref="Shell"/></param>
-	/// <param name="view">Popup content</param>
-	/// <param name="options"><see cref="IPopupOptions"/></param>
-	/// <param name="shellParameters">Parameters used by <see cref="IQueryAttributable"/></param>
-	/// <param name="token"><see cref="CancellationToken"/></param>
-	/// <returns><see cref="IPopupResult"/></returns>
+	/// <param name="view">The <see cref="View"/> that will be displayed as the content in the popup.</param>
+	/// <param name="options">The <see cref="IPopupOptions"/> that enable support for customizing the display and behavior of the presented popup.</param>
+	/// <param name="shellParameters">Parameters that will be passed into the <paramref name="view"/> or its associated BindingContext if they implement <see cref="IQueryAttributable"/>.</param>
+	/// <param name="token">A <see cref="CancellationToken"/> providing support for canceling the wait for a result to be returned. This will <b>not</b> close the popup.</param>
+	/// <returns>An <see cref="IPopupResult"/> when the popup is closed or the <see cref="token"/> is cancelled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup"/> value to determine how the popup was closed.</returns>
 	public static async Task<IPopupResult> ShowPopupAsync(this Shell shell, View view, IPopupOptions? options, IDictionary<string, object>? shellParameters = null, CancellationToken token = default)
 	{
 		ArgumentNullException.ThrowIfNull(shell);

--- a/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
@@ -173,7 +173,15 @@ public static class PopupExtensions
 		
 		try
 		{
-			await shell.GoToAsync(popupPageRoute, shellParameters);
+			if (shellParameters is null)
+			{
+				await shell.GoToAsync(popupPageRoute).WaitAsync(token);
+			}
+			else
+			{
+				await shell.GoToAsync(popupPageRoute, shellParameters).WaitAsync(token);
+			}
+			
 			return await taskCompletionSource.Task.WaitAsync(token);
 		}
 		finally

--- a/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
@@ -34,7 +34,7 @@ public static class PopupExtensions
 		ArgumentNullException.ThrowIfNull(navigation);
 		ArgumentNullException.ThrowIfNull(view);
 
-		var popupPage = new PopupPage(view, options ?? PopupOptions.Empty);
+		var popupPage = new PopupPage(view, options ?? PopupOptions.Empty, null);
 
 		await navigation.PushModalAsync(popupPage, false);
 	}
@@ -133,7 +133,7 @@ public static class PopupExtensions
 
 		TaskCompletionSource<IPopupResult> taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-		var popupPage = new PopupPage(view, options ?? PopupOptions.Empty);
+		var popupPage = new PopupPage(view, options ?? PopupOptions.Empty, null);
 		popupPage.PopupClosed += HandlePopupClosed;
 
 		await navigation.PushModalAsync(popupPage, false).WaitAsync(token);
@@ -166,7 +166,7 @@ public static class PopupExtensions
 
 		TaskCompletionSource<IPopupResult> taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-		var popupPage = new PopupPage(view, options ?? PopupOptions.Empty);
+		var popupPage = new PopupPage(view, options ?? PopupOptions.Empty, shellParameters);
 		popupPage.PopupClosed += HandlePopupClosed;
 
 		Routing.RegisterRoute(popupPageRoute, new PopupPageRouteFactory(popupPage));

--- a/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
@@ -38,6 +38,22 @@ public static class PopupExtensions
 
 		await navigation.PushModalAsync(popupPage, false);
 	}
+	
+	/// <summary>
+	/// Shows a popup with the specified options.
+	/// </summary>
+	/// <param name="shell">Current <see cref="Shell"/></param>
+	/// <param name="view">Popup content</param>
+	/// <param name="options"><see cref="IPopupOptions"/></param>
+	/// <param name="shellParameters">Parameters used by <see cref="IQueryAttributable"/></param>
+	/// <remarks>This is an <see langword="async"/> <see langword="void"/> method. Use <see cref="ShowPopupAsync(Page,View,CommunityToolkit.Maui.IPopupOptions?,CancellationToken)"/> to <see langword="await"/> this method</remarks>
+	public static async void ShowPopup(this Shell shell, View view, IPopupOptions? options = null, IDictionary<string, object>? shellParameters = null)
+	{
+		ArgumentNullException.ThrowIfNull(shell);
+		ArgumentNullException.ThrowIfNull(view);
+
+		await shell.ShowPopupAsync(view, options, shellParameters);
+	}
 
 	/// <summary>
 	/// Opens a popup with the specified options.
@@ -66,12 +82,23 @@ public static class PopupExtensions
 	{
 		var result = await ShowPopupAsync(navigation, view, options, token);
 
-		return result switch
-		{
-			PopupResult<TResult> popupResult => popupResult,
-			IPopupResult => new PopupResult<TResult>(null, result.WasDismissedByTappingOutsideOfPopup),
-			_ => throw new NotSupportedException($"PopupResult type {typeof(TResult)} is not supported")
-		};
+		return GetPopupResult<TResult>(result);
+	}
+	
+	/// <summary>
+	/// Opens a popup with the specified options.
+	/// </summary>
+	/// <param name="shell">Current <see cref="Shell"/></param>
+	/// <param name="view">Popup content</param>
+	/// <param name="options"><see cref="IPopupOptions"/></param>
+	/// <param name="shellParameters">Parameters used by <see cref="IQueryAttributable"/></param>
+	/// <param name="token"><see cref="CancellationToken"/></param>
+	/// <returns><see cref="IPopupResult{T}"/></returns>
+	public static async Task<IPopupResult<TResult>> ShowPopupAsync<TResult>(this Shell shell, View view, IPopupOptions? options = null, IDictionary<string, object>? shellParameters = null, CancellationToken token = default)
+	{
+		var result = await ShowPopupAsync(shell, view, options, shellParameters, token);
+		
+		return GetPopupResult<TResult>(result);
 	}
 
 	/// <summary>
@@ -117,5 +144,66 @@ public static class PopupExtensions
 			popupPage.PopupClosed -= HandlePopupClosed;
 			taskCompletionSource.SetResult(e);
 		}
+	}
+
+	/// <summary>
+	/// Shows a popup with the specified options.
+	/// </summary>
+	/// <param name="shell">Current <see cref="Shell"/></param>
+	/// <param name="view">Popup content</param>
+	/// <param name="options"><see cref="IPopupOptions"/></param>
+	/// <param name="shellParameters">Parameters used by <see cref="IQueryAttributable"/></param>
+	/// <param name="token"><see cref="CancellationToken"/></param>
+	/// <returns><see cref="IPopupResult"/></returns>
+	public static async Task<IPopupResult> ShowPopupAsync(this Shell shell, View view, IPopupOptions? options, IDictionary<string, object>? shellParameters = null, CancellationToken token = default)
+	{
+		ArgumentNullException.ThrowIfNull(shell);
+		ArgumentNullException.ThrowIfNull(view);
+
+		token.ThrowIfCancellationRequested();
+
+		var popupPageRoute = $"{nameof(PopupPage)}" + Guid.NewGuid(); // Add a GUID to the PopupPage Route to avoid duplicate Routes being added to Shell Routing
+
+		TaskCompletionSource<IPopupResult> taskCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		var popupPage = new PopupPage(view, options ?? PopupOptions.Empty);
+		popupPage.PopupClosed += HandlePopupClosed;
+
+		Routing.RegisterRoute(popupPageRoute, new PopupPageRouteFactory(popupPage));
+		
+		try
+		{
+			await shell.GoToAsync(popupPageRoute, shellParameters);
+			return await taskCompletionSource.Task.WaitAsync(token);
+		}
+		finally
+		{
+			Routing.UnRegisterRoute(popupPageRoute);
+		}
+
+		void HandlePopupClosed(object? sender, IPopupResult e)
+		{
+			popupPage.PopupClosed -= HandlePopupClosed;
+			taskCompletionSource.SetResult(e);
+		}
+	}
+	
+	static PopupResult<T> GetPopupResult<T>(in IPopupResult result)
+	{
+		return result switch
+		{
+			PopupResult<T> popupResult => popupResult,
+			IPopupResult => new PopupResult<T>(null, result.WasDismissedByTappingOutsideOfPopup),
+			_ => throw new NotSupportedException($"PopupResult type {typeof(T)} is not supported")
+		};
+	}
+
+	sealed class PopupPageRouteFactory(in PopupPage popupPage) : RouteFactory
+	{
+		readonly PopupPage popupPage = popupPage;
+
+		public override Element GetOrCreate() => popupPage;
+
+		public override Element GetOrCreate(IServiceProvider services) => popupPage;
 	}
 }

--- a/src/CommunityToolkit.Maui/Interfaces/IPopupService.shared.cs
+++ b/src/CommunityToolkit.Maui/Interfaces/IPopupService.shared.cs
@@ -20,11 +20,34 @@ public interface IPopupService
 	/// Opens a popup with the specified options.
 	/// </summary>
 	/// <typeparam name="T">Supports both Popup Type or Popup ViewModel Type</typeparam>
+	/// <param name="shell">Current <see cref="Shell"/></param>
+	/// <param name="options"><see cref="IPopupOptions"/></param>
+	/// <param name="shellParameters"><see cref="IPopupOptions"/></param>
+	/// <returns><see cref="PopupResult"/></returns>
+	void ShowPopup<T>(Shell shell, IPopupOptions? options = null, IDictionary<string, object>? shellParameters = null)
+		where T : notnull;
+
+	/// <summary>
+	/// Opens a popup with the specified options.
+	/// </summary>
+	/// <typeparam name="T">Supports both Popup Type or Popup ViewModel Type</typeparam>
 	/// <param name="navigation">The parent of the popup</param>
 	/// <param name="options"><see cref="IPopupOptions"/></param>
 	/// <param name="cancellationToken"><see cref="CancellationToken"/></param>
 	/// <returns><see cref="PopupResult"/></returns>
 	Task<IPopupResult> ShowPopupAsync<T>(INavigation navigation, IPopupOptions? options = null, CancellationToken cancellationToken = default)
+		where T : notnull;
+
+	/// <summary>
+	/// Opens a popup with the specified options.
+	/// </summary>
+	/// <typeparam name="T">Supports both Popup Type or Popup ViewModel Type</typeparam>
+	/// <param name="shell">Current <see cref="Shell"/></param>
+	/// <param name="options"><see cref="IPopupOptions"/></param>
+	/// <param name="shellParameters"><see cref="IPopupOptions"/></param>
+	/// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+	/// <returns><see cref="PopupResult"/></returns>
+	Task<IPopupResult> ShowPopupAsync<T>(Shell shell, IPopupOptions? options, IDictionary<string, object>? shellParameters = null, CancellationToken cancellationToken = default)
 		where T : notnull;
 
 	/// <summary>
@@ -37,6 +60,19 @@ public interface IPopupService
 	/// <param name="cancellationToken"><see cref="CancellationToken"/></param>
 	/// <returns><see cref="PopupResult"/></returns>
 	Task<IPopupResult<TResult>> ShowPopupAsync<T, TResult>(INavigation navigation, IPopupOptions? options = null, CancellationToken cancellationToken = default)
+		where T : notnull;
+
+	/// <summary>
+	/// Opens a popup with the specified options.
+	/// </summary>
+	/// <typeparam name="T">Supports both Popup Type or Popup ViewModel Type</typeparam>
+	/// <typeparam name="TResult">Popup Result Type</typeparam>
+	/// <param name="shell">Current <see cref="Shell"/></param>
+	/// <param name="options"><see cref="IPopupOptions"/></param>
+	/// <param name="shellParameters"><see cref="IPopupOptions"/></param>
+	/// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+	/// <returns><see cref="PopupResult"/></returns>
+	Task<IPopupResult<TResult>> ShowPopupAsync<T, TResult>(Shell shell, IPopupOptions? options = null, IDictionary<string, object>? shellParameters = null, CancellationToken cancellationToken = default)
 		where T : notnull;
 
 	/// <summary>

--- a/src/CommunityToolkit.Maui/Services/PopupService.shared.cs
+++ b/src/CommunityToolkit.Maui/Services/PopupService.shared.cs
@@ -33,12 +33,20 @@ public class PopupService : IPopupService
 	}
 
 	/// <inheritdoc />
-	/// <remarks>This is an <see langword="async"/> <see langword="void"/> method. Use <see cref="ShowPopupAsync{T}"/> to <see langword="await"/> this method</remarks>
+	/// <remarks>This is an <see langword="async"/> <see langword="void"/> method. Use <see cref="ShowPopupAsync{T}(Microsoft.Maui.Controls.INavigation,CommunityToolkit.Maui.IPopupOptions?,System.Threading.CancellationToken)"/> to <see langword="await"/> this method</remarks>
 	public void ShowPopup<T>(INavigation navigation, IPopupOptions? options = null) where T : notnull
 	{
 		var popupContent = GetPopupContent(serviceProvider.GetRequiredService<T>());
 
 		navigation.ShowPopup(popupContent, options);
+	}
+
+	/// <inheritdoc />
+	/// <remarks>This is an <see langword="async"/> <see langword="void"/> method. Use <see cref="ShowPopupAsync{T}(Microsoft.Maui.Controls.Shell,CommunityToolkit.Maui.IPopupOptions?,IDictionary{string,object}?, System.Threading.CancellationToken)"/> to <see langword="await"/> this method</remarks>
+	public void ShowPopup<T>(Shell shell, IPopupOptions? options = null, IDictionary<string, object>? shellParameters = null) where T : notnull
+	{
+		var popupContent = GetPopupContent(serviceProvider.GetRequiredService<T>());
+		shell.ShowPopup(popupContent, options, shellParameters);
 	}
 
 	/// <inheritdoc />
@@ -53,6 +61,16 @@ public class PopupService : IPopupService
 	}
 
 	/// <inheritdoc />
+	public Task<IPopupResult> ShowPopupAsync<T>(Shell shell, IPopupOptions? options, IDictionary<string, object>? shellParameters, CancellationToken token) where T : notnull
+	{
+		token.ThrowIfCancellationRequested();
+
+		var popupContent = GetPopupContent(serviceProvider.GetRequiredService<T>());
+
+		return shell.ShowPopupAsync(popupContent, options, shellParameters, token);
+	}
+
+	/// <inheritdoc />
 	public Task<IPopupResult<TResult>> ShowPopupAsync<T, TResult>(INavigation navigation,
 		IPopupOptions? options = null,
 		CancellationToken token = default)
@@ -62,6 +80,15 @@ public class PopupService : IPopupService
 		var popupContent = GetPopupContent(serviceProvider.GetRequiredService<T>());
 
 		return navigation.ShowPopupAsync<TResult>(popupContent, options, token);
+	}
+
+	/// <inheritdoc />
+	public Task<IPopupResult<TResult>> ShowPopupAsync<T, TResult>(Shell shell, IPopupOptions? options, IDictionary<string, object>? shellParameters = null, CancellationToken token = default) where T : notnull
+	{
+		token.ThrowIfCancellationRequested();
+		var popupContent = GetPopupContent(serviceProvider.GetRequiredService<T>());
+
+		return shell.ShowPopupAsync<TResult>(popupContent, options, shellParameters, token);
 	}
 
 	/// <inheritdoc />

--- a/src/CommunityToolkit.Maui/Views/Popup/PopupPage.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/PopupPage.shared.cs
@@ -8,40 +8,31 @@ using Microsoft.Maui.Controls.Shapes;
 
 namespace CommunityToolkit.Maui.Views;
 
-sealed partial class PopupPage<T>(Popup<T> popup, IPopupOptions popupOptions, IDictionary<string, object>? shellParameters)
-	: PopupPage(popup, popupOptions, shellParameters)
+sealed partial class PopupPage<T>(Popup<T> popup, IPopupOptions popupOptions)
+	: PopupPage(popup, popupOptions)
 {
-	public PopupPage(View view, IPopupOptions popupOptions, IDictionary<string,object>? shellParameters)
-		: this(view as Popup<T> ?? CreatePopupFromView<Popup<T>>(view), popupOptions, shellParameters)
+	public PopupPage(View view, IPopupOptions popupOptions)
+		: this(view as Popup<T> ?? CreatePopupFromView<Popup<T>>(view), popupOptions)
 	{
-		if (view is IQueryAttributable queryAttributableView && shellParameters is not null)
-		{
-			queryAttributableView.ApplyQueryAttributes(shellParameters);
-		}
 	}
 
 	public Task Close(PopupResult<T> result, CancellationToken token = default) => base.Close(result, token);
 }
 
-partial class PopupPage : ContentPage
+partial class PopupPage : ContentPage, IQueryAttributable
 {
 	readonly Popup popup;
 	readonly IPopupOptions popupOptions;
 	readonly Command tapOutsideOfPopupCommand;
 	readonly WeakEventManager popupClosedEventManager = new();
 
-	public PopupPage(View view, IPopupOptions popupOptions, IDictionary<string,object>? shellParameters)
-		: this(view as Popup ?? CreatePopupFromView<Popup>(view), popupOptions, shellParameters)
+	public PopupPage(View view, IPopupOptions popupOptions)
+		: this(view as Popup ?? CreatePopupFromView<Popup>(view), popupOptions)
 	{
 		ArgumentNullException.ThrowIfNull(view);
-
-		if (view is IQueryAttributable queryAttributableView && shellParameters is not null)
-		{
-			queryAttributableView.ApplyQueryAttributes(shellParameters);
-		}
 	}
 
-	public PopupPage(Popup popup, IPopupOptions popupOptions, IDictionary<string,object>? shellParameters)
+	public PopupPage(Popup popup, IPopupOptions popupOptions)
 	{
 		ArgumentNullException.ThrowIfNull(popup);
 		ArgumentNullException.ThrowIfNull(popupOptions);
@@ -55,11 +46,6 @@ partial class PopupPage : ContentPage
 		if (Shell.Current is Shell shell)
 		{
 			Shell.SetPresentationMode(shell, PresentationMode.ModalNotAnimated);
-		}
-		
-		if (popup is IQueryAttributable queryAttributablePopup && shellParameters is not null)
-		{
-			queryAttributablePopup.ApplyQueryAttributes(shellParameters);
 		}
 
 		tapOutsideOfPopupCommand = new Command(async () =>
@@ -175,6 +161,19 @@ partial class PopupPage : ContentPage
 		if (e.PropertyName == nameof(IPopupOptions.CanBeDismissedByTappingOutsideOfPopup))
 		{
 			tapOutsideOfPopupCommand.ChangeCanExecute();
+		}
+	}
+	
+	void IQueryAttributable.ApplyQueryAttributes(IDictionary<string, object> query)
+	{
+		if (popup is IQueryAttributable popupIQueryAttributable)
+		{
+			popupIQueryAttributable.ApplyQueryAttributes(query);	
+		}
+
+		if (popup.Content is IQueryAttributable popupContentIQueryAttributable)
+		{
+			popupContentIQueryAttributable.ApplyQueryAttributes(query);
 		}
 	}
 

--- a/src/CommunityToolkit.Maui/Views/Popup/PopupPage.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/PopupPage.shared.cs
@@ -42,6 +42,11 @@ partial class PopupPage : ContentPage
 		// Only set the content if the parent constructor hasn't set the content already; don't override content if it already exists
 		base.Content ??= new PopupPageLayout(popup, popupOptions);
 
+		if (Shell.Current is Shell shell)
+		{
+			Shell.SetPresentationMode(shell, PresentationMode.ModalNotAnimated);
+		}
+
 		tapOutsideOfPopupCommand = new Command(async () =>
 		{
 			popupOptions.OnTappingOutsideOfPopup?.Invoke();

--- a/src/CommunityToolkit.Maui/Views/Popup/PopupPage.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/PopupPage.shared.cs
@@ -8,12 +8,16 @@ using Microsoft.Maui.Controls.Shapes;
 
 namespace CommunityToolkit.Maui.Views;
 
-sealed partial class PopupPage<T>(Popup<T> popup, IPopupOptions popupOptions, IDictionary<string,object>? shellParameters) 
+sealed partial class PopupPage<T>(Popup<T> popup, IPopupOptions popupOptions, IDictionary<string, object>? shellParameters)
 	: PopupPage(popup, popupOptions, shellParameters)
 {
 	public PopupPage(View view, IPopupOptions popupOptions, IDictionary<string,object>? shellParameters)
 		: this(view as Popup<T> ?? CreatePopupFromView<Popup<T>>(view), popupOptions, shellParameters)
 	{
+		if (view is IQueryAttributable queryAttributableView && shellParameters is not null)
+		{
+			queryAttributableView.ApplyQueryAttributes(shellParameters);
+		}
 	}
 
 	public Task Close(PopupResult<T> result, CancellationToken token = default) => base.Close(result, token);

--- a/src/CommunityToolkit.Maui/Views/Popup/PopupPage.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/PopupPage.shared.cs
@@ -155,8 +155,6 @@ partial class PopupPage : ContentPage
 		popup.SetBinding(BindingContextProperty, static (View view) => view.BindingContext, source: view, mode: BindingMode.OneWay);
 		popup.SetBinding(BackgroundColorProperty, static (View view) => view.BackgroundColor, source: view, mode: BindingMode.OneWay);
 		popup.SetBinding(Popup.MarginProperty, static (View view) => view.Margin, source: view, mode: BindingMode.OneWay);
-		popup.SetBinding(Popup.BackgroundProperty, static (View view) => view.Background, source: view, mode: BindingMode.OneWay);
-		popup.SetBinding(Popup.BackgroundColorProperty, static (View view) => view.BackgroundColor, source: view, mode: BindingMode.OneWay);
 		popup.SetBinding(Popup.VerticalOptionsProperty, static (View view) => view.VerticalOptions, source: view, mode: BindingMode.OneWay);
 		popup.SetBinding(Popup.HorizontalOptionsProperty, static (View view) => view.HorizontalOptions, source: view, mode: BindingMode.OneWay);
 


### PR DESCRIPTION
 ### Description of Change ###

This PR augments https://github.com/CommunityToolkit/Maui/pull/1581, adding support for `Shell` and `IQueryAttributable`. I.e., this PR will be merged into the open [PopupV2 PR](https://github.com/CommunityToolkit/Maui/pull/1581), not the `main` branch.

Specifically, this PR was created in response to @bijington's review noting that users will no longer be able to pass data from ViewModel to ViewModel after removing the `onPresenting` parameter: https://github.com/CommunityToolkit/Maui/pull/1581#discussion_r2079810384

 ### Additional information ###

This PR is currently in Draft because it still requires Unit Tests.

I updated `SimplePopup` and `CsharpBindingPopup` to demonstrate using `IQueryAttributable` in the Sample App.
