### PR TITLE
Fix Media Element PlatformSeek CTD

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.android.cs
@@ -312,6 +312,12 @@ public partial class MediaManager : Java.Lang.Object, IPlayerListener
 		{
 			throw new InvalidOperationException($"{nameof(IExoPlayer)} is not yet initialized");
 		}
+		
+		if(!Player.IsCurrentMediaItemSeekable)
+		{
+			Logger.LogInformation("The current media item is not seekable. Seek operation will be ignored.");
+			return;
+		}
 
 		await seekToSemaphoreSlim.WaitAsync(token);
 


### PR DESCRIPTION
 ### Description of Change ###

Some video sources do not allow seeking through video and crash the video player on android when attempting to manually seek using media element. 
!Note: This can easily be seen with player as seek bar is greyed out and cannot be clicked on. This PR just adds a check in case a developer uses custom controls and tries to seek when it is disabled.

 ### Linked Issues ###
 - Fixes #2801

 ### PR Checklist ###
 
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

This adds an additional check to `PlatformSeek` that checks to see if video is seekable and exits function with log message about error if it cannot seek. This is platform specific to android. 
 
