### PR TITLE
Add missing media3 Stub `OnPositionDiscontinuity` back to Android Med…

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.android.cs
@@ -734,6 +734,7 @@ public partial class MediaManager : Java.Lang.Object, IPlayerListener
 	public void OnMediaItemTransition(MediaItem? mediaItem, int reason) { }
 	public void OnMediaMetadataChanged(MediaMetadata? mediaMetadata) { }
 	public void OnPlayWhenReadyChanged(bool playWhenReady, int reason) { }
+	public void OnPositionDiscontinuity(PlayerPositionInfo? oldPosition, PlayerPositionInfo? newPosition, int reason) { }
 	public void OnPlaybackSuppressionReasonChanged(int playbackSuppressionReason) { }
 	public void OnPlayerErrorChanged(PlaybackException? error) { }
 	public void OnPlaylistMetadataChanged(MediaMetadata? mediaMetadata) { }


### PR DESCRIPTION
 ### Description of Change ###

Add missing media3 Stub `OnPositionDiscontinuity` back to Android MediaManager class

#### PR Classification
New feature to enhance media playback handling.

#### PR Summary
This pull request introduces a new method to improve the media manager's ability to respond to playback position changes. 
- `MediaManager.android.cs`: Added the `OnPositionDiscontinuity` method with parameters for old and new positions and a reason.

 ### Linked Issues ###

 - Fixes #2824

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [ ] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

This is the last Stub I had forgotten to add back. There was a specific reason why I removed it.  https://github.com/dotnet/android-libraries/issues/929  & https://github.com/dotnet/android-libraries/pull/949

There are issues with having it and not having this specific stub in media element. I am not sure exactly what issues it will generate by adding it back now. It may cause no problem for developers. But I do remember that it was excluded for a reason that caused actual issues for some people. I don't remember what issues as it was a while back.
 
