### PR TITLE
Add missing AudioSessionIdChanged stub to android MediaElement

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.android.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.android.cs
@@ -722,6 +722,7 @@ public partial class MediaManager : Java.Lang.Object, IPlayerListener
 
 	#region PlayerListener implementation method stubs
 	public void OnAudioAttributesChanged(AudioAttributes? audioAttributes) { }
+	public void OnAudioSessionIdChanged(int audioSessionId) { }
 	public void OnAvailableCommandsChanged(PlayerCommands? player) { }
 	public void OnCues(CueGroup? cues) { }
 	public void OnDeviceInfoChanged(DeviceInfo? deviceInfo) { }


### PR DESCRIPTION
-Bug Fix

 ### Description of Change ###

Users have reported a bug that can be fixed by adding another method to `MediaElement` stubs for `Player.Listener` Adding `OnAudioSessionIdChanged(int audioSessionId)` should fix the linked issue.

 ### Linked Issues ###

 - Fixes #2989

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
