### PR TITLE
[Popup] Add `Popup.CanBeDismissedByTappingOutsideOfPopup`

### DIFF
--- a/src/CommunityToolkit.Maui.UnitTests/Views/Popup/PopupPageTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/Popup/PopupPageTests.cs
@@ -1,7 +1,5 @@
 ﻿using CommunityToolkit.Maui.Core;
 using CommunityToolkit.Maui.Extensions;
-using CommunityToolkit.Maui.UnitTests.Extensions;
-using CommunityToolkit.Maui.UnitTests.Services;
 using CommunityToolkit.Maui.Views;
 using FluentAssertions;
 using Microsoft.Maui.Controls.PlatformConfiguration;
@@ -217,6 +215,49 @@ public class PopupPageTests : BaseHandlerTest
 
 		// Assert
 		act.Should().ThrowAsync<OperationCanceledException>();
+	}
+
+	[Fact]
+	public void TapGestureRecognizer_VerifyCanBeDismissedByTappingOutsideOfPopup_ShouldNotExecuteWhenEitherFalse()
+	{
+		// Arrange
+		var view = new Popup
+		{
+			CanBeDismissedByTappingOutsideOfPopup = false
+		};
+		var popupOptions = new PopupOptions
+		{
+			CanBeDismissedByTappingOutsideOfPopup = false
+		};
+
+		// Act
+		var popupPage = new PopupPage(view, popupOptions);
+		var tapGestureRecognizer = popupPage.Content.Children.OfType<BoxView>().Single().GestureRecognizers.OfType<TapGestureRecognizer>().Single();
+
+		// Assert
+		Assert.False(tapGestureRecognizer.Command?.CanExecute(null));
+		
+		// Act
+		view.CanBeDismissedByTappingOutsideOfPopup = true;
+		popupOptions.CanBeDismissedByTappingOutsideOfPopup = false;
+		
+		// Assert
+		Assert.False(tapGestureRecognizer.Command?.CanExecute(null));
+		
+		// Act
+		view.CanBeDismissedByTappingOutsideOfPopup = false;
+		popupOptions.CanBeDismissedByTappingOutsideOfPopup = true;
+		
+		// Assert
+		Assert.False(tapGestureRecognizer.Command?.CanExecute(null));
+		
+		// Act
+		view.CanBeDismissedByTappingOutsideOfPopup = true;
+		popupOptions.CanBeDismissedByTappingOutsideOfPopup = true;
+		
+		// Assert
+		Assert.True(tapGestureRecognizer.Command?.CanExecute(null));
+
 	}
 
 	[Fact]

--- a/src/CommunityToolkit.Maui/Primitives/Defaults/PopupDefaults.shared.cs
+++ b/src/CommunityToolkit.Maui/Primitives/Defaults/PopupDefaults.shared.cs
@@ -31,4 +31,9 @@ static class PopupDefaults
 	/// Default value for <see cref="VisualElement.BackgroundColor"/> BackgroundColor 
 	/// </summary>
 	public static Color BackgroundColor { get; } = Colors.White;
+	
+	/// <summary>
+	/// Default value for <see cref="Popup.CanBeDismissedByTappingOutsideOfPopup"/>
+	/// </summary>
+	public const bool CanBeDismissedByTappingOutsideOfPopup = PopupOptionsDefaults.CanBeDismissedByTappingOutsideOfPopup;
 }

--- a/src/CommunityToolkit.Maui/Views/Popup/Popup.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/Popup.shared.cs
@@ -26,6 +26,11 @@ public partial class Popup : ContentView
 	/// Bindable property to set the vertical position of the <see cref="Popup"/> when displayed on screen
 	/// </summary>
 	public static new readonly BindableProperty VerticalOptionsProperty = View.VerticalOptionsProperty;
+	
+	/// <summary>
+	///  Backing BindableProperty for the <see cref="CanBeDismissedByTappingOutsideOfPopup"/> property.
+	/// </summary>
+	public static readonly BindableProperty CanBeDismissedByTappingOutsideOfPopupProperty = BindableProperty.Create(nameof(CanBeDismissedByTappingOutsideOfPopup), typeof(bool), typeof(Popup), PopupDefaults.CanBeDismissedByTappingOutsideOfPopup);
 
 	/// <summary>
 	/// Initializes Popup
@@ -82,6 +87,17 @@ public partial class Popup : ContentView
 	{
 		get => base.VerticalOptions;
 		set => base.VerticalOptions = value;
+	}
+	
+	/// <inheritdoc cref="IPopupOptions.CanBeDismissedByTappingOutsideOfPopup"/> />
+	/// <remarks>
+	/// When true and the user taps outside the popup, it will dismiss.
+	/// On Android - when false the hardware back button is disabled.
+	/// </remarks>
+	public bool CanBeDismissedByTappingOutsideOfPopup
+	{
+		get => (bool)GetValue(CanBeDismissedByTappingOutsideOfPopupProperty);
+		set => SetValue(CanBeDismissedByTappingOutsideOfPopupProperty, value);
 	}
 
 	/// <summary>

--- a/src/CommunityToolkit.Maui/Views/Popup/PopupPage.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/PopupPage.shared.cs
@@ -46,7 +46,7 @@ partial class PopupPage : ContentPage, IQueryAttributable
 		{
 			popupOptions.OnTappingOutsideOfPopup?.Invoke();
 			await CloseAsync(new PopupResult(true));
-		}, () => popupOptions.CanBeDismissedByTappingOutsideOfPopup & popup.CanBeDismissedByTappingOutsideOfPopup);
+		}, () => GetCanBeDismissedByTappingOutsideOfPopup(popup, popupOptions));
 
 		// Only set the content if the parent constructor hasn't set the content already; don't override content if it already exists
 		base.Content = new PopupPageLayout(popup, popupOptions, tapOutsideOfPopupCommand);
