### PR TITLE
Don't break us please oh mighty MCT

### DIFF
--- a/src/CommunityToolkit.Maui/Behaviors/Validators/ValidationBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/Validators/ValidationBehavior.shared.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -21,6 +22,13 @@ public enum ValidationFlags
 	ValidateOnValueChanged = 8,
 	/// <summary>Force make valid when focused</summary>
 	ForceMakeValidWhenFocused = 16
+
+	/// <summary> Validate on focusing</summary>
+ 	[Obsolete("Use ValidateOnFocused instead.")]
+	ValidateOnFocusing = ValidateOnFocused,
+	/// <summary>Validate on unfocusing</summary>
+ 	[Obsolete("Use ValidateOnUnfocused instead.")]
+	ValidateOnUnfocusing = ValidateOnUnfocused,
 }
 
 /// <summary>


### PR DESCRIPTION
This pull request introduces updates to the `ValidationBehavior` class and its associated `ValidationFlags` enum in the `CommunityToolkit.Maui` project. The changes include adding new obsolete flags for validation behavior and updating the file's imports.

### Updates to `ValidationFlags` enum:

* Added two obsolete flags, `ValidateOnFocusing` and `ValidateOnUnfocusing`, which map to existing flags `ValidateOnFocused` and `ValidateOnUnfocused`. These changes aim to provide backward compatibility while encouraging the use of newer flag names.

### Codebase maintenance:

* Imported the `System` namespace in `ValidationBehavior.shared.cs`, possibly to support the `[Obsolete]` attribute or other added functionality.