### PR TITLE
Fix typo in the example label text on IsInRangeConverterPage

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Converters/IsInRangeConverterPage.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Converters/IsInRangeConverterPage.cs
@@ -118,7 +118,7 @@ public partial class IsInRangeConverterPage : BasePage<IsInRangeConverterViewMod
 
 					new ExampleLabel()
 						.Row(Row.StringExample3).Column(Column.Input)
-						.Text("String Commpare Less Than or Equal To \"Community\""),
+						.Text("String Compare Less Than or Equal To \"Community\""),
 
 					new Label()
 						.Row(Row.StringExample3).Column(Column.Result)


### PR DESCRIPTION
 ### Description of Change ###

Fix typo: `Commpare` -> `Compare`


 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->