@@ -107,8 +107,8 @@ partial class PopupPage : ContentPage, IQueryAttributable
 
 	protected override bool OnBackButtonPressed()
 	{
-		// Only close the Popup if PopupOptions.CanBeDismissedByTappingOutsideOfPopup is true
-		if (popupOptions.CanBeDismissedByTappingOutsideOfPopup)
+		// Only close the Popup if CanBeDismissedByTappingOutsideOfPopup is true
+		if (GetCanBeDismissedByTappingOutsideOfPopup(popup, popupOptions))
 		{
 			CloseAsync(new PopupResult(true), CancellationToken.None).SafeFireAndForget();
 		}
@@ -153,6 +153,10 @@ partial class PopupPage : ContentPage, IQueryAttributable
 		return popup;
 	}
 
+	// Only dismiss when a user taps outside Popup when **both** Popup.CanBeDismissedByTappingOutsideOfPopup and PopupOptions.CanBeDismissedByTappingOutsideOfPopup are true
+	// If either value is false, do not dismiss Popup
+	static bool GetCanBeDismissedByTappingOutsideOfPopup(in Popup popup, in IPopupOptions popupOptions) => popup.CanBeDismissedByTappingOutsideOfPopup & popupOptions.CanBeDismissedByTappingOutsideOfPopup;
+
 	void HandlePopupOptionsPropertyChanged(object? sender, PropertyChangedEventArgs e)
 	{
 		if (e.PropertyName == nameof(IPopupOptions.CanBeDismissedByTappingOutsideOfPopup))
@@ -163,7 +167,7 @@ partial class PopupPage : ContentPage, IQueryAttributable
 	
 	void HandlePopupPropertyChanged(object? sender, PropertyChangedEventArgs e)
 	{
-		if (e.PropertyName == nameof(Popup.CanBeDismissedByTappingOutsideOfPopup))
+		if (e.PropertyName == Popup.CanBeDismissedByTappingOutsideOfPopupProperty.PropertyName)
 		{
 			tapOutsideOfPopupCommand.ChangeCanExecute();
 		}

--- a/src/CommunityToolkit.Maui/Views/Popup/PopupPage.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/PopupPage.shared.cs
@@ -46,14 +46,15 @@ partial class PopupPage : ContentPage, IQueryAttributable
 		{
 			popupOptions.OnTappingOutsideOfPopup?.Invoke();
 			await CloseAsync(new PopupResult(true));
-		}, () => popupOptions.CanBeDismissedByTappingOutsideOfPopup);
+		}, () => popupOptions.CanBeDismissedByTappingOutsideOfPopup & popup.CanBeDismissedByTappingOutsideOfPopup);
 
 		// Only set the content if the parent constructor hasn't set the content already; don't override content if it already exists
 		base.Content = new PopupPageLayout(popup, popupOptions, tapOutsideOfPopupCommand);
 
+		popup.PropertyChanged += HandlePopupPropertyChanged;
 		if (popupOptions is BindableObject bindablePopupOptions)
 		{
-			bindablePopupOptions.PropertyChanged += HandlePopupPropertyChanged;
+			bindablePopupOptions.PropertyChanged += HandlePopupOptionsPropertyChanged;
 		}
 
 		this.SetBinding(BindingContextProperty, static (Popup x) => x.BindingContext, source: popup, mode: BindingMode.OneWay);
@@ -152,9 +153,17 @@ partial class PopupPage : ContentPage, IQueryAttributable
 		return popup;
 	}
 
-	void HandlePopupPropertyChanged(object? sender, PropertyChangedEventArgs e)
+	void HandlePopupOptionsPropertyChanged(object? sender, PropertyChangedEventArgs e)
 	{
 		if (e.PropertyName == nameof(IPopupOptions.CanBeDismissedByTappingOutsideOfPopup))
+		{
+			tapOutsideOfPopupCommand.ChangeCanExecute();
+		}
+	}
+	
+	void HandlePopupPropertyChanged(object? sender, PropertyChangedEventArgs e)
+	{
+		if (e.PropertyName == nameof(Popup.CanBeDismissedByTappingOutsideOfPopup))
 		{
 			tapOutsideOfPopupCommand.ChangeCanExecute();
 		}


### PR DESCRIPTION
 ### Description of Change ###

This PR adds the bindable property `public bool CanBeDismissedByTappingOutsideOfPopup { get; set }` to `Popup`.

This PR also updates the logic in `PopupPage` to only dismiss a Popup when **both** `Popup.CanBeDismissedByTappingOutsideOfPopup` and `IPopupOptions.CanBeDismissedByTappingOutsideOfPopup` are true:
 

```cs
	// Only dismiss when a user taps outside Popup when **both** Popup.CanBeDismissedByTappingOutsideOfPopup and PopupOptions.CanBeDismissedByTappingOutsideOfPopup are true
	// If either value is false, do not dismiss Popup
	static bool GetCanBeDismissedByTappingOutsideOfPopup(in Popup popup, in IPopupOptions popupOptions) => popup.CanBeDismissedByTappingOutsideOfPopup & popupOptions.CanBeDismissedByTappingOutsideOfPopup;
```

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes https://github.com/CommunityToolkit/Maui/discussions/2707

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->
