### PR TITLE
PoC for allowing developers to control the defaults

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/MauiProgram.cs
+++ b/samples/CommunityToolkit.Maui.Sample/MauiProgram.cs
@@ -55,6 +55,8 @@ public static class MauiProgram
 								.UseMauiCommunityToolkit(static options =>
 								{
 									options.SetShouldEnableSnackbarOnWindows(true);
+
+									options.Defaults.Popup.SetCanBeDismissedByTappingOutsideOfPopup(false);
 								})
 #else
 								.UseMauiCommunityToolkit(static options =>

--- a/src/CommunityToolkit.Maui/Options.cs
+++ b/src/CommunityToolkit.Maui/Options.cs
@@ -24,6 +24,34 @@ public class Options() : Core.Options
 	internal static bool ShouldEnableSnackbarOnWindows { get; private set; }
 
 	/// <summary>
+	/// 
+	/// </summary>
+	public Default Defaults { get; } = new Default();
+	
+	/// <summary>
+	/// 
+	/// </summary>
+	public class Default
+	{
+		/// <summary>
+		/// 
+		/// </summary>
+		public PopupDefault Popup { get; } = new();
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		public class PopupDefault
+		{
+			/// <summary>
+			/// 
+			/// </summary>
+			/// <param name="canBeDismissedByTappingOutsideOfPopup"></param>
+			public void SetCanBeDismissedByTappingOutsideOfPopup(bool canBeDismissedByTappingOutsideOfPopup) => PopupDefaults.CanBeDismissedByTappingOutsideOfPopup = canBeDismissedByTappingOutsideOfPopup;
+		}
+	}
+
+	/// <summary>
 	/// Will return the <see cref="ICommunityToolkitValueConverter.DefaultConvertReturnValue"/> default value instead of throwing an exception when using <see cref="BaseConverter{TFrom,TTo}"/>.
 	/// </summary>
 	/// <remarks>

--- a/src/CommunityToolkit.Maui/Primitives/Defaults/PopupDefaults.shared.cs
+++ b/src/CommunityToolkit.Maui/Primitives/Defaults/PopupDefaults.shared.cs
@@ -31,4 +31,7 @@ static class PopupDefaults
 	/// Default value for <see cref="VisualElement.BackgroundColor"/> BackgroundColor 
 	/// </summary>
 	public static Color BackgroundColor { get; } = Colors.White;
+
+	public static bool CanBeDismissedByTappingOutsideOfPopup { get; internal set; } =
+		PopupDefaults.CanBeDismissedByTappingOutsideOfPopup;
 }


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->

This is not the typical approach to proposing change but I find it helps me to follow through with seeing the change and impact of that change.

This is an idea that I have had for a while but the recent Popup bug reports around `CanBeDismissedByTappingOutsideOfPopup` has prompted an investigation into feasibility. The proposal is to make it possible for developers to modify our Defaults classes through the Options class when initialising the toolkit. Therefore it keeps it relatively safe knowing that the defaults cannot change at runtime.

I have tried to group the defaults under feature specific classes to make it easier to navigate for a developer but I am keen to hear feedback on this.

I appreciate that it could be effort to add in all potential defaults but my thinking is to use this as an excuse to learn more about source generation and have that do the work that you see in the bulk of this PR. We could then place an attribute `[ConfigurableDefault("FeatureName")]` and let the magic happen.

It would then result in developers being able to call something like:

```csharp
var builder = MauiApp.CreateBuilder()
    .UseMauiCommunityToolkit(static options =>
    {
        options.Defaults.Popup.SetCanBeDismissedByTappingOutsideOfPopup(false);

        options.Defaults.Popup.CanBeDismissedByTappingOutsideOfPopup = false;
    });
```

Thoughts?

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [ ] Rebased on top of `main` at time of PR
 - [ ] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
