### PR TITLE
Fix RS1038 Warning: Compiler extensions should be implemented in assemblies with compiler-provided references

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -173,7 +173,8 @@
      XC0618: Property, Property setter or BindableProperty "BackgroundColor" is deprecated
      IL2***: Trim Warnings     
      IL3***: AOT Warnings     
-     RS2007: Analyzer release file 'AnalyzerReleases.Shipped.md' has a missing or invalid release header-->
+     RS1038: Compiler extensions should be implemented in assemblies with compiler-provided references
+     RS2007: Analyzer release file 'AnalyzerReleases.Shipped.md' has a missing or invalid release header -->
     <WarningsAsErrors>
       nullable,
       CS0419,CS1570,CS1571,CS1572,CS1573,CS1574,CS1580,CS1581,CS1584,CS1587,CS1589,CS1590,CS1591,CS1592,CS1598,CS1658,CS1710,CS1711,CS1712,CS1723,CS1734,
@@ -198,7 +199,7 @@
       IL2110,IL2111,IL2112,IL2113,IL2114,IL2115,IL2116,IL2117,IL2118,IL2119,
       IL2120,IL2121,IL2122,
       IL3050,IL3051,IL3052,IL3053,IL3054,IL3055,IL3056,
-      RS2007
+      RS1038,RS2007
     </WarningsAsErrors>
 
     <!--

--- a/src/CommunityToolkit.Maui.Analyzers/CommunityToolkit.Maui.Analyzers.csproj
+++ b/src/CommunityToolkit.Maui.Analyzers/CommunityToolkit.Maui.Analyzers.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CommunityToolkit.Maui.Camera.Analyzers/CommunityToolkit.Maui.Camera.Analyzers.csproj
+++ b/src/CommunityToolkit.Maui.Camera.Analyzers/CommunityToolkit.Maui.Camera.Analyzers.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CommunityToolkit.Maui.MediaElement.Analyzers/CommunityToolkit.Maui.MediaElement.Analyzers.csproj
+++ b/src/CommunityToolkit.Maui.MediaElement.Analyzers/CommunityToolkit.Maui.MediaElement.Analyzers.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CommunityToolkit.Maui.SourceGenerators.Internal/CommunityToolkit.Maui.SourceGenerators.Internal.csproj
+++ b/src/CommunityToolkit.Maui.SourceGenerators.Internal/CommunityToolkit.Maui.SourceGenerators.Internal.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/CommunityToolkit.Maui.SourceGenerators/CommunityToolkit.Maui.SourceGenerators.csproj
+++ b/src/CommunityToolkit.Maui.SourceGenerators/CommunityToolkit.Maui.SourceGenerators.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
 ### Description of Change ###

This PR adds `RS1038` to `<WarningsAsErrors>` and replaces `Microsoft.CodeAnalysis.CSharp.Workspaces` -> `Microsoft.CodeAnalysis.CSharp`

Link to RS1038 Docs:
https://github.com/dotnet/roslyn-analyzers/blob/main/docs/rules/RS1038.md


 ### Additional information ###

Link to Compiler Warnings seen in `CommunityToolkit.Maui`: https://github.com/CommunityToolkit/Maui/actions/runs/15263232470/job/42928522628#step:14:61

> Warning: D:\a\Maui\Maui\src\CommunityToolkit.Maui.Analyzers\UseCommunityToolkitInitializationAnalyzer.cs(9,2): warning RS1038: This compiler extension should not be implemented in an assembly containing a reference to Microsoft.CodeAnalysis.Workspaces. The Microsoft.CodeAnalysis.Workspaces assembly is not provided during command line compilation scenarios, so references to it could cause the compiler extension to behave unpredictably. (https://github.com/dotnet/roslyn-analyzers/blob/main/docs/rules/RS1038.md) [D:\a\Maui\Maui\src\CommunityToolkit.Maui.Analyzers\CommunityToolkit.Maui.Analyzers.csproj]
 
