### PR TITLE
Add popup related navigation extension methods

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/Popup/PopupsPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/Popup/PopupsPage.xaml.cs
@@ -29,6 +29,15 @@ public partial class PopupsPage : BasePage<PopupsViewModel>
 		}
 	}
 
+	protected override async void OnNavigatedFrom(NavigatedFromEventArgs args)
+	{
+		base.OnNavigatedFrom(args);
+		if (args.IsDestinationPageACommunityToolkitPopupPage())
+		{
+			await Toast.Make("Opening Popup").Show();
+		}
+	}
+
 	async void HandleSimplePopupButtonClicked(object? sender, EventArgs e)
 	{
 		var queryAttributes = new Dictionary<string, object>

--- a/src/CommunityToolkit.Maui.UnitTests/Extensions/NavigatedFromEventArgsExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Extensions/NavigatedFromEventArgsExtensionsTests.cs
@@ -1,0 +1,82 @@
+using CommunityToolkit.Maui.Extensions;
+using CommunityToolkit.Maui.UnitTests.Mocks;
+using CommunityToolkit.Maui.UnitTests.Services;
+using Xunit;
+
+namespace CommunityToolkit.Maui.UnitTests.Extensions;
+
+public class NavigatedFromEventArgsExtensionsTests : BaseViewTest
+{
+	[Fact]
+	public async Task NavigatedFromEventArgsExtensions_IsDestinationPageACommunityToolkitPopupPage_ShouldReturnTrue()
+	{
+		// Arrange
+		TaskCompletionSource<bool?> isDestinationPageACommunityToolkitPopupPageTCS = new();
+		var application = (MockApplication)ServiceProvider.GetRequiredService<IApplication>();
+		var popupService = ServiceProvider.GetRequiredService<IPopupService>();
+
+		var shell = (Shell)(application.Windows[0].Page ?? throw new InvalidOperationException("Unable to retrieve Shell"));
+		var mainPage = shell.CurrentPage;
+		var shellContentPage = new ShellContentPage();
+		shellContentPage.NavigatedFromEventArgsReceived += HandleNavigatedFromEventArgsReceived;
+
+		var shellParameters = new Dictionary<string, object>
+		{
+			{ nameof(ContentPage.BackgroundColor), Colors.Orange }
+		};
+
+
+		// Act
+		await mainPage.Navigation.PushAsync(shellContentPage);
+		await popupService.ShowPopupAsync<ShortLivedMockPageViewModel>(shell, null, shellParameters, TestContext.Current.CancellationToken);
+		var isDestinationPageACommunityToolkitPopupPage = await isDestinationPageACommunityToolkitPopupPageTCS.Task;
+
+		// Assert
+		Assert.True(isDestinationPageACommunityToolkitPopupPage);
+
+		void HandleNavigatedFromEventArgsReceived(object? sender, NavigatedFromEventArgs e)
+		{
+			isDestinationPageACommunityToolkitPopupPageTCS.SetResult(e.IsDestinationPageACommunityToolkitPopupPage());
+		}
+	}
+
+	[Fact]
+	public async Task NavigatedFromEventArgsExtensions_IsDestinationPageACommunityToolkitPopupPage_ShouldReturnFalse()
+	{
+		// Arrange
+		TaskCompletionSource<bool?> isDestinationPageACommunityToolkitPopupPageTCS = new();
+		var application = (MockApplication)ServiceProvider.GetRequiredService<IApplication>();
+
+		var shell = (Shell)(application.Windows[0].Page ?? throw new InvalidOperationException("Unable to retrieve Shell"));
+		var mainPage = shell.CurrentPage;
+		var shellContentPage = new ShellContentPage();
+		shellContentPage.NavigatedFromEventArgsReceived += HandleNavigatedFromEventArgsReceived;
+		var newShellContentPage = new ShellContentPage();
+
+
+		// Act
+		await mainPage.Navigation.PushAsync(shellContentPage);
+		//push a new content page on top to make sure the navigation handler doesn't think we're navigating to a popup page
+		await mainPage.Navigation.PushAsync(newShellContentPage);
+		var isDestinationPageACommunityToolkitPopupPage = await isDestinationPageACommunityToolkitPopupPageTCS.Task;
+
+		// Assert
+		Assert.False(isDestinationPageACommunityToolkitPopupPage);
+
+		void HandleNavigatedFromEventArgsReceived(object? sender, NavigatedFromEventArgs e)
+		{
+			isDestinationPageACommunityToolkitPopupPageTCS.SetResult(e.IsDestinationPageACommunityToolkitPopupPage());
+		}
+	}
+
+	sealed class ShellContentPage : ContentPage
+	{
+		public event EventHandler<NavigatedFromEventArgs>? NavigatedFromEventArgsReceived;
+
+		protected override void OnNavigatedFrom(NavigatedFromEventArgs args)
+		{
+			base.OnNavigatedFrom(args);
+			NavigatedFromEventArgsReceived?.Invoke(this, args);
+		}
+	}
+}

--- a/src/CommunityToolkit.Maui/Extensions/NavigatedFromEventArgsExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui/Extensions/NavigatedFromEventArgsExtensions.shared.cs
@@ -1,0 +1,16 @@
+using CommunityToolkit.Maui.Views;
+
+namespace CommunityToolkit.Maui.Extensions;
+
+/// <summary>
+/// Extension methods for <see cref="NavigatedFromEventArgs"/>.
+/// </summary>
+public static class NavigatedFromEventArgsExtensions
+{
+	/// <summary>
+	/// Determines whether the previous page was a Community Toolkit <see cref="Popup"/>.
+	/// </summary>
+	/// <param name="args">The current <see cref="NavigatedFromEventArgs"/>.</param>
+	/// <returns>A boolean indicating whether the previous page was a Community Toolkit <see cref="Popup"/>.</returns>
+	public static bool IsDestinationPageACommunityToolkitPopupPage(this NavigatedFromEventArgs args) => args.DestinationPage is PopupPage;
+}


### PR DESCRIPTION
From parent page when calling a popup, when the onnavigatedfrom event, check args if the destination is a popup page.

Unit tests implemented

Sample code applied

 ### Description of Change ###

Added an extension method to OnNavigatedFrom event which checks if the destination page is a popup and if so returns true.

 ### Linked Issues ###

 - Fixes [https://github.com/CommunityToolkit/Maui/discussions/2927]

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [ ] Rebased on top of `main` at time of PR
 - [ ] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: [https://github.com/MicrosoftDocs/CommunityToolkit/pull/605] 


 ### Additional information ###

Tested on Android.
 
