### PR TITLE
Refactor TextCaseConverter and enhance ListToStringConverterTests

### DIFF
--- a/src/CommunityToolkit.Maui.UnitTests/Converters/ListToStringConverterTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Converters/ListToStringConverterTests.cs
@@ -25,6 +25,15 @@ public class ListToStringConverterTests : BaseOneWayConverterTest<ListToStringCo
 		{
 			["A", "B", "C"], null, "ABC"
 		},
+		{
+			["A", "   ", "C"], ",", "A,C"
+		},
+		{
+			["A", "\t", "C"], ",", "A,C"
+		},
+		{
+			["A", "\n", "C"], ",", "A,C"
+		},
 	};
 
 	[Theory]

--- a/src/CommunityToolkit.Maui/Converters/TextCaseConverter.shared.cs
+++ b/src/CommunityToolkit.Maui/Converters/TextCaseConverter.shared.cs
@@ -75,7 +75,6 @@ public partial class TextCaseConverter : BaseConverterOneWay<string?, string?, T
 			parameter = Type;
 		}
 
-
 		return parameter switch
 		{
 			TextCaseType.Lower => value.ToLowerInvariant(),


### PR DESCRIPTION
### Description of Change ###

This PR adds missing unit test coverage for the `ListToStringConverter` when handling whitespace-only strings.

The `ListToStringConverter` correctly filters out strings that are null, empty, or contain only whitespace characters (as implemented in line 40 of the converter), but there were no unit tests verifying this behavior for whitespace-only strings like spaces, tabs, and newlines.

**Changes:**
- Added 3 new test cases to verify whitespace-only strings are properly filtered out
- Covers spaces, tabs, and newlines as edge cases
- Improves test coverage without changing functionality

**Test Cases Added:**
- `["A", "   ", "C"]` → `"A,C"` (spaces)
- `["A", "\t", "C"]` → `"A,C"` (tabs)  
- `["A", "\n", "C"]` → `"A,C"` (newlines)

### Linked Issues ###

- Fixes # (This is a test coverage improvement, not a bug fix)

### PR Checklist ###

- [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal
  - **Note**: This is a test coverage improvement, not a bug fix or new feature
- [x] Has tests (if omitted, state reason in description)
  - **Added**: 3 new unit tests for whitespace-only strings
- [x] Has samples (if omitted, state reason in description)
  - **Omitted**: This is a test-only change, no samples needed
- [x] Rebased on top of `main` at time of PR
- [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
- [x] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls
  - **Omitted**: This is a test-only change, no documentation needed

### Additional information ###

**Platforms tested**: N/A (unit tests only)

**Type of change**: Test coverage improvement

**Impact**: Low risk - only adds unit tests, no functional changes