### PR TITLE
[Housekeeping] GitHub Actions: Set `fail-fast: true`

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -54,7 +54,7 @@ jobs:
     name: Build Sample App using Latest .NET SDK
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [windows-latest, macos-15]
     steps:
@@ -99,7 +99,7 @@ jobs:
     name: Build Library
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [windows-latest, macos-15]
     steps:


### PR DESCRIPTION
This PR updates the CI/CD pipeline, setting `fail-fast: true`.

The goal of this PR is to prevent our CI/CD pipelines from hanging once completed.