### PR TITLE
[CameraView][iOS] Favor Photo Formats During Default Resolution Selection

### DIFF
--- a/src/CommunityToolkit.Maui.Camera/CameraManager.macios.cs
+++ b/src/CommunityToolkit.Maui.Camera/CameraManager.macios.cs
@@ -104,22 +104,21 @@ partial class CameraManager
 			cameraView.SelectedCamera = cameraProvider.AvailableCameras?.FirstOrDefault() ?? throw new CameraException("No camera available on device");
 		}
 
-		var filteredFormatList = cameraView.SelectedCamera.SupportedFormats.Where(f =>
-		{
-			var d = ((CMVideoFormatDescription)f.FormatDescription).Dimensions;
-			return d.Width <= resolution.Width && d.Height <= resolution.Height;
-		}).ToList();
+		var formatsMatchingResolution = cameraView.SelectedCamera.SupportedFormats
+			.Where(format => MatchesResolution(format, resolution))
+			.ToList();
 
-		filteredFormatList = [.. (filteredFormatList.Count is not 0 ? filteredFormatList : cameraView.SelectedCamera.SupportedFormats)
-			.OrderByDescending(f =>
-			{
-				var d = ((CMVideoFormatDescription)f.FormatDescription).Dimensions;
-				return d.Width * d.Height;
-			})];
+		var availableFormats = formatsMatchingResolution.Count is not 0
+			? formatsMatchingResolution
+			: GetPhotoCompatibleFormats(cameraView.SelectedCamera.SupportedFormats);
 
-		if (filteredFormatList.Count is not 0)
+		var selectedFormat = availableFormats
+			.OrderByDescending(f => f.ResolutionArea)
+			.FirstOrDefault();
+
+		if (selectedFormat is not null)
 		{
-			captureDevice.ActiveFormat = filteredFormatList.First();
+			captureDevice.ActiveFormat = selectedFormat;
 		}
 
 		captureDevice.UnlockForConfiguration();
@@ -458,6 +457,24 @@ partial class CameraManager
 	{
 		videoOrientation = GetVideoOrientation();
 		previewView?.UpdatePreviewVideoOrientation(videoOrientation);
+	}
+
+	IEnumerable<AVCaptureDeviceFormat> GetPhotoCompatibleFormats(IEnumerable<AVCaptureDeviceFormat> formats)
+	{
+		if (photoOutput is not null)
+		{
+			var photoPixelFormats = photoOutput.GetSupportedPhotoPixelFormatTypesForFileType(nameof(AVFileTypes.Jpeg));
+			return formats.Where(format => photoPixelFormats.Contains((NSNumber)format.FormatDescription.MediaSubType));
+		}	
+
+		return formats;
+	}
+
+	static bool MatchesResolution(AVCaptureDeviceFormat format, Size resolution)
+	{
+		var dimensions = ((CMVideoFormatDescription)format.FormatDescription).Dimensions;
+		return dimensions.Width <= resolution.Width 
+			&& dimensions.Height <= resolution.Height;
 	}
 
 	sealed class AVCapturePhotoCaptureDelegateWrapper : AVCapturePhotoCaptureDelegate

--- a/src/CommunityToolkit.Maui.Camera/Extensions/CameraViewExtensions.macios.cs
+++ b/src/CommunityToolkit.Maui.Camera/Extensions/CameraViewExtensions.macios.cs
@@ -1,5 +1,6 @@
 ﻿using AVFoundation;
 using CommunityToolkit.Maui.Core;
+using CoreMedia;
 
 namespace CommunityToolkit.Maui.Extensions;
 
@@ -30,4 +31,23 @@ static class CameraViewExtensions
 	{
 		cameraView.IsAvailable = AVCaptureDevice.GetDefaultDevice(AVMediaTypes.Video) is not null;
 	}
+
+	extension(AVCaptureDeviceFormat avCaptureDeviceFormat)
+    {
+		/// <summary>
+        /// Gets the total resolution area in pixels (width × height) of the <see cref="AVCaptureDeviceFormat"/>.
+        /// </summary>
+        /// <value>
+        /// The total number of pixels, calculated as width multiplied by height.
+        /// </value>
+        public int ResolutionArea
+		{
+            get
+            {
+				var dimensions = ((CMVideoFormatDescription)avCaptureDeviceFormat.FormatDescription).Dimensions;
+				return dimensions.Width * dimensions.Height;
+            }
+		}
+
+    }
 }


### PR DESCRIPTION
 ### Description of Change ###
- Add GetPhotoCompatibleFormats to filter JPEG-compatible formats
  - When no formats match requested resolution, fallback to formats supported by photoOutput
    - Prevents automatic selection of raw/Bayer formats that cause "No active and enabled video connection" crash
- Resolution-matching formats still preferred (supports video with any format)

 ### Linked Issues ###
 - Fixes #2920
 - Fixes https://github.com/CommunityToolkit/Maui/issues/3037

 ### PR Checklist ###
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [ ] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->
