### PR TITLE
Add ExpanderAnimationBehavior, IExpansionController

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/Expander/ExpanderPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/Expander/ExpanderPage.xaml
@@ -22,6 +22,10 @@
                     <Label Text="Simple Expander (Tap Me)" FontSize="16" FontAttributes="Bold"/>
                 </mct:Expander.Header>
 
+                <mct:Expander.Behaviors>
+                    <mct:ExpanderAnimationBehavior />
+                </mct:Expander.Behaviors>
+
                 <mct:Expander.Content>
                     <VerticalStackLayout>
                         <Label Text="Item 1"/>
@@ -36,11 +40,21 @@
                 <mct:Expander.Header>
                     <Label Text="Multi-Level Expander (Tap Me)" FontSize="16" FontAttributes="Bold"/>
                 </mct:Expander.Header>
+
+                <mct:Expander.Behaviors>
+                    <mct:ExpanderAnimationBehavior />
+                </mct:Expander.Behaviors>
+
                 <mct:Expander.Content>
                     <mct:Expander Direction="Down" BackgroundColor="LightGray">
                         <mct:Expander.Header>
                             <Label Text="Nested Expander (Tap Me)" FontSize="14" FontAttributes="Bold"/>
                         </mct:Expander.Header>
+
+                        <mct:Expander.Behaviors>
+                            <mct:ExpanderAnimationBehavior />
+                        </mct:Expander.Behaviors>
+
                         <mct:Expander.Content>
                             <Label Text="Item 1" />
                         </mct:Expander.Content>
@@ -54,10 +68,16 @@
                 <CollectionView.ItemTemplate>
                     <DataTemplate>
                         <mct:Expander x:DataType="sample:ContentCreator"
+                                      ExpandedChanging="Expander_ExpandedChanging"
                                       ExpandedChanged="Expander_ExpandedChanged">
                             <mct:Expander.Header>
                                 <Label Text="{Binding Name}"/>
                             </mct:Expander.Header>
+
+                            <mct:Expander.Behaviors>
+                                <mct:ExpanderAnimationBehavior />
+                            </mct:Expander.Behaviors>
+
                             <mct:Expander.Content>
                                 <VerticalStackLayout>
                                     <Label Text="{Binding Resource}" HorizontalOptions="Center"/>
@@ -83,6 +103,8 @@
                 <CollectionView.ItemTemplate>
                     <DataTemplate>
                         <mct:Expander x:DataType="sample:ContentCreator"
+                                      HeightRequest="180"
+                                      ExpandedChanging="Expander_ExpandedChanging"
                                       ExpandedChanged="Expander_ExpandedChanged">
                             <mct:Expander.Header>
                                 <Label Text="{Binding Name}"/>

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/Expander/ExpanderPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/Expander/ExpanderPage.xaml
@@ -104,7 +104,6 @@
                     <DataTemplate>
                         <mct:Expander x:DataType="sample:ContentCreator"
                                       HeightRequest="180"
-                                      ExpandedChanging="Expander_ExpandedChanging"
                                       ExpandedChanged="Expander_ExpandedChanged">
                             <mct:Expander.Header>
                                 <Label Text="{Binding Name}"/>

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/Expander/ExpanderPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/Expander/ExpanderPage.xaml
@@ -68,7 +68,6 @@
                 <CollectionView.ItemTemplate>
                     <DataTemplate>
                         <mct:Expander x:DataType="sample:ContentCreator"
-                                      ExpandedChanging="Expander_ExpandedChanging"
                                       ExpandedChanged="Expander_ExpandedChanged">
                             <mct:Expander.Header>
                                 <Label Text="{Binding Name}"/>

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/Expander/ExpanderPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/Expander/ExpanderPage.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics;
 using CommunityToolkit.Maui.Alerts;
 using CommunityToolkit.Maui.Sample.ViewModels.Views;
 
@@ -11,10 +12,18 @@ public partial class ExpanderPage : BasePage<ExpanderViewModel>
 		InitializeComponent();
 	}
 
+	Stopwatch stopWatch = new();
+
+	void Expander_ExpandedChanging(object? sender, Core.ExpandedChangingEventArgs e)
+	{
+		stopWatch.Restart();
+	}
+
 	async void Expander_ExpandedChanged(object? sender, Core.ExpandedChangedEventArgs e)
 	{
+		stopWatch.Stop();
 		var collapsedText = e.IsExpanded ? "expanded" : "collapsed";
-		await Toast.Make($"Expander is {collapsedText}").Show(CancellationToken.None);
+		await Toast.Make($"Expander is {collapsedText} ({stopWatch.ElapsedMilliseconds} ms)").Show(CancellationToken.None);
 	}
 
 	async void GoToCSharpSampleClicked(object? sender, EventArgs? e)

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/Expander/ExpanderPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/Expander/ExpanderPage.xaml.cs
@@ -1,7 +1,7 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics;
 using CommunityToolkit.Maui.Alerts;
 using CommunityToolkit.Maui.Sample.ViewModels.Views;
+using CommunityToolkit.Maui.Views;
 
 namespace CommunityToolkit.Maui.Sample.Pages.Views;
 
@@ -12,18 +12,31 @@ public partial class ExpanderPage : BasePage<ExpanderViewModel>
 		InitializeComponent();
 	}
 
-	Stopwatch stopWatch = new();
+	Dictionary<Expander, long> expandTimes = new();
 
 	void Expander_ExpandedChanging(object? sender, Core.ExpandedChangingEventArgs e)
 	{
-		stopWatch.Restart();
+		if (sender is Expander expander)
+		{
+			expandTimes[expander] = DateTime.Now.Ticks;
+		}
 	}
 
 	async void Expander_ExpandedChanged(object? sender, Core.ExpandedChangedEventArgs e)
 	{
-		stopWatch.Stop();
 		var collapsedText = e.IsExpanded ? "expanded" : "collapsed";
-		await Toast.Make($"Expander is {collapsedText} ({stopWatch.ElapsedMilliseconds} ms)").Show(CancellationToken.None);
+		if (sender is Expander expander)
+		{
+			if (expandTimes.TryGetValue(expander, out var startTime))
+			{
+				var elapsed = DateTime.Now.Ticks - startTime;
+				await Toast.Make($"Expander is {collapsedText} ({elapsed} ms)").Show(CancellationToken.None);
+			}
+			else
+			{
+				await Toast.Make($"Expander is {collapsedText}").Show(CancellationToken.None);
+			}
+		}
 	}
 
 	async void GoToCSharpSampleClicked(object? sender, EventArgs? e)

--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/Expander/ExpanderPage.xaml.cs
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/Expander/ExpanderPage.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using CommunityToolkit.Maui.Alerts;
 using CommunityToolkit.Maui.Sample.ViewModels.Views;
-using CommunityToolkit.Maui.Views;
 
 namespace CommunityToolkit.Maui.Sample.Pages.Views;
 
@@ -12,31 +11,10 @@ public partial class ExpanderPage : BasePage<ExpanderViewModel>
 		InitializeComponent();
 	}
 
-	Dictionary<Expander, long> expandTimes = new();
-
-	void Expander_ExpandedChanging(object? sender, Core.ExpandedChangingEventArgs e)
-	{
-		if (sender is Expander expander)
-		{
-			expandTimes[expander] = DateTime.Now.Ticks;
-		}
-	}
-
 	async void Expander_ExpandedChanged(object? sender, Core.ExpandedChangedEventArgs e)
 	{
 		var collapsedText = e.IsExpanded ? "expanded" : "collapsed";
-		if (sender is Expander expander)
-		{
-			if (expandTimes.TryGetValue(expander, out var startTime))
-			{
-				var elapsed = DateTime.Now.Ticks - startTime;
-				await Toast.Make($"Expander is {collapsedText} ({elapsed} ms)").Show(CancellationToken.None);
-			}
-			else
-			{
-				await Toast.Make($"Expander is {collapsedText}").Show(CancellationToken.None);
-			}
-		}
+		await Toast.Make($"Expander is {collapsedText}").Show(CancellationToken.None);
 	}
 
 	async void GoToCSharpSampleClicked(object? sender, EventArgs? e)

--- a/src/CommunityToolkit.Maui.Core/Primitives/Defaults/ExpanderAnimationBehaviorDefaults.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Primitives/Defaults/ExpanderAnimationBehaviorDefaults.shared.cs
@@ -1,0 +1,9 @@
+﻿namespace CommunityToolkit.Maui.Core;
+
+static class ExpanderAnimationBehaviorDefaults
+{
+	public const uint CollapsingLength = 250u;
+	public static Easing CollapsingEasing { get; } = Easing.Linear;
+	public const uint ExpandingLength = 250u;
+	public static Easing ExpandingEasing { get; } = Easing.Linear;
+}

--- a/src/CommunityToolkit.Maui.Core/Primitives/ExpandedChangingEventArgs.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Primitives/ExpandedChangingEventArgs.shared.cs
@@ -1,0 +1,17 @@
+﻿namespace CommunityToolkit.Maui.Core;
+
+/// <summary>
+/// Provides data for an event that occurs when an Expander is about to change its IsExpanded state.
+/// </summary>
+public class ExpandedChangingEventArgs(bool oldIsExpanded, bool newIsExpanded) : EventArgs
+{
+	/// <summary>
+	/// True if expander was expanded before the change.
+	/// </summary>
+	public bool OldIsExpanded { get; } = oldIsExpanded;
+
+	/// <summary>
+	/// True if expander will be expanded after the change.
+	/// </summary>
+	public bool NewIsExpanded { get; } = newIsExpanded;
+}

--- a/src/CommunityToolkit.Maui.UnitTests/Views/Expander/ExpanderTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/Expander/ExpanderTests.cs
@@ -240,6 +240,16 @@ public class ExpanderTests : BaseViewTest
 		Assert.True(element.IsVisible);
 	}
 
+	[Fact]
+	public async Task ExpanderContentHostIsUnsetWhenContentIsRemoved()
+	{
+		var expander = new Expander();
+		expander.Content = new Label { Text = "Hello" };
+		Assert.NotNull(expander.ContentHost);
+		expander.Content = (IView)null!;
+		Assert.Null(expander.ContentHost);
+	}
+
 	class MockExpansionController : IExpansionController
 	{
 		public event EventHandler? Expanding;

--- a/src/CommunityToolkit.Maui.UnitTests/Views/Expander/ExpanderTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/Expander/ExpanderTests.cs
@@ -121,7 +121,7 @@ public class ExpanderTests : BaseViewTest
 		Assert.Equal(ExpanderDefaults.Direction, expander.Direction);
 	}
 
-	[Fact]
+	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ExpanderRaisesEventsInCorrectOrderWhenExpanding()
 	{
 		TaskCompletionSource tcs = new();
@@ -140,7 +140,7 @@ public class ExpanderTests : BaseViewTest
 		Assert.Equal("changing,controllerExpanding,changed,", callOrder.ToString());
 	}
 
-	[Fact]
+	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ExpanderCallsCorrectControllerMethod()
 	{
 		TaskCompletionSource tcs = new();
@@ -156,7 +156,7 @@ public class ExpanderTests : BaseViewTest
 		Assert.Equal(0, controller.CollapsingCount);
 	}
 
-	[Fact]
+	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ExpanderExpandsContentBecomesVisibleHeightRestored()
 	{
 		var tcs = new TaskCompletionSource();
@@ -174,7 +174,7 @@ public class ExpanderTests : BaseViewTest
 		Assert.Equal(-1, expander.ContentHost.HeightRequest);
 	}
 
-	[Fact]
+	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ExpanderCollapseContentHiddenHeightZero()
 	{
 		var expander = new Maui.Views.Expander();
@@ -193,7 +193,7 @@ public class ExpanderTests : BaseViewTest
 		Assert.Equal(0, expander.ContentHost.HeightRequest);
 	}
 
-	[Fact]
+	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ExpanderIsExpandedSetBeforeContentAssignedInitialStateCorrect()
 	{
 		var expander = new Maui.Views.Expander();
@@ -208,7 +208,7 @@ public class ExpanderTests : BaseViewTest
 	}
 
 	[Fact]
-	public async Task AttachingAnimationBehaviorSetsExpansionController()
+	public void AttachingAnimationBehaviorSetsExpansionController()
 	{
 		var expander = new Maui.Views.Expander();
 		var behavior = new ExpanderAnimationBehavior();
@@ -219,7 +219,7 @@ public class ExpanderTests : BaseViewTest
 		Assert.Same(behavior, expander.ExpansionController);
 	}
 
-	[Fact]
+	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task OnExpandingAsyncAnimatesHeightCorrectly()
 	{
 		var tcs = new TaskCompletionSource();

--- a/src/CommunityToolkit.Maui.UnitTests/Views/Expander/ExpanderTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/Expander/ExpanderTests.cs
@@ -1,5 +1,8 @@
 ﻿using System.ComponentModel;
+using System.Text;
+using CommunityToolkit.Maui.Behaviors;
 using CommunityToolkit.Maui.Core;
+using CommunityToolkit.Maui.Views;
 using FluentAssertions;
 using Xunit;
 
@@ -116,5 +119,147 @@ public class ExpanderTests : BaseViewTest
 	{
 		var expander = new Maui.Views.Expander();
 		Assert.Equal(ExpanderDefaults.Direction, expander.Direction);
+	}
+
+	[Fact]
+	public async Task ExpanderRaisesEventsInCorrectOrderWhenExpanding()
+	{
+		TaskCompletionSource tcs = new();
+		var expander = new Maui.Views.Expander();
+		StringBuilder callOrder = new();
+		expander.ExpandedChanging += (_, _) => callOrder.Append("changing,");
+		expander.ExpandedChanged += (_, _) => { callOrder.Append("changed,"); tcs.TrySetResult(); };
+		var controller = new MockExpansionController();
+		controller.Expanding += (_, _) => callOrder.Append("controllerExpanding,");
+		controller.Collapsing += (_, _) => callOrder.Append("controllerCollapsing,");
+		expander.ExpansionController = controller;
+		expander.Header = new Label { Text = "Header" };
+		expander.Content = new Label { Text = "Hello" };
+		expander.IsExpanded = true;
+		await tcs.Task;
+		Assert.Equal("changing,controllerExpanding,changed,", callOrder.ToString());
+	}
+
+	[Fact]
+	public async Task ExpanderCallsCorrectControllerMethod()
+	{
+		TaskCompletionSource tcs = new();
+		var expander = new Maui.Views.Expander();
+		expander.ExpandedChanged += (_, _) => tcs.TrySetResult();
+		var controller = new MockExpansionController();
+		expander.ExpansionController = controller;
+		expander.Header = new Label { Text = "Header" };
+		expander.Content = new Label { Text = "Hello" };
+		expander.IsExpanded = true;
+		await tcs.Task;
+		Assert.Equal(1, controller.ExpandingCount);
+		Assert.Equal(0, controller.CollapsingCount);
+	}
+
+	[Fact]
+	public async Task ExpanderExpandsContentBecomesVisibleHeightRestored()
+	{
+		var tcs = new TaskCompletionSource();
+		var expander = new Maui.Views.Expander();
+		expander.ExpandedChanged += (_, _) => tcs.TrySetResult();
+		expander.Header = new Label { Text = "Header" };
+		expander.Content = new Label { Text = "Hello" };
+		expander.IsExpanded = true;
+		await tcs.Task;
+		var element = expander.Content as VisualElement;
+		Assert.NotNull(expander.ContentHost);
+		Assert.NotNull(expander.Content);
+		Assert.NotNull(element);
+		Assert.True(element.IsVisible);
+		Assert.Equal(-1, expander.ContentHost.HeightRequest);
+	}
+
+	[Fact]
+	public async Task ExpanderCollapseContentHiddenHeightZero()
+	{
+		var expander = new Maui.Views.Expander();
+		expander.IsExpanded = true;
+		var tcs = new TaskCompletionSource();
+		expander.ExpandedChanged += (_, _) => tcs.TrySetResult();
+		expander.Header = new Label { Text = "Header" };
+		expander.Content = new Label { Text = "Hello" };
+		expander.IsExpanded = false;
+		await tcs.Task;
+		var element = expander.Content as VisualElement;
+		Assert.NotNull(expander.ContentHost);
+		Assert.NotNull(expander.Content);
+		Assert.NotNull(element);
+		Assert.False(element.IsVisible);
+		Assert.Equal(0, expander.ContentHost.HeightRequest);
+	}
+
+	[Fact]
+	public async Task ExpanderIsExpandedSetBeforeContentAssignedInitialStateCorrect()
+	{
+		var expander = new Maui.Views.Expander();
+		expander.IsExpanded = true;
+		expander.Header = new Label { Text = "Header" };
+		expander.Content = new Label { Text = "Hello" };
+		var element = expander.Content as VisualElement;
+		Assert.NotNull(expander.ContentHost);
+		Assert.NotNull(element);
+		Assert.True(element.IsVisible);
+		Assert.Equal(-1, expander.ContentHost.HeightRequest);
+	}
+
+	[Fact]
+	public async Task AttachingAnimationBehaviorSetsExpansionController()
+	{
+		var expander = new Maui.Views.Expander();
+		var behavior = new ExpanderAnimationBehavior();
+		expander.Behaviors.Add(behavior);
+		Assert.IsType<ExpanderAnimationBehavior>(expander.Behaviors[0]);
+		Assert.IsType<ExpanderAnimationBehavior>(behavior);
+		Assert.IsType<ExpanderAnimationBehavior>(expander.ExpansionController);
+		Assert.Same(behavior, expander.ExpansionController);
+	}
+
+	[Fact]
+	public async Task OnExpandingAsyncAnimatesHeightCorrectly()
+	{
+		var tcs = new TaskCompletionSource();
+		var expander = new Maui.Views.Expander();
+		expander.ExpandedChanged += (_, _) => tcs.TrySetResult();
+		var behavior = new ExpanderAnimationBehavior();
+		expander.Behaviors.Add(behavior);
+		expander.Header = new Label { Text = "Header" };
+		expander.Content = new Label { Text = "Hello" };
+		Assert.NotNull(expander.ContentHost);
+		expander.ContentHost.HeightRequest = 0;
+		expander.IsExpanded = true;
+		await tcs.Task;
+		var element = expander.Content as VisualElement;
+		Assert.True(expander.IsExpanded);
+		Assert.Equal(-1, expander.ContentHost.HeightRequest);
+		Assert.NotNull(element);
+		Assert.True(element.IsVisible);
+	}
+
+	class MockExpansionController : IExpansionController
+	{
+		public event EventHandler? Expanding;
+		public event EventHandler? Collapsing;
+
+		public int ExpandingCount { get; private set; } = 0;
+		public int CollapsingCount { get; private set; } = 0;
+
+		public async Task OnExpandingAsync(Expander expander)
+		{
+			await Task.Yield();
+			ExpandingCount++;
+			Expanding?.Invoke(this, EventArgs.Empty);
+		}
+
+		public async Task OnCollapsingAsync(Expander expander)
+		{
+			await Task.Yield();
+			CollapsingCount++;
+			Collapsing?.Invoke(this, EventArgs.Empty);
+		}
 	}
 }

--- a/src/CommunityToolkit.Maui.UnitTests/Views/Expander/ExpanderTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/Expander/ExpanderTests.cs
@@ -241,12 +241,12 @@ public class ExpanderTests : BaseViewTest
 	}
 
 	[Fact]
-	public async Task ExpanderContentHostIsUnsetWhenContentIsRemoved()
+	public void ExpanderContentHostIsUnsetWhenContentIsRemoved()
 	{
 		var expander = new Expander();
 		expander.Content = new Label { Text = "Hello" };
 		Assert.NotNull(expander.ContentHost);
-		expander.Content = (IView)null!;
+		expander.SetValue(Expander.ContentProperty, null);
 		Assert.Null(expander.ContentHost);
 	}
 

--- a/src/CommunityToolkit.Maui/Behaviors/ExpanderAnimationBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/ExpanderAnimationBehavior.shared.cs
@@ -1,0 +1,88 @@
+using CommunityToolkit.Maui.Core;
+using CommunityToolkit.Maui.Views;
+
+namespace CommunityToolkit.Maui.Behaviors;
+
+/// <summary>
+/// A behavior that adds smooth expand and collapse animations to an <see cref="Views.Expander"/>.
+/// </summary>
+public partial class ExpanderAnimationBehavior : BaseBehavior<Views.Expander>, IExpansionController
+{
+	/// <summary>
+	/// Gets or sets the easing function used when the expander collapses.
+	/// </summary>
+	[BindableProperty]
+	public partial Easing CollapsingEasing { get; set; } = ExpanderAnimationBehaviorDefaults.CollapsingEasing;
+
+	/// <summary>
+	/// Gets or sets the duration, in milliseconds, of the collapse animation.
+	/// </summary>
+	[BindableProperty]
+	public partial uint CollapsingLength { get; set; } = ExpanderAnimationBehaviorDefaults.CollapsingLength;
+
+	/// <summary>
+	/// Gets or sets the easing function used when the expander expands.
+	/// </summary>
+	[BindableProperty]
+	public partial Easing ExpandingEasing { get; set; } = ExpanderAnimationBehaviorDefaults.ExpandingEasing;
+
+	/// <summary>
+	/// Gets or sets the duration, in milliseconds, of the expansion animation.
+	/// </summary>
+	[BindableProperty]
+	public partial uint ExpandingLength { get; set; } = ExpanderAnimationBehaviorDefaults.ExpandingLength;
+
+	/// <summary>
+	/// Attaches the behavior to the specified expander and assigns it as the controller responsible for handling expansion animations.
+	/// </summary>
+	/// <param name="bindable">The Expander control to which the behavior is being attached to.</param>
+	protected override void OnAttachedTo(Views.Expander bindable)
+	{
+		base.OnAttachedTo(bindable);
+		bindable.ExpansionController = this;
+	}
+
+	/// <summary>
+	/// Detaches the behavior from the specified Expander control and resets its expansion controller to the shared instance.
+	/// </summary>
+	/// <param name="bindable">The Expander control from which the behavior is being detached from.</param>
+	protected override void OnDetachingFrom(Views.Expander bindable)
+	{
+		base.OnDetachingFrom(bindable);
+		bindable.ExpansionController = InstantExpansionController.Instance;
+	}
+
+	/// <summary>
+	/// Performs the animation that runs when the expander transitions from a collapsed to an expanded state.
+	/// </summary>
+	/// <param name="expander">The Expander control that is expanding.</param>
+	public async Task OnExpandingAsync(Views.Expander expander)
+	{
+		if (expander.ContentHost is ContentView host && expander.Content is View view)
+		{
+			var tcs = new TaskCompletionSource();
+			var size = view.Measure(host.Width, double.PositiveInfinity);
+			var animation = new Animation(v => host.HeightRequest = v, 0, size.Height);
+			animation.Commit(expander, "ExpandingAnimation", 16, ExpandingLength, ExpandingEasing, (v, c) => tcs.TrySetResult());
+			host.HeightRequest = -1;
+			await tcs.Task;
+		}
+	}
+
+	/// <summary>
+	/// Performs the animation that runs when the expander transitions from an expanded to a collapsed state.
+	/// </summary>
+	/// <param name="expander">The Expander control that is collapsing.</param>
+	public async Task OnCollapsingAsync(Views.Expander expander)
+	{
+		if (expander.ContentHost is ContentView host && expander.Content is View view)
+		{
+			var tcs = new TaskCompletionSource();
+			var size = view.Measure(host.Width, double.PositiveInfinity);
+			var animation = new Animation(v => host.HeightRequest = v, size.Height, 0);
+			animation.Commit(expander, "CollapsingAnimation", 16, CollapsingLength, CollapsingEasing, (v, c) => tcs.TrySetResult());
+			host.HeightRequest = 0;
+			await tcs.Task;
+		}
+	}
+}

--- a/src/CommunityToolkit.Maui/Behaviors/ExpanderAnimationBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/ExpanderAnimationBehavior.shared.cs
@@ -1,5 +1,4 @@
 using CommunityToolkit.Maui.Core;
-using CommunityToolkit.Maui.Views;
 
 namespace CommunityToolkit.Maui.Behaviors;
 
@@ -32,7 +31,7 @@ public partial class ExpanderAnimationBehavior : BaseBehavior<Views.Expander>, I
 	[BindableProperty]
 	public partial uint ExpandingLength { get; set; } = ExpanderAnimationBehaviorDefaults.ExpandingLength;
 
-	IExpansionController previousController = InstantExpansionController.Instance;
+	IExpansionController? previousController;
 
 	/// <summary>
 	/// Attaches the behavior to the specified expander and assigns it as the controller responsible for handling expansion animations.
@@ -41,7 +40,7 @@ public partial class ExpanderAnimationBehavior : BaseBehavior<Views.Expander>, I
 	protected override void OnAttachedTo(Views.Expander bindable)
 	{
 		base.OnAttachedTo(bindable);
-		previousController = bindable.ExpansionController ?? InstantExpansionController.Instance;
+		previousController = bindable.ExpansionController;
 		bindable.ExpansionController = this;
 	}
 
@@ -66,7 +65,7 @@ public partial class ExpanderAnimationBehavior : BaseBehavior<Views.Expander>, I
 	{
 		if (expander.ContentHost is ContentView host && expander.Content is View view)
 		{
-			var tcs = new TaskCompletionSource();
+			var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 			var size = view.Measure(host.Width, double.PositiveInfinity);
 			var animation = new Animation(v => host.HeightRequest = v, 0, size.Height);
 			animation.Commit(expander, "ExpanderAnimation", 16, ExpandingLength, ExpandingEasing,
@@ -83,7 +82,7 @@ public partial class ExpanderAnimationBehavior : BaseBehavior<Views.Expander>, I
 	{
 		if (expander.ContentHost is ContentView host && expander.Content is View view)
 		{
-			var tcs = new TaskCompletionSource();
+			var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 			var size = view.Measure(host.Width, double.PositiveInfinity);
 			var animation = new Animation(v => host.HeightRequest = v, size.Height, 0);
 			animation.Commit(expander, "ExpanderAnimation", 16, CollapsingLength, CollapsingEasing,

--- a/src/CommunityToolkit.Maui/Behaviors/ExpanderAnimationBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/ExpanderAnimationBehavior.shared.cs
@@ -68,9 +68,9 @@ public partial class ExpanderAnimationBehavior : BaseBehavior<Views.Expander>, I
 			var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 			var size = view.Measure(host.Width, double.PositiveInfinity);
 			var animation = new Animation(v => host.HeightRequest = v, 0, size.Height);
-			animation.Commit(expander, "ExpanderAnimation", 16, ExpandingLength, ExpandingEasing,
-				(v, c) => { tcs.TrySetResult(); host.HeightRequest = -1; });
+			animation.Commit(expander, "ExpanderAnimation", 16, ExpandingLength, ExpandingEasing, (v, c) => tcs.TrySetResult());
 			await tcs.Task;
+			host.HeightRequest = -1;
 		}
 	}
 
@@ -85,9 +85,9 @@ public partial class ExpanderAnimationBehavior : BaseBehavior<Views.Expander>, I
 			var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 			var size = view.Measure(host.Width, double.PositiveInfinity);
 			var animation = new Animation(v => host.HeightRequest = v, size.Height, 0);
-			animation.Commit(expander, "ExpanderAnimation", 16, CollapsingLength, CollapsingEasing,
-				(v, c) => { tcs.TrySetResult(); host.HeightRequest = 0; });
+			animation.Commit(expander, "ExpanderAnimation", 16, CollapsingLength, CollapsingEasing, (v, c) => tcs.TrySetResult());
 			await tcs.Task;
+			host.HeightRequest = 0;
 		}
 	}
 }

--- a/src/CommunityToolkit.Maui/Behaviors/ExpanderAnimationBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/ExpanderAnimationBehavior.shared.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.Maui.Core;
+using CommunityToolkit.Maui.Views;
 
 namespace CommunityToolkit.Maui.Behaviors;
 
@@ -31,6 +32,8 @@ public partial class ExpanderAnimationBehavior : BaseBehavior<Views.Expander>, I
 	[BindableProperty]
 	public partial uint ExpandingLength { get; set; } = ExpanderAnimationBehaviorDefaults.ExpandingLength;
 
+	IExpansionController previousController = InstantExpansionController.Instance;
+
 	/// <summary>
 	/// Attaches the behavior to the specified expander and assigns it as the controller responsible for handling expansion animations.
 	/// </summary>
@@ -38,7 +41,21 @@ public partial class ExpanderAnimationBehavior : BaseBehavior<Views.Expander>, I
 	protected override void OnAttachedTo(Views.Expander bindable)
 	{
 		base.OnAttachedTo(bindable);
+		previousController = bindable.ExpansionController ?? InstantExpansionController.Instance;
 		bindable.ExpansionController = this;
+	}
+
+	/// <summary>
+	/// Detaches the behavior from the specified Expander control and restores its previous expansion controller.
+	/// </summary>
+	/// <param name="bindable">The Expander control from which the behavior is being detached.</param>
+	protected override void OnDetachingFrom(Views.Expander bindable)
+	{
+		base.OnDetachingFrom(bindable);
+		if (bindable.ExpansionController == this)
+		{
+			bindable.ExpansionController = previousController;
+		}
 	}
 
 	/// <summary>

--- a/src/CommunityToolkit.Maui/Behaviors/ExpanderAnimationBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/ExpanderAnimationBehavior.shared.cs
@@ -1,5 +1,4 @@
 using CommunityToolkit.Maui.Core;
-using CommunityToolkit.Maui.Views;
 
 namespace CommunityToolkit.Maui.Behaviors;
 
@@ -43,16 +42,6 @@ public partial class ExpanderAnimationBehavior : BaseBehavior<Views.Expander>, I
 	}
 
 	/// <summary>
-	/// Detaches the behavior from the specified Expander control and resets its expansion controller to the shared instance.
-	/// </summary>
-	/// <param name="bindable">The Expander control from which the behavior is being detached from.</param>
-	protected override void OnDetachingFrom(Views.Expander bindable)
-	{
-		base.OnDetachingFrom(bindable);
-		bindable.ExpansionController = InstantExpansionController.Instance;
-	}
-
-	/// <summary>
 	/// Performs the animation that runs when the expander transitions from a collapsed to an expanded state.
 	/// </summary>
 	/// <param name="expander">The Expander control that is expanding.</param>
@@ -63,8 +52,8 @@ public partial class ExpanderAnimationBehavior : BaseBehavior<Views.Expander>, I
 			var tcs = new TaskCompletionSource();
 			var size = view.Measure(host.Width, double.PositiveInfinity);
 			var animation = new Animation(v => host.HeightRequest = v, 0, size.Height);
-			animation.Commit(expander, "ExpandingAnimation", 16, ExpandingLength, ExpandingEasing, (v, c) => tcs.TrySetResult());
-			host.HeightRequest = -1;
+			animation.Commit(expander, "ExpanderAnimation", 16, ExpandingLength, ExpandingEasing,
+				(v, c) => { tcs.TrySetResult(); host.HeightRequest = -1; });
 			await tcs.Task;
 		}
 	}
@@ -80,8 +69,8 @@ public partial class ExpanderAnimationBehavior : BaseBehavior<Views.Expander>, I
 			var tcs = new TaskCompletionSource();
 			var size = view.Measure(host.Width, double.PositiveInfinity);
 			var animation = new Animation(v => host.HeightRequest = v, size.Height, 0);
-			animation.Commit(expander, "CollapsingAnimation", 16, CollapsingLength, CollapsingEasing, (v, c) => tcs.TrySetResult());
-			host.HeightRequest = 0;
+			animation.Commit(expander, "ExpanderAnimation", 16, CollapsingLength, CollapsingEasing,
+				(v, c) => { tcs.TrySetResult(); host.HeightRequest = 0; });
 			await tcs.Task;
 		}
 	}

--- a/src/CommunityToolkit.Maui/Interfaces/IExpansionController.shared.cs
+++ b/src/CommunityToolkit.Maui/Interfaces/IExpansionController.shared.cs
@@ -1,0 +1,24 @@
+﻿namespace CommunityToolkit.Maui;
+
+/// <summary>
+/// Defines a pluggable controller responsible for handling expansion
+/// and collapse transitions for an <see cref="Views.Expander"/>.
+/// </summary>
+public interface IExpansionController
+{
+	/// <summary>
+	/// Executes asynchronous logic when the expander transitions
+	/// from a collapsed to an expanded state.
+	/// </summary>
+	/// <param name="expander">The <see cref="Views.Expander"/> instance initiating the expansion.</param>
+	/// <returns>A task representing the asynchronous operation.</returns>
+	Task OnExpandingAsync(Views.Expander expander);
+
+	/// <summary>
+	/// Executes asynchronous logic when the expander transitions
+	/// from an expanded to a collapsed state.
+	/// </summary>
+	/// <param name="expander">The <see cref="Views.Expander"/> instance initiating the collapse.</param>
+	/// <returns>A task representing the asynchronous operation.</returns>
+	Task OnCollapsingAsync(Views.Expander expander);
+}

--- a/src/CommunityToolkit.Maui/Views/Expander/Expander.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Expander/Expander.shared.cs
@@ -131,7 +131,16 @@ public partial class Expander : ContentView, IExpander
 			{
 				expander.ContentGrid.Remove(expander.ContentHost);
 			}
-			expander.ContentHost = new ContentView { Content = view, IsClippedToBounds = true, HeightRequest = 0 };
+
+			// Initialize content visibility and height based on the current expansion state
+			view.IsVisible = expander.IsExpanded;
+			expander.ContentHost = new ContentView
+			{
+				Content = view,
+				IsClippedToBounds = true,
+				HeightRequest = expander.IsExpanded ? -1 : 0
+			};
+
 			expander.ContentGrid.Add(expander.ContentHost);
 			expander.ContentGrid.SetRow(expander.ContentHost, expander.Direction switch
 			{
@@ -171,7 +180,7 @@ public partial class Expander : ContentView, IExpander
 
 	void HandleDirectionChanged(ExpandDirection expandDirection)
 	{
-		if (Header is null || Content is null)
+		if (Header is null || ContentHost is null)
 		{
 			return;
 		}
@@ -180,12 +189,12 @@ public partial class Expander : ContentView, IExpander
 		{
 			case ExpandDirection.Down:
 				ContentGrid.SetRow(Header, 0);
-				ContentGrid.SetRow(Content, 1);
+				ContentGrid.SetRow(ContentHost, 1);
 				break;
 
 			case ExpandDirection.Up:
 				ContentGrid.SetRow(Header, 1);
-				ContentGrid.SetRow(Content, 0);
+				ContentGrid.SetRow(ContentHost, 0);
 				break;
 
 			default:
@@ -244,10 +253,6 @@ public partial class Expander : ContentView, IExpander
 			if (element.Parent is ListView listView && element is Cell cell)
 			{
 				cell.ForceUpdateSize();
-			}
-			else if (element is CollectionView collectionView)
-			{
-				var tapLocation = tappedEventArgs.GetPosition(collectionView);
 			}
 #endif
 

--- a/src/CommunityToolkit.Maui/Views/Expander/Expander.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Expander/Expander.shared.cs
@@ -215,14 +215,24 @@ public partial class Expander : ContentView, IExpander
 		HandleHeaderTapped?.Invoke(tappedEventArgs);
 	}
 
-	TaskCompletionSource resizeTCS = new();
+	TaskCompletionSource expansionGate = new();
+
+	Task WaitForExpandedChangedAsync()
+	{
+		if (!expansionGate.Task.IsCompleted)
+		{
+			return expansionGate.Task;
+		}
+
+		expansionGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+		return expansionGate.Task;
+	}
 
 	void ResizeExpanderInItemsView(TappedEventArgs tappedEventArgs)
 	{
 		_ = Dispatcher.Dispatch(async () =>
 		{
-			resizeTCS = new();
-			await resizeTCS.Task;
+			await WaitForExpandedChangedAsync();
 			ResizeExpanderInItemsView2(tappedEventArgs);
 		});
 	}
@@ -269,23 +279,28 @@ public partial class Expander : ContentView, IExpander
 	{
 		expandedChangingEventManager.HandleEvent(this, new ExpandedChangingEventArgs(wasExpanded, isExpanded), nameof(ExpandedChanging));
 
-		if (ContentHost is ContentView host && Content is View view)
+		try
 		{
-			if (!wasExpanded && isExpanded)
+			if (ContentHost is ContentView host && Content is View view)
 			{
-				view.IsVisible = true;
-				await ExpansionController.OnExpandingAsync(this);
-				host.HeightRequest = -1;
-			}
-			else
-			{
-				await ExpansionController.OnCollapsingAsync(this);
-				host.HeightRequest = 0;
-				view.IsVisible = false;
+				if (!wasExpanded && isExpanded)
+				{
+					view.IsVisible = true;
+					await ExpansionController.OnExpandingAsync(this);
+					host.HeightRequest = -1;
+				}
+				else
+				{
+					await ExpansionController.OnCollapsingAsync(this);
+					host.HeightRequest = 0;
+					view.IsVisible = false;
+				}
 			}
 		}
-
-		resizeTCS.TrySetResult();
+		finally
+		{
+			expansionGate.TrySetResult();
+		}
 
 		if (Command?.CanExecute(CommandParameter) is true)
 		{

--- a/src/CommunityToolkit.Maui/Views/Expander/Expander.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Expander/Expander.shared.cs
@@ -243,11 +243,6 @@ public partial class Expander : ContentView, IExpander
 		}
 
 		Element element = this;
-#if WINDOWS
-		var size = IsExpanded
-					? Measure(double.PositiveInfinity, double.PositiveInfinity)
-					: Header.Measure(double.PositiveInfinity, double.PositiveInfinity);
-#endif
 		while (element is not null)
 		{
 #if IOS || MACCATALYST

--- a/src/CommunityToolkit.Maui/Views/Expander/Expander.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Expander/Expander.shared.cs
@@ -70,7 +70,7 @@ public partial class Expander : ContentView, IExpander
 	/// <summary>
 	/// Gets or sets a value indicating whether the expander is expanded.
 	/// </summary>
-	[BindableProperty(PropertyChangedMethodName = nameof(OnIsExpandedPropertyChanged))]
+	[BindableProperty(PropertyChangingMethodName = nameof(OnIsExpandedPropertyChanging), PropertyChangedMethodName = nameof(OnIsExpandedPropertyChanged))]
 	public partial bool IsExpanded { get; set; }
 
 	/// <summary>
@@ -90,7 +90,7 @@ public partial class Expander : ContentView, IExpander
 	/// logic for this expander, including any optional animations.
 	/// </summary>
 	[BindableProperty]
-	public partial IExpansionController ExpansionController { get; set; } = InstantExpansionController.Instance;
+	public partial IExpansionController? ExpansionController { get; set; }
 
 	/// <summary>
 	/// The Action that fires when <see cref="Header"/> is tapped.
@@ -168,6 +168,12 @@ public partial class Expander : ContentView, IExpander
 				_ => throw new NotSupportedException($"{nameof(ExpandDirection)} {expander.Direction} is not yet supported")
 			});
 		}
+	}
+
+	static void OnIsExpandedPropertyChanging(BindableObject bindable, object oldValue, object newValue)
+	{
+		Expander expander = (Expander)bindable;
+		expander.expandedChangingEventManager.HandleEvent(expander, new ExpandedChangingEventArgs((bool)oldValue, (bool)newValue), nameof(ExpandedChanging));
 	}
 
 	static void OnIsExpandedPropertyChanged(BindableObject bindable, object oldValue, object newValue)
@@ -277,21 +283,20 @@ public partial class Expander : ContentView, IExpander
 
 	async Task ExpandedChangedAsync(bool wasExpanded, bool isExpanded)
 	{
-		expandedChangingEventManager.HandleEvent(this, new ExpandedChangingEventArgs(wasExpanded, isExpanded), nameof(ExpandedChanging));
-
 		try
 		{
 			if (ContentHost is ContentView host && Content is View view)
 			{
+				IExpansionController controller = ExpansionController ?? InstantExpansionController.Instance;
 				if (!wasExpanded && isExpanded)
 				{
 					view.IsVisible = true;
-					await ExpansionController.OnExpandingAsync(this);
+					await controller.OnExpandingAsync(this);
 					host.HeightRequest = -1;
 				}
 				else
 				{
-					await ExpansionController.OnCollapsingAsync(this);
+					await controller.OnCollapsingAsync(this);
 					host.HeightRequest = 0;
 					view.IsVisible = false;
 				}

--- a/src/CommunityToolkit.Maui/Views/Expander/Expander.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Expander/Expander.shared.cs
@@ -311,9 +311,10 @@ public partial class Expander : ContentView, IExpander
 	}
 }
 
-class InstantExpansionController : IExpansionController
+sealed class InstantExpansionController : IExpansionController
 {
 	public static InstantExpansionController Instance { get; } = new();
+	InstantExpansionController() { }
 	public Task OnExpandingAsync(Expander expander) => Task.CompletedTask;
 	public Task OnCollapsingAsync(Expander expander) => Task.CompletedTask;
 }

--- a/src/CommunityToolkit.Maui/Views/Expander/Expander.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Expander/Expander.shared.cs
@@ -173,6 +173,7 @@ public partial class Expander : ContentView, IExpander
 	static void OnIsExpandedPropertyChanging(BindableObject bindable, object oldValue, object newValue)
 	{
 		Expander expander = (Expander)bindable;
+		expander.expansionGate = new();
 		expander.expandedChangingEventManager.HandleEvent(expander, new ExpandedChangingEventArgs((bool)oldValue, (bool)newValue), nameof(ExpandedChanging));
 	}
 
@@ -223,22 +224,11 @@ public partial class Expander : ContentView, IExpander
 
 	TaskCompletionSource expansionGate = new();
 
-	Task WaitForExpandedChangedAsync()
-	{
-		if (!expansionGate.Task.IsCompleted)
-		{
-			return expansionGate.Task;
-		}
-
-		expansionGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
-		return expansionGate.Task;
-	}
-
 	void ResizeExpanderInItemsView(TappedEventArgs tappedEventArgs)
 	{
 		_ = Dispatcher.Dispatch(async () =>
 		{
-			await WaitForExpandedChangedAsync();
+			await expansionGate.Task;
 			ResizeExpanderInItemsView2(tappedEventArgs);
 		});
 	}

--- a/src/CommunityToolkit.Maui/Views/Expander/Expander.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Expander/Expander.shared.cs
@@ -125,13 +125,15 @@ public partial class Expander : ContentView, IExpander
 	static void OnContentPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 	{
 		var expander = (Expander)bindable;
+
+		if (expander.ContentHost is not null)
+		{
+			expander.ContentGrid.Remove(expander.ContentHost);
+			expander.ContentHost = null;
+		}
+
 		if (newValue is View view)
 		{
-			if (expander.ContentHost is not null)
-			{
-				expander.ContentGrid.Remove(expander.ContentHost);
-			}
-
 			// Initialize content visibility and height based on the current expansion state
 			view.IsVisible = expander.IsExpanded;
 			expander.ContentHost = new ContentView
@@ -173,7 +175,7 @@ public partial class Expander : ContentView, IExpander
 	static void OnIsExpandedPropertyChanging(BindableObject bindable, object oldValue, object newValue)
 	{
 		Expander expander = (Expander)bindable;
-		expander.expansionGate = new();
+		expander.expansionGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
 		expander.expandedChangingEventManager.HandleEvent(expander, new ExpandedChangingEventArgs((bool)oldValue, (bool)newValue), nameof(ExpandedChanging));
 	}
 


### PR DESCRIPTION
…EventArgs

<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

Enables animated expand/collapse behavior for the `Expander` by wrapping the user’s content `Expander.Content` in a `Expander.ContentHost` (ContentView) and animating changes to `Expander.ContentHost.HeightRequest`.

 - Add `Expander.ContentHost` property (read-only).
 - Add `IExpansionController` interface.
 - Add `Expander.ExpansionController` property.
 - Add `Expander.ExpandedChanging` event with `ExpandedChangingEventArgs`.
 - Add `ExpansionAnimationBehavior` behavior.
 - Update the sample app to demonstrate `ExpandedAnimationBehavior`.

Opt in to animations by assigning `ExpansionAnimationBehavior` to either (1) `Expander.Behaviors`, or (2) `Expander.ExpansionController`. Alternatively, custom animations can be created by implementing `IExpansionController`.

 ### Linked Issues ###
 
  - Fixes #2521
  - Discussion https://github.com/CommunityToolkit/Maui/discussions/1628
  - Replace old PR https://github.com/CommunityToolkit/Maui/pull/2723
  - Replace old PR https://github.com/CommunityToolkit/Maui/pull/2522

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: TODO: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

This is a reboot of the work that began in PR #2723 and PR #2522.