### PR TITLE
Enable package validation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -230,6 +230,10 @@
     <!-- Embed symbols containing Source Link in the main file (exe/dll) -->
     <DebugType>embedded</DebugType>
   </PropertyGroup>
+  
+  <PropertyGroup Label="PackageValidation">
+      <CompatibilitySuppressionFilePath Condition="('$(GenerateCompatibilitySuppressionFile)'=='true') OR Exists('$(MSBuildProjectDirectory)\PackageValidationSuppression.txt')">PackageValidationSuppression.txt</CompatibilitySuppressionFilePath>
+  </PropertyGroup>
 
   <ItemGroup>
     <SupportedPlatform Include="Tizen" />

--- a/src/CommunityToolkit.Maui.Camera/CommunityToolkit.Maui.Camera.csproj
+++ b/src/CommunityToolkit.Maui.Camera/CommunityToolkit.Maui.Camera.csproj
@@ -17,6 +17,10 @@
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>CommunityToolkit.Maui</RootNamespace>
     <AndroidGenerateResourceDesigner>false</AndroidGenerateResourceDesigner>
+    <!-- Update this to latest released version.
+	     When updating this, make sure to delete PackageValidationSuppression.txt files -->
+    <PackageValidationBaselineVersion>3.0.2</PackageValidationBaselineVersion>
+    <EnablePackageValidation>true</EnablePackageValidation>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/CommunityToolkit.Maui.Core/CommunityToolkit.Maui.Core.csproj
+++ b/src/CommunityToolkit.Maui.Core/CommunityToolkit.Maui.Core.csproj
@@ -16,6 +16,10 @@
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
+    <!-- Update this to latest released version.
+	     When updating this, make sure to delete PackageValidationSuppression.txt files -->
+    <PackageValidationBaselineVersion>12.2.0</PackageValidationBaselineVersion>
+    <EnablePackageValidation>true</EnablePackageValidation>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/CommunityToolkit.Maui.Maps/CommunityToolkit.Maui.Maps.csproj
+++ b/src/CommunityToolkit.Maui.Maps/CommunityToolkit.Maui.Maps.csproj
@@ -16,6 +16,10 @@
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
+    <!-- Update this to latest released version.
+	     When updating this, make sure to delete PackageValidationSuppression.txt files -->
+    <PackageValidationBaselineVersion>3.0.3</PackageValidationBaselineVersion>
+    <EnablePackageValidation>true</EnablePackageValidation>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/CommunityToolkit.Maui.MediaElement/CommunityToolkit.Maui.MediaElement.csproj
+++ b/src/CommunityToolkit.Maui.MediaElement/CommunityToolkit.Maui.MediaElement.csproj
@@ -16,6 +16,10 @@
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
     <RootNamespace>CommunityToolkit.Maui</RootNamespace>
     <AndroidGenerateResourceDesigner>false</AndroidGenerateResourceDesigner>
+    <!-- Update this to latest released version.
+	     When updating this, make sure to delete PackageValidationSuppression.txt files -->
+    <PackageValidationBaselineVersion>6.1.2</PackageValidationBaselineVersion>
+    <EnablePackageValidation>true</EnablePackageValidation>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/CommunityToolkit.Maui/CommunityToolkit.Maui.csproj
+++ b/src/CommunityToolkit.Maui/CommunityToolkit.Maui.csproj
@@ -24,6 +24,10 @@
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
+    <!-- Update this to latest released version.
+	     When updating this, make sure to delete PackageValidationSuppression.txt files -->
+    <PackageValidationBaselineVersion>12.2.0</PackageValidationBaselineVersion>
+    <EnablePackageValidation>true</EnablePackageValidation>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
 ### Description of Change ###

This enables package validation.
Currently this will cause a failure locally because the local build defaults to v1.0.0, and that will fail validation. So that probably needs some adjusting, or we can have the package validation only run on the PR checkers, so only turn it on for the cloud builds.
This draft PR is just as much to help with discussion on this at next month's meeting.

 ### Linked Issues ###

 - Fixes #https://github.com/CommunityToolkit/Maui/issues/2884

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
