### PR TITLE
Fix memory leak on popups

### DIFF
--- a/src/CommunityToolkit.Maui/Views/Popup/PopupPage.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/PopupPage.shared.cs
@@ -40,7 +40,12 @@ partial class PopupPage : ContentPage, IQueryAttributable
 		this.popup = popup;
 		this.popupOptions = popupOptions ??= Options.DefaultPopupOptionsSettings;
 
-		tapOutsideOfPopupCommand = new Command(async () => await TapOutsideCommand(), () => GetCanBeDismissedByTappingOutsideOfPopup(popup, popupOptions));
+		tapOutsideOfPopupCommand = new Command(async () =>
+		{
+			popupOptions.OnTappingOutsideOfPopup?.Invoke();
+			await CloseAsync(new PopupResult(true));
+		}, () => GetCanBeDismissedByTappingOutsideOfPopup(popup, popupOptions));
+
 
 		var pageTapGestureRecognizer = new TapGestureRecognizer();
 		pageTapGestureRecognizer.Tapped += HandleTapGestureRecognizerTapped;
@@ -62,13 +67,6 @@ partial class PopupPage : ContentPage, IQueryAttributable
 		Shell.SetPresentationMode(this, PresentationMode.ModalNotAnimated);
 		On<iOS>().SetModalPresentationStyle(UIModalPresentationStyle.OverFullScreen);
 	}
-
-	async Task TapOutsideCommand()
-	{
-		popupOptions.OnTappingOutsideOfPopup?.Invoke();
-		await CloseAsync(new PopupResult(true));
-	}
-
 
 	public event EventHandler<IPopupResult>? PopupClosed;
 


### PR DESCRIPTION
This leak just happens if the Popup is singleton, the `PropertyChanged` and `pageTapGestureRecognizer.Tapped`event subscriptions will hold a strong reference between those elements and cause a memory leak. Making sure to unhold from references will solve the leak.

`PopupPageLayout` will take longer to be released, not sure why but even with that there's no leak.

Fixes: #2855