### PR TITLE
[Popup] Properly handle Android Back Button pressed

### DIFF
--- a/src/CommunityToolkit.Maui/Views/Popup/PopupPage.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/PopupPage.shared.cs
@@ -43,11 +43,6 @@ partial class PopupPage : ContentPage, IQueryAttributable
 		// Only set the content if the parent constructor hasn't set the content already; don't override content if it already exists
 		base.Content ??= new PopupPageLayout(popup, popupOptions);
 
-		if (Shell.Current is Shell shell)
-		{
-			Shell.SetPresentationMode(shell, PresentationMode.ModalNotAnimated);
-		}
-
 		tapOutsideOfPopupCommand = new Command(async () =>
 		{
 			popupOptions.OnTappingOutsideOfPopup?.Invoke();
@@ -114,9 +109,10 @@ partial class PopupPage : ContentPage, IQueryAttributable
 	{
 		if (popupOptions.CanBeDismissedByTappingOutsideOfPopup)
 		{
+			popupClosedEventManager.HandleEvent(this, new PopupResult(true), nameof(PopupClosed));
 			return base.OnBackButtonPressed();
 		}
-
+		
 		return true;
 	}
 

--- a/src/CommunityToolkit.Maui/Views/Popup/PopupPage.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/PopupPage.shared.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Globalization;
 using CommunityToolkit.Maui.Converters;
 using CommunityToolkit.Maui.Core;
+using CommunityToolkit.Maui.Extensions;
 using Microsoft.Maui.Controls.PlatformConfiguration;
 using Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;
 using Microsoft.Maui.Controls.Shapes;
@@ -109,8 +110,7 @@ partial class PopupPage : ContentPage, IQueryAttributable
 	{
 		if (popupOptions.CanBeDismissedByTappingOutsideOfPopup)
 		{
-			popupClosedEventManager.HandleEvent(this, new PopupResult(true), nameof(PopupClosed));
-			return base.OnBackButtonPressed();
+			CloseAsync(new PopupResult(true), CancellationToken.None).SafeFireAndForget();
 		}
 		
 		return true;


### PR DESCRIPTION
 ### Description of Change ###

This PR updates `protected override bool PopupPage.OnBackButtonPressed()` to ensure we properly close the Popup using `CloseAsync()` when the Android Back Button is tapped by the user.

This ensures that the `Task` returned by `ShowPopupAsync()` completes when the Android Back Button is tapped.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

This fixes the Issue highlighted by @crwsolutions in their comment here: https://github.com/CommunityToolkit/Maui/issues/2703#issuecomment-2970573356. 

**Note:** This does not close resolve the issue #2703. We currently unable to reproduce that Issue and are awaiting a sample reproduction to help us solve that Issue.

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

**SafeFireAndForget**
Because `protected override bool OnBackButtonPressed()` does not return a `Task`, we are unable to use the `await` keyword. Since `PopupPage.Close` returns a `Task`, we use `.SafeFireAndForget()` to ensure we follow best practices and await its `Task` under the hood.

**PopupResult**
For the `PopupResult`, I am setting `WasDismissedByTappingOutsideOfPopup` to `true` for two reasons:
1. By tapping the Android Back button, the user did tap outside of the popup to close it
1. `WasDismissedByTappingOutsideOfPopup = false` requires `PopupResult<T>.Result` to be a value provided by the developer when programmatically closing the popup
