### PR TITLE
CarouselViewHandler2 `InvalidCastException` for `MauiMediaElement.macios.cs` when using `CollectionViewHandler2` and `CarouselViewHandler2`

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MauiMediaElement.macios.cs
@@ -84,12 +84,12 @@ public class MauiMediaElement : UIView
 
 				// The Controller we need is a `protected internal` property called ItemsViewController in the ItemsViewHandler2 class: https://github.com/dotnet/maui/blob/70e8ddfd4bd494bc71aa7afb812cc09161cf0c72/src/Controls/src/Core/Handlers/Items2/ItemsViewHandler2.iOS.cs#L64
 				// In this method, we must use reflection to get the value of its backing field 
-				static ItemsViewController<TItemsView> GetInternalControllerForItemsView2<TItemsView>(ItemsViewHandler2<TItemsView> handler) where TItemsView : ItemsView
+				static ItemsViewController2<TItemsView> GetInternalControllerForItemsView2<TItemsView>(ItemsViewHandler2<TItemsView> handler) where TItemsView : ItemsView
 				{
 					var nonPublicInstanceFields = typeof(ItemsViewHandler2<TItemsView>).GetFields(BindingFlags.NonPublic | BindingFlags.Instance);
 
 					var controllerProperty = nonPublicInstanceFields.Single(x => x.FieldType == typeof(ItemsViewController2<TItemsView>));
-					return (ItemsViewController<TItemsView>)(controllerProperty.GetValue(handler) ?? throw new InvalidOperationException($"Unable to get the value for the Controller property on {handler.GetType()}"));
+					return (ItemsViewController2<TItemsView>)(controllerProperty.GetValue(handler) ?? throw new InvalidOperationException($"Unable to get the value for the Controller property on {handler.GetType()}"));
 				}
 			}
 			// If we don't find an ItemsView, default to the current UIViewController


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

This PR fixes a typo I made when adding support for `ItemsViewController2<T>` in `MauiMediaElement.macios.cs`.

When a developer is using an `ItemsViewController2<T>`, we were incorrectly casting it to `ItemsViewController<T>` instead of a `ItemsViewController2<T>`, causing the `InvalidCastException`.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes https://github.com/CommunityToolkit/Maui/issues/2925

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)


 ### Additional information ###

The bug was due to a copy/paste error when I created the following two methods side-by-side:
- `static ItemsViewController<TItemsView> GetInternalControllerForItemsView<TItemsView>(ItemsViewHandler<TItemsView>) where TItemsView : ItemsView`
- `static ItemsViewController2<TItemsView> GetInternalControllerForItemsView2<TItemsView>(ItemsViewHandler2<TItemsView>) where TItemsView : ItemsView`
 
This bug was not caught earlier because the Controller we need from .NET MAUI is a `protected internal` property, forcing us to use reflection to retrieve it. If the property was public we could rely on C# type-safety.
