### PR TITLE
Adds installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,32 @@ All of the [documentation](https://learn.microsoft.com/dotnet/communitytoolkit/m
 
 https://learn.microsoft.com/dotnet/communitytoolkit/maui/get-started
 
+## Installation
+
+The release versions of .NET MAUI Community Toolkit are available at Nuget.org as NuGet packagez. You can install them using the following commands in your terminal or Package Manager Console:
+
+```bash
+dotnet add package CommunityToolkit.Maui
+dotnet add package CommunityToolkit.Maui.MediaElement
+dotnet add package CommunityToolkit.Maui.Maps
+dotnet add package CommunityToolkit.Maui.Camera
+```
+
+You can also try the latest pre-release version of the main branch. We use GitHub Packages to host the pre-release versions of the .NET MAUI Community Toolkit. To install the pre-release version, you need to add the GitHub Packages source to your NuGet configuration. GitHub Packages only supports authentication using a personal access token (classic) (https://github.com/settings/tokens). For more information, see [Managing your personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). You can use a personal access token (classic) to authenticate to GitHub Packages. When you create a personal access token (classic), you can assign the token different scopes depending on your needs, but `read:packages` is enough.
+
+```bash
+dotnet nuget add source https://nuget.pkg.github.com/CommunityToolkit/index.json -n CoummunityToolkitGitHubNuget -u YOUR_GITHUB_USERNAME -p YOUR_GITHUB_PERSONAL_ACCESS_TOKEN
+```
+
+and then install the packages as follows:
+
+```bash
+dotnet add package CommunityToolkit.Maui --version 99.0.0-preview980
+dotnet add package CommunityToolkit.Maui.MediaElement --version 99.0.0-preview980
+dotnet add package CommunityToolkit.Maui.Maps --version 99.0.0-preview980
+dotnet add package CommunityToolkit.Maui.Camera --version 99.0.0-preview980
+```
+
 ## Getting Started
 
 In order to use the .NET MAUI Community Toolkit you need to call the extension method in your `MauiProgram.cs` file as follows:


### PR DESCRIPTION
Adds installation instructions for the .NET MAUI Community Toolkit to the README, including:

- Instructions for installing release versions from NuGet.org
- Instructions for installing pre-release versions from GitHub Packages, including authentication details.