### PR TITLE
Revert "Fix Windows Picker Initial Path is not set (#3030)"

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Essentials/FileSaverViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Essentials/FileSaverViewModel.cs
@@ -38,8 +38,7 @@ public partial class FileSaverViewModel(IFileSaver fileSaver) : BaseViewModel
 		try
 		{
 			var fileName = Application.Current?.Windows[0].Page?.DisplayPromptAsync("FileSaver", "Choose filename") ?? Task.FromResult("test.txt");
-			var initialFolder = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-			var fileLocationResult = await fileSaver.SaveAsync(initialFolder, await fileName, stream, cancellationToken);
+			var fileLocationResult = await fileSaver.SaveAsync(await fileName, stream, cancellationToken);
 			fileLocationResult.EnsureSuccess();
 
 			await Toast.Make($"File is saved: {fileLocationResult.FilePath}").Show(cancellationToken);

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Essentials/FolderPickerViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Essentials/FolderPickerViewModel.cs
@@ -33,8 +33,7 @@ public partial class FolderPickerViewModel(IFolderPicker folderPicker) : BaseVie
 			return;
 		}
 
-		var initialFolder = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-		var folderPickerResult = await folderPicker.PickAsync(initialFolder, cancellationToken);
+		var folderPickerResult = await folderPicker.PickAsync(cancellationToken);
 		if (folderPickerResult.IsSuccessful)
 		{
 			await Toast.Make($"Folder picked: Name - {folderPickerResult.Folder.Name}, Path - {folderPickerResult.Folder.Path}", ToastDuration.Long).Show(cancellationToken);

--- a/src/CommunityToolkit.Maui.Core/CommunityToolkit.Maui.Core.csproj
+++ b/src/CommunityToolkit.Maui.Core/CommunityToolkit.Maui.Core.csproj
@@ -55,17 +55,13 @@
     <PackageReference Include="Microsoft.Maui.Core" Version="$(MauiPackageVersion)" />
     <PackageReference Include="Microsoft.Maui.Essentials" Version="$(MauiPackageVersion)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" Condition=" '$(Configuration)'=='Release' " PrivateAssets="All" />
+    <PackageReference Include="System.Speech" Version="10.0.0" Condition="'$(TargetFramework)' == '$(NetVersion)-windows10.0.19041.0'" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.Contains('-tizen'))">
     <PackageReference Include="Microsoft.Maui.Graphics.Skia" Version="$(MauiPackageVersion)" />
     <PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="*" />
     <PackageReference Include="Tizen.UIExtensions.NUI" Version="*" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == '$(NetVersion)-windows10.0.19041.0'">
-    <PackageReference Include="System.Speech" Version="10.0.1" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.0-experimental3" />
   </ItemGroup>
 
 </Project>

--- a/src/CommunityToolkit.Maui.Core/Essentials/FileSaver/FileSaverImplementation.windows.cs
+++ b/src/CommunityToolkit.Maui.Core/Essentials/FileSaver/FileSaverImplementation.windows.cs
@@ -1,4 +1,5 @@
-using Microsoft.Windows.Storage.Pickers;
+using System.Diagnostics;
+using Windows.Storage.Pickers;
 
 namespace CommunityToolkit.Maui.Storage;
 
@@ -9,18 +10,11 @@ public sealed partial class FileSaverImplementation : IFileSaver
 
 	async Task<string> InternalSaveAsync(string initialPath, string fileName, Stream stream, IProgress<double>? progress, CancellationToken cancellationToken)
 	{
-		if (IPlatformApplication.Current?.Application.Windows[0].Handler?.PlatformView is not MauiWinUIWindow window)
+		var savePicker = new FileSavePicker
 		{
-			throw new FileSaveException(
-				"Cannot present file picker: No active window found. Ensure the app is active with a visible window.");
-		}
-
-		var savePicker = new FileSavePicker(window.AppWindow.Id)
-		{
-			SuggestedStartLocation = PickerLocationId.DocumentsLibrary,
-			SuggestedFolder = initialPath,
-			SuggestedFileName = Path.GetFileNameWithoutExtension(fileName)
+			SuggestedStartLocation = PickerLocationId.DocumentsLibrary
 		};
+		WinRT.Interop.InitializeWithWindow.Initialize(savePicker, Process.GetCurrentProcess().MainWindowHandle);
 
 		var extension = Path.GetExtension(fileName);
 		if (!string.IsNullOrEmpty(extension))
@@ -29,18 +23,15 @@ public sealed partial class FileSaverImplementation : IFileSaver
 		}
 
 		savePicker.FileTypeChoices.Add("All files", allFilesExtension);
+		savePicker.SuggestedFileName = Path.GetFileNameWithoutExtension(fileName);
 
 		var filePickerOperation = savePicker.PickSaveFileAsync();
+
 		await using var _ = cancellationToken.Register(CancelFilePickerOperation);
 		var file = await filePickerOperation;
-		if (file is null)
+		if (string.IsNullOrEmpty(file?.Path))
 		{
-			throw new OperationCanceledException("Operation cancelled.");
-		}
-
-		if (string.IsNullOrEmpty(file.Path))
-		{
-			throw new FileSaveException("Path doesn't exist.");
+			throw new FileSaveException("Operation cancelled or Path doesn't exist.");
 		}
 
 		await WriteStream(stream, file.Path, progress, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION

 ### Description of Change ###

This reverts commit d12df7f80542c7c456814d3ef102bad4db00e928.

The bug fix applied in https://github.com/CommunityToolkit/Maui/pull/3030 requires the use of `<PackageReference Include="Microsoft.WindowsAppSDK" Version="2.0.0-experimental3" />` which does not yet have a stable release. 

Users have reported being unable to publish their app to the Microsoft Store because it is using an experimental release: https://github.com/CommunityToolkit/Maui/issues/3069.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes https://github.com/CommunityToolkit/Maui/issues/3069


 ### Additional information ###

I will open a Draft PR shortly that re-implements the bug fix in https://github.com/CommunityToolkit/Maui/pull/3030 that we will remain in Draft until `Microsoft.WindowsAppSDK v2.0.0` is promoted to stable.
