### PR TITLE
Add Support for `NavigationBar.SetColor(Color)` on Android 35+

### DIFF
--- a/src/CommunityToolkit.Maui/PlatformConfiguration/AndroidSpecific/NavigationBar.android.cs
+++ b/src/CommunityToolkit.Maui/PlatformConfiguration/AndroidSpecific/NavigationBar.android.cs
@@ -118,6 +118,7 @@ static partial class NavigationBar
 					}
 				};
 
+				navigationBarOverlay.Tag = navigationBarOverlayTag;
 				decorGroup.AddView(navigationBarOverlay);
 				navigationBarOverlay.SetZ(0);
 			}


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

This PR adds support for `NavigationBar.SetColor(Color)` on Android 35+.

This bug was introduced in Android 35+ when they deprecated the `Window.SetNavigationBarColor()` API that we were using to set the Navigation Bar Color:

https://github.com/CommunityToolkit/Maui/blob/a63844e1ab2518f30793856d02557b10418028cf/src/CommunityToolkit.Maui/PlatformConfiguration/AndroidSpecific/NavigationBar.android.cs#L100

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes https://github.com/CommunityToolkit/Maui/issues/3056

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)


 ### Additional information ###

This demo shows it now working on an Android API 36.1 Emulator:

![ScreenFlow](https://github.com/user-attachments/assets/cf13ae57-60ef-4d20-bc49-070d8a84467f)

The fix for this is similar to the 35.0+ bug fixed for `StatusBar` in https://github.com/CommunityToolkit/Maui/pull/2939