### PR TITLE
Fix MediaElement in Sample App

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/MediaElement/MediaElementPage.xaml.cs
@@ -274,16 +274,18 @@ public partial class MediaElementPage : BasePage<MediaElementViewModel>
 
 		var popupMediaElement = new MediaElement
 		{
+			WidthRequest = 600,
+			HeightRequest = 400,
 			AndroidViewType = AndroidViewType.SurfaceView,
 			Source = source,
-			MetadataArtworkUrl = "dotnet_bot.png",
+			MetadataArtworkUrl = botImageUrl,
 			ShouldAutoPlay = true,
 			ShouldShowPlaybackControls = true,
 		};
 
 		await this.ShowPopupAsync(popupMediaElement);
 
-		popupMediaElement.Stop();
-		popupMediaElement.Source = null;
+			popupMediaElement.Stop();
+			popupMediaElement.Source = null;
 	}
 }


### PR DESCRIPTION
 ### Description of Change ###

Fix sample app MediaElement Popup to use a `URL` for MetadataArtworkUrl. Set `Width` and `Height` for Popup MediaElement so that you can click outside popup to close it. 

 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

This fixes a bug where the artwork URL was set to string and not a url and the popup cannot be tapped outside popup as it takes the full screen in Windows.
 
