### PR TITLE
Explicitly target iOS and macOS to osx and Windows platforms (only)

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -43,6 +43,7 @@
     <None Include="**\net\**\*.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
   </ItemGroup>
   <!-- iOS and macCatalyst workloads are only available on macOS/Windows -->
+    <!-- The following PropertyGroup ensures no build errors on Linux  -->
   <PropertyGroup Condition="!$([MSBuild]::IsOSPlatform('osx')) AND !$([MSBuild]::IsOSPlatform('windows')) AND ($(TargetFrameworks.Contains('-ios')) OR $(TargetFrameworks.Contains('-maccatalyst')))">
      <TargetFrameworks>$(NetVersion);$(NetVersion)-android</TargetFrameworks>
      <TargetFrameworks Condition="'$(OutputType)' == 'Exe'">$(NetVersion)-android</TargetFrameworks>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -42,4 +42,11 @@
     <Compile Remove="**\net\**\*.cs" />
     <None Include="**\net\**\*.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
   </ItemGroup>
+  <!-- iOS and macCatalyst workloads are only available on macOS/Windows -->
+  <PropertyGroup Condition="!$([MSBuild]::IsOSPlatform('osx')) AND !$([MSBuild]::IsOSPlatform('windows')) AND $(TargetFrameworks.Contains('-ios'))">
+    <TargetFrameworks>$(NetVersion);$(NetVersion)-android</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OutputType)' == 'Exe'">$(NetVersion)-android</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IncludeTizenTargetFrameworks)' == 'true'">$(TargetFrameworks);$(NetVersion)-tizen</TargetFrameworks>
+  </PropertyGroup>
+
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -46,9 +46,7 @@
   <PropertyGroup Condition="!$([MSBuild]::IsOSPlatform('osx')) AND !$([MSBuild]::IsOSPlatform('windows')) AND ($(TargetFrameworks.Contains('-ios')) OR $(TargetFrameworks.Contains('-maccatalyst')))">
      <TargetFrameworks>$(NetVersion);$(NetVersion)-android</TargetFrameworks>
      <TargetFrameworks Condition="'$(OutputType)' == 'Exe'">$(NetVersion)-android</TargetFrameworks>
-    <TargetFrameworks>$(NetVersion);$(NetVersion)-android</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OutputType)' == 'Exe'">$(NetVersion)-android</TargetFrameworks>
-    <TargetFrameworks Condition="'$(IncludeTizenTargetFrameworks)' == 'true'">$(TargetFrameworks);$(NetVersion)-tizen</TargetFrameworks>
+     <TargetFrameworks Condition="'$(IncludeTizenTargetFrameworks)' == 'true'">$(TargetFrameworks);$(NetVersion)-tizen</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -43,7 +43,9 @@
     <None Include="**\net\**\*.cs" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
   </ItemGroup>
   <!-- iOS and macCatalyst workloads are only available on macOS/Windows -->
-  <PropertyGroup Condition="!$([MSBuild]::IsOSPlatform('osx')) AND !$([MSBuild]::IsOSPlatform('windows')) AND $(TargetFrameworks.Contains('-ios'))">
+  <PropertyGroup Condition="!$([MSBuild]::IsOSPlatform('osx')) AND !$([MSBuild]::IsOSPlatform('windows')) AND ($(TargetFrameworks.Contains('-ios')) OR $(TargetFrameworks.Contains('-maccatalyst')))">
+     <TargetFrameworks>$(NetVersion);$(NetVersion)-android</TargetFrameworks>
+     <TargetFrameworks Condition="'$(OutputType)' == 'Exe'">$(NetVersion)-android</TargetFrameworks>
     <TargetFrameworks>$(NetVersion);$(NetVersion)-android</TargetFrameworks>
     <TargetFrameworks Condition="'$(OutputType)' == 'Exe'">$(NetVersion)-android</TargetFrameworks>
     <TargetFrameworks Condition="'$(IncludeTizenTargetFrameworks)' == 'true'">$(TargetFrameworks);$(NetVersion)-tizen</TargetFrameworks>


### PR DESCRIPTION

<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->

Adds MS Build conditions to explicitly exclude macOS and iOS TFMs when the OS is not macOS or Windows.

No tests included as it would require adding a new workflow with a Linux-targetted runner specifically just for this one test. That's probably not necessary; however could be useful in future as would allow building Android (and Tizen) binaries on a Linux runner. Might be worth considering, but for now I did not want to introduce a workflow just for that.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #3185

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: N/A - not related to public docs. I also checked the contributing guide and there was nothing there to update.


 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
Just confirming that this is a no-op for any existing users, and just enables development on Linux.