### PR TITLE
Add DynamicDependency to MauiMediaElement constructors

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Platform/KeyboardExtensions/KeyboardExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Platform/KeyboardExtensions/KeyboardExtensions.shared.cs
@@ -118,7 +118,10 @@ public static partial class KeyboardExtensions
 		return true;
 	}
 
-	sealed class SoftKeyboardException(string message) : Exception(message)
+	/// <summary>
+	/// An <see cref="Exception"/> thrown when unable to retrieve the platform view to determine soft keyboard status.
+	/// </summary>
+	public sealed class SoftKeyboardException(string message) : Exception(message)
 	{
 	}
 }

--- a/src/CommunityToolkit.Maui/Views/Popup/Popup.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/Popup.shared.cs
@@ -112,8 +112,17 @@ public partial class Popup<T> : Popup
 	public virtual Task CloseAsync(T result, CancellationToken token = default) => GetPopupPage().CloseAsync(new PopupResult<T>(result, false), token);
 }
 
-sealed class PopupNotFoundException() : InvalidPopupOperationException($"Unable to close popup: could not locate {nameof(PopupPage)}. {nameof(PopupExtensions.ShowPopup)} or {nameof(PopupExtensions.ShowPopupAsync)} must be called before {nameof(Popup.CloseAsync)}. If using a custom implementation of {nameof(Popup)}, override the {nameof(Popup.CloseAsync)} method");
+/// <summary>
+/// An <see cref="InvalidOperationException"/> thrown when attempting to close a <see cref="Popup"/> that cannot locate its associated <see cref="PopupPage"/>.
+/// </summary>
+public sealed class PopupNotFoundException() : InvalidPopupOperationException($"Unable to close popup: could not locate {nameof(PopupPage)}. {nameof(PopupExtensions.ShowPopup)} or {nameof(PopupExtensions.ShowPopupAsync)} must be called before {nameof(Popup.CloseAsync)}. If using a custom implementation of {nameof(Popup)}, override the {nameof(Popup.CloseAsync)} method");
 
-sealed class PopupBlockedException(in Page currentVisibleModalPage) : InvalidPopupOperationException($"Unable to close Popup because it is blocked by the Modal Page {currentVisibleModalPage.GetType().FullName}. Please call `{nameof(Page.Navigation)}.{nameof(Page.Navigation.PopModalAsync)}()` to first remove {currentVisibleModalPage.GetType().FullName} from the {nameof(Page.Navigation.ModalStack)}");
+/// <summary>
+/// An <see cref="InvalidOperationException"/> thrown when attempting to close a <see cref="Popup"/> that is blocked by a visible modal page.
+/// </summary>
+public sealed class PopupBlockedException(in Page currentVisibleModalPage) : InvalidPopupOperationException($"Unable to close Popup because it is blocked by the Modal Page {currentVisibleModalPage.GetType().FullName}. Please call `{nameof(Page.Navigation)}.{nameof(Page.Navigation.PopModalAsync)}()` to first remove {currentVisibleModalPage.GetType().FullName} from the {nameof(Page.Navigation.ModalStack)}");
 
-class InvalidPopupOperationException(in string message) : InvalidOperationException(message);
+/// <summary>
+/// An <see cref="InvalidOperationException"/> thrown when an invalid operation is performed on a <see cref="Popup"/>.
+/// </summary>
+public class InvalidPopupOperationException(in string message) : InvalidOperationException(message);


### PR DESCRIPTION
 ### Description of Change ###

Added `[DynamicDependency]` to `MauiMediaElement` constructors to preserve MediaElement public constructors during linking/trimming.

 ### Linked Issues ###
 - Fixes #3114

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

Fixes parameter-less constructor error and crash in Android when using `MediaElement`.
 
