### PR TITLE
Prevent race conditions in BindableProperty tests and benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -49,11 +49,16 @@ jobs:
             -   name: Display dotnet info
                 run: dotnet --info
 
+            -   name: Build Benchmarks
+                run: |
+                    dotnet build ${{ env.PathToCommunityToolkitAnalyzersBenchmarksCsproj }} -c Release
+                    dotnet build ${{ env.PathToCommunityToolkitSourceGeneratorsBenchmarksCsproj }} -c Release
+
             -   name: Run Analyzer Benchmarks
-                run: dotnet run --project ${{ env.PathToCommunityToolkitAnalyzersBenchmarksCsproj }} -c Release -- -a "${{ runner.temp }}"
+                run: dotnet run --project ${{ env.PathToCommunityToolkitAnalyzersBenchmarksCsproj }} -c Release --no-build -- -a "${{ runner.temp }}"
 
             -   name: Run Source Generator Benchmarks
-                run: dotnet run --project ${{ env.PathToCommunityToolkitSourceGeneratorsBenchmarksCsproj }} -c Release -- -a "${{ runner.temp }}"
+                run: dotnet run --project ${{ env.PathToCommunityToolkitSourceGeneratorsBenchmarksCsproj }} -c Release --no-build -- -a "${{ runner.temp }}"
 
             -   name: Publish Benchmarks
                 uses: actions/upload-artifact@v7

--- a/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyAttributeSourceGeneratorTests/BindablePropertyAttributeSourceGenerator_CommonUsageTests.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyAttributeSourceGeneratorTests/BindablePropertyAttributeSourceGenerator_CommonUsageTests.cs
@@ -610,22 +610,36 @@ public class BindablePropertyAttributeSourceGenerator_CommonUsageTests : BaseBin
 
 			file static class __{{defaultTestClassName}}BindablePropertyInitHelpers
 			{
-			    public static volatile bool IsInitializingText = false;
+			    [global::System.ThreadStatic]
+			    public static bool IsInitializingText;
 			    public static object CreateDefaultText(global::Microsoft.Maui.Controls.BindableObject bindable)
 			    {
 			        IsInitializingText = true;
-			        var defaultValue = ((TestView)bindable).Text;
-			        IsInitializingText = false;
-			        return defaultValue;
+			        try
+			        {
+			            var defaultValue = ((TestView)bindable).Text;
+			            return defaultValue;
+			        }
+			        finally
+			        {
+			            IsInitializingText = false;
+			        }
 			    }
 			
-			    public static volatile bool IsInitializingCustomDuration = false;
+			    [global::System.ThreadStatic]
+			    public static bool IsInitializingCustomDuration;
 			    public static object CreateDefaultCustomDuration(global::Microsoft.Maui.Controls.BindableObject bindable)
 			    {
 			        IsInitializingCustomDuration = true;
-			        var defaultValue = ((TestView)bindable).CustomDuration;
-			        IsInitializingCustomDuration = false;
-			        return defaultValue;
+			        try
+			        {
+			            var defaultValue = ((TestView)bindable).CustomDuration;
+			            return defaultValue;
+			        }
+			        finally
+			        {
+			            IsInitializingCustomDuration = false;
+			        }
 			    }
 			}
 			""";

--- a/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyAttributeSourceGeneratorTests/BindablePropertyAttributeSourceGenerator_CommonUsageTests.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyAttributeSourceGeneratorTests/BindablePropertyAttributeSourceGenerator_CommonUsageTests.cs
@@ -595,50 +595,39 @@ public class BindablePropertyAttributeSourceGenerator_CommonUsageTests : BaseBin
 			namespace {{defaultTestNamespace}};
 			public partial class {{defaultTestClassName}}
 			{
+			    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+			    bool __isInitializingText;
 			    /// <summary>
 			    /// BindableProperty for the <see cref = "Text"/> property.
 			    /// </summary>
-			    public static readonly global::Microsoft.Maui.Controls.BindableProperty TextProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Text", typeof(string), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultText);
-			    public partial string Text { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingText ? field : (string)GetValue(TextProperty); set => SetValue(TextProperty, value); }
+			    public static readonly global::Microsoft.Maui.Controls.BindableProperty TextProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Text", typeof(string), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __BindablePropertyInitHelpers.CreateDefaultText);
+			    public partial string Text { get => __isInitializingText ? field : (string)GetValue(TextProperty); set => SetValue(TextProperty, value); }
 
+			    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+			    bool __isInitializingCustomDuration;
 			    /// <summary>
 			    /// BindableProperty for the <see cref = "CustomDuration"/> property.
 			    /// </summary>
-			    public static readonly global::Microsoft.Maui.Controls.BindableProperty CustomDurationProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("CustomDuration", typeof(System.TimeSpan), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultCustomDuration);
-			    public partial System.TimeSpan CustomDuration { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingCustomDuration ? field : (System.TimeSpan)GetValue(CustomDurationProperty); set => SetValue(CustomDurationProperty, value); }
-			}
+			    public static readonly global::Microsoft.Maui.Controls.BindableProperty CustomDurationProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("CustomDuration", typeof(System.TimeSpan), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __BindablePropertyInitHelpers.CreateDefaultCustomDuration);
+			    public partial System.TimeSpan CustomDuration { get => __isInitializingCustomDuration ? field : (System.TimeSpan)GetValue(CustomDurationProperty); set => SetValue(CustomDurationProperty, value); }
 
-			file static class __{{defaultTestClassName}}BindablePropertyInitHelpers
-			{
-			    [global::System.ThreadStatic]
-			    public static bool IsInitializingText;
-			    public static object CreateDefaultText(global::Microsoft.Maui.Controls.BindableObject bindable)
+			    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+			    static class __BindablePropertyInitHelpers
 			    {
-			        IsInitializingText = true;
-			        try
+			        public static object CreateDefaultText(global::Microsoft.Maui.Controls.BindableObject bindable)
 			        {
-			            var defaultValue = ((TestView)bindable).Text;
+			            (({{defaultTestClassName}})bindable).__isInitializingText = true;
+			            var defaultValue = (({{defaultTestClassName}})bindable).Text;
+			            (({{defaultTestClassName}})bindable).__isInitializingText = false;
 			            return defaultValue;
 			        }
-			        finally
+
+			        public static object CreateDefaultCustomDuration(global::Microsoft.Maui.Controls.BindableObject bindable)
 			        {
-			            IsInitializingText = false;
-			        }
-			    }
-			
-			    [global::System.ThreadStatic]
-			    public static bool IsInitializingCustomDuration;
-			    public static object CreateDefaultCustomDuration(global::Microsoft.Maui.Controls.BindableObject bindable)
-			    {
-			        IsInitializingCustomDuration = true;
-			        try
-			        {
-			            var defaultValue = ((TestView)bindable).CustomDuration;
+			            (({{defaultTestClassName}})bindable).__isInitializingCustomDuration = true;
+			            var defaultValue = (({{defaultTestClassName}})bindable).CustomDuration;
+			            (({{defaultTestClassName}})bindable).__isInitializingCustomDuration = false;
 			            return defaultValue;
-			        }
-			        finally
-			        {
-			            IsInitializingCustomDuration = false;
 			        }
 			    }
 			}

--- a/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyAttributeSourceGeneratorTests/BindablePropertyAttributeSourceGenerator_EdgeCaseTests.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyAttributeSourceGeneratorTests/BindablePropertyAttributeSourceGenerator_EdgeCaseTests.cs
@@ -91,28 +91,23 @@ public class BindablePropertyAttributeSourceGenerator_EdgeCaseTests : BaseBindab
             namespace {{defaultTestNamespace}};
             public partial class {{defaultTestClassName}}
             {
+                [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+                bool __isInitializingInvoiceStatus;
                 /// <summary>
                 /// BindableProperty for the <see cref = "InvoiceStatus"/> property.
                 /// </summary>
-                public static readonly global::Microsoft.Maui.Controls.BindableProperty InvoiceStatusProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("InvoiceStatus", typeof(TestNamespace.Status), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultInvoiceStatus);
-                public partial TestNamespace.Status InvoiceStatus { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingInvoiceStatus ? field : (TestNamespace.Status)GetValue(InvoiceStatusProperty); set => SetValue(InvoiceStatusProperty, value); }
-            }
+                public static readonly global::Microsoft.Maui.Controls.BindableProperty InvoiceStatusProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("InvoiceStatus", typeof(TestNamespace.Status), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __BindablePropertyInitHelpers.CreateDefaultInvoiceStatus);
+                public partial TestNamespace.Status InvoiceStatus { get => __isInitializingInvoiceStatus ? field : (TestNamespace.Status)GetValue(InvoiceStatusProperty); set => SetValue(InvoiceStatusProperty, value); }
 
-            file static class __{{defaultTestClassName}}BindablePropertyInitHelpers
-            {
-                [global::System.ThreadStatic]
-                public static bool IsInitializingInvoiceStatus;
-                public static object CreateDefaultInvoiceStatus(global::Microsoft.Maui.Controls.BindableObject bindable)
+                [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+                static class __BindablePropertyInitHelpers
                 {
-                    IsInitializingInvoiceStatus = true;
-                    try
+                    public static object CreateDefaultInvoiceStatus(global::Microsoft.Maui.Controls.BindableObject bindable)
                     {
-                        var defaultValue = ((TestView)bindable).InvoiceStatus;
+                        (({{defaultTestClassName}})bindable).__isInitializingInvoiceStatus = true;
+                        var defaultValue = (({{defaultTestClassName}})bindable).InvoiceStatus;
+                        (({{defaultTestClassName}})bindable).__isInitializingInvoiceStatus = false;
                         return defaultValue;
-                    }
-                    finally
-                    {
-                        IsInitializingInvoiceStatus = false;
                     }
                 }
             }
@@ -158,28 +153,23 @@ public class BindablePropertyAttributeSourceGenerator_EdgeCaseTests : BaseBindab
             namespace {{defaultTestNamespace}};
             public partial class {{defaultTestClassName}}
             {
+                [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+                bool __isInitializingInvoiceStatus;
                 /// <summary>
                 /// BindableProperty for the <see cref = "InvoiceStatus"/> property.
                 /// </summary>
-                public static readonly global::Microsoft.Maui.Controls.BindableProperty InvoiceStatusProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("InvoiceStatus", typeof(TestNamespace.Status), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultInvoiceStatus);
-                public partial TestNamespace.Status InvoiceStatus { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingInvoiceStatus ? field : (TestNamespace.Status)GetValue(InvoiceStatusProperty); set => SetValue(InvoiceStatusProperty, value); }
-            }
+                public static readonly global::Microsoft.Maui.Controls.BindableProperty InvoiceStatusProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("InvoiceStatus", typeof(TestNamespace.Status), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __BindablePropertyInitHelpers.CreateDefaultInvoiceStatus);
+                public partial TestNamespace.Status InvoiceStatus { get => __isInitializingInvoiceStatus ? field : (TestNamespace.Status)GetValue(InvoiceStatusProperty); set => SetValue(InvoiceStatusProperty, value); }
 
-            file static class __{{defaultTestClassName}}BindablePropertyInitHelpers
-            {
-                [global::System.ThreadStatic]
-                public static bool IsInitializingInvoiceStatus;
-                public static object CreateDefaultInvoiceStatus(global::Microsoft.Maui.Controls.BindableObject bindable)
+                [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+                static class __BindablePropertyInitHelpers
                 {
-                    IsInitializingInvoiceStatus = true;
-                    try
+                    public static object CreateDefaultInvoiceStatus(global::Microsoft.Maui.Controls.BindableObject bindable)
                     {
-                        var defaultValue = ((TestView)bindable).InvoiceStatus;
+                        (({{defaultTestClassName}})bindable).__isInitializingInvoiceStatus = true;
+                        var defaultValue = (({{defaultTestClassName}})bindable).InvoiceStatus;
+                        (({{defaultTestClassName}})bindable).__isInitializingInvoiceStatus = false;
                         return defaultValue;
-                    }
-                    finally
-                    {
-                        IsInitializingInvoiceStatus = false;
                     }
                 }
             }
@@ -485,160 +475,119 @@ public class BindablePropertyAttributeSourceGenerator_EdgeCaseTests : BaseBindab
             namespace {{defaultTestNamespace}};
             public partial class {{defaultTestClassName}}
             {
+                [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+                bool __isInitializingIsEnabled;
                 /// <summary>
                 /// BindableProperty for the <see cref = "IsEnabled"/> property.
                 /// </summary>
-                public static readonly global::Microsoft.Maui.Controls.BindableProperty IsEnabledProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("IsEnabled", typeof(bool), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultIsEnabled);
-                public partial bool IsEnabled { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingIsEnabled ? field : (bool)GetValue(IsEnabledProperty); set => SetValue(IsEnabledProperty, value); }
+                public static readonly global::Microsoft.Maui.Controls.BindableProperty IsEnabledProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("IsEnabled", typeof(bool), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __BindablePropertyInitHelpers.CreateDefaultIsEnabled);
+                public partial bool IsEnabled { get => __isInitializingIsEnabled ? field : (bool)GetValue(IsEnabledProperty); set => SetValue(IsEnabledProperty, value); }
 
+                [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+                bool __isInitializingPi;
                 /// <summary>
                 /// BindableProperty for the <see cref = "Pi"/> property.
                 /// </summary>
-                public static readonly global::Microsoft.Maui.Controls.BindableProperty PiProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Pi", typeof(double), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultPi);
-                public partial double Pi { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingPi ? field : (double)GetValue(PiProperty); set => SetValue(PiProperty, value); }
+                public static readonly global::Microsoft.Maui.Controls.BindableProperty PiProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Pi", typeof(double), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __BindablePropertyInitHelpers.CreateDefaultPi);
+                public partial double Pi { get => __isInitializingPi ? field : (double)GetValue(PiProperty); set => SetValue(PiProperty, value); }
 
+                [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+                bool __isInitializingLetter;
                 /// <summary>
                 /// BindableProperty for the <see cref = "Letter"/> property.
                 /// </summary>
-                public static readonly global::Microsoft.Maui.Controls.BindableProperty LetterProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Letter", typeof(char), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultLetter);
-                public partial char Letter { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingLetter ? field : (char)GetValue(LetterProperty); set => SetValue(LetterProperty, value); }
+                public static readonly global::Microsoft.Maui.Controls.BindableProperty LetterProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Letter", typeof(char), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __BindablePropertyInitHelpers.CreateDefaultLetter);
+                public partial char Letter { get => __isInitializingLetter ? field : (char)GetValue(LetterProperty); set => SetValue(LetterProperty, value); }
             
+                [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+                bool __isInitializingTimeSpent;
                 /// <summary>
                 /// BindableProperty for the <see cref = "TimeSpent"/> property.
                 /// </summary>
-                public static readonly global::Microsoft.Maui.Controls.BindableProperty TimeSpentProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("TimeSpent", typeof(System.TimeSpan), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultTimeSpent);
-                public partial System.TimeSpan TimeSpent { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingTimeSpent ? field : (System.TimeSpan)GetValue(TimeSpentProperty); set => SetValue(TimeSpentProperty, value); }
+                public static readonly global::Microsoft.Maui.Controls.BindableProperty TimeSpentProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("TimeSpent", typeof(System.TimeSpan), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __BindablePropertyInitHelpers.CreateDefaultTimeSpent);
+                public partial System.TimeSpan TimeSpent { get => __isInitializingTimeSpent ? field : (System.TimeSpan)GetValue(TimeSpentProperty); set => SetValue(TimeSpentProperty, value); }
             
+                [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+                bool __isInitializingDoubleEpsilon;
                 /// <summary>
                 /// BindableProperty for the <see cref = "DoubleEpsilon"/> property.
                 /// </summary>
-                public static readonly global::Microsoft.Maui.Controls.BindableProperty DoubleEpsilonProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("DoubleEpsilon", typeof(double), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultDoubleEpsilon);
-                public partial double DoubleEpsilon { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingDoubleEpsilon ? field : (double)GetValue(DoubleEpsilonProperty); set => SetValue(DoubleEpsilonProperty, value); }
+                public static readonly global::Microsoft.Maui.Controls.BindableProperty DoubleEpsilonProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("DoubleEpsilon", typeof(double), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __BindablePropertyInitHelpers.CreateDefaultDoubleEpsilon);
+                public partial double DoubleEpsilon { get => __isInitializingDoubleEpsilon ? field : (double)GetValue(DoubleEpsilonProperty); set => SetValue(DoubleEpsilonProperty, value); }
             
+                [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+                bool __isInitializingSingleEpsilon;
                 /// <summary>
                 /// BindableProperty for the <see cref = "SingleEpsilon"/> property.
                 /// </summary>
-                public static readonly global::Microsoft.Maui.Controls.BindableProperty SingleEpsilonProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("SingleEpsilon", typeof(double), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultSingleEpsilon);
-                public partial double SingleEpsilon { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingSingleEpsilon ? field : (double)GetValue(SingleEpsilonProperty); set => SetValue(SingleEpsilonProperty, value); }
+                public static readonly global::Microsoft.Maui.Controls.BindableProperty SingleEpsilonProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("SingleEpsilon", typeof(double), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __BindablePropertyInitHelpers.CreateDefaultSingleEpsilon);
+                public partial double SingleEpsilon { get => __isInitializingSingleEpsilon ? field : (double)GetValue(SingleEpsilonProperty); set => SetValue(SingleEpsilonProperty, value); }
             
+                [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+                bool __isInitializingCurrentTime;
                 /// <summary>
                 /// BindableProperty for the <see cref = "CurrentTime"/> property.
                 /// </summary>
-                public static readonly global::Microsoft.Maui.Controls.BindableProperty CurrentTimeProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("CurrentTime", typeof(System.DateTimeOffset), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultCurrentTime);
-                public partial System.DateTimeOffset CurrentTime { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingCurrentTime ? field : (System.DateTimeOffset)GetValue(CurrentTimeProperty); set => SetValue(CurrentTimeProperty, value); }
-            }
+                public static readonly global::Microsoft.Maui.Controls.BindableProperty CurrentTimeProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("CurrentTime", typeof(System.DateTimeOffset), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __BindablePropertyInitHelpers.CreateDefaultCurrentTime);
+                public partial System.DateTimeOffset CurrentTime { get => __isInitializingCurrentTime ? field : (System.DateTimeOffset)GetValue(CurrentTimeProperty); set => SetValue(CurrentTimeProperty, value); }
 
-            file static class __{{defaultTestClassName}}BindablePropertyInitHelpers
-            {
-                [global::System.ThreadStatic]
-                public static bool IsInitializingIsEnabled;
-                public static object CreateDefaultIsEnabled(global::Microsoft.Maui.Controls.BindableObject bindable)
+                [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+                static class __BindablePropertyInitHelpers
                 {
-                    IsInitializingIsEnabled = true;
-                    try
+                    public static object CreateDefaultIsEnabled(global::Microsoft.Maui.Controls.BindableObject bindable)
                     {
-                        var defaultValue = ((TestView)bindable).IsEnabled;
+                        (({{defaultTestClassName}})bindable).__isInitializingIsEnabled = true;
+                        var defaultValue = (({{defaultTestClassName}})bindable).IsEnabled;
+                        (({{defaultTestClassName}})bindable).__isInitializingIsEnabled = false;
                         return defaultValue;
                     }
-                    finally
-                    {
-                        IsInitializingIsEnabled = false;
-                    }
-                }
 
-                [global::System.ThreadStatic]
-                public static bool IsInitializingPi;
-                public static object CreateDefaultPi(global::Microsoft.Maui.Controls.BindableObject bindable)
-                {
-                    IsInitializingPi = true;
-                    try
+                    public static object CreateDefaultPi(global::Microsoft.Maui.Controls.BindableObject bindable)
                     {
-                        var defaultValue = ((TestView)bindable).Pi;
+                        (({{defaultTestClassName}})bindable).__isInitializingPi = true;
+                        var defaultValue = (({{defaultTestClassName}})bindable).Pi;
+                        (({{defaultTestClassName}})bindable).__isInitializingPi = false;
                         return defaultValue;
                     }
-                    finally
-                    {
-                        IsInitializingPi = false;
-                    }
-                }
 
-                [global::System.ThreadStatic]
-                public static bool IsInitializingLetter;
-                public static object CreateDefaultLetter(global::Microsoft.Maui.Controls.BindableObject bindable)
-                {
-                    IsInitializingLetter = true;
-                    try
+                    public static object CreateDefaultLetter(global::Microsoft.Maui.Controls.BindableObject bindable)
                     {
-                        var defaultValue = ((TestView)bindable).Letter;
+                        (({{defaultTestClassName}})bindable).__isInitializingLetter = true;
+                        var defaultValue = (({{defaultTestClassName}})bindable).Letter;
+                        (({{defaultTestClassName}})bindable).__isInitializingLetter = false;
                         return defaultValue;
                     }
-                    finally
-                    {
-                        IsInitializingLetter = false;
-                    }
-                }
 
-                [global::System.ThreadStatic]
-                public static bool IsInitializingTimeSpent;
-                public static object CreateDefaultTimeSpent(global::Microsoft.Maui.Controls.BindableObject bindable)
-                {
-                    IsInitializingTimeSpent = true;
-                    try
+                    public static object CreateDefaultTimeSpent(global::Microsoft.Maui.Controls.BindableObject bindable)
                     {
-                        var defaultValue = ((TestView)bindable).TimeSpent;
+                        (({{defaultTestClassName}})bindable).__isInitializingTimeSpent = true;
+                        var defaultValue = (({{defaultTestClassName}})bindable).TimeSpent;
+                        (({{defaultTestClassName}})bindable).__isInitializingTimeSpent = false;
                         return defaultValue;
                     }
-                    finally
-                    {
-                        IsInitializingTimeSpent = false;
-                    }
-                }
 
-                [global::System.ThreadStatic]
-                public static bool IsInitializingDoubleEpsilon;
-                public static object CreateDefaultDoubleEpsilon(global::Microsoft.Maui.Controls.BindableObject bindable)
-                {
-                    IsInitializingDoubleEpsilon = true;
-                    try
+                    public static object CreateDefaultDoubleEpsilon(global::Microsoft.Maui.Controls.BindableObject bindable)
                     {
-                        var defaultValue = ((TestView)bindable).DoubleEpsilon;
+                        (({{defaultTestClassName}})bindable).__isInitializingDoubleEpsilon = true;
+                        var defaultValue = (({{defaultTestClassName}})bindable).DoubleEpsilon;
+                        (({{defaultTestClassName}})bindable).__isInitializingDoubleEpsilon = false;
                         return defaultValue;
                     }
-                    finally
-                    {
-                        IsInitializingDoubleEpsilon = false;
-                    }
-                }
 
-                [global::System.ThreadStatic]
-                public static bool IsInitializingSingleEpsilon;
-                public static object CreateDefaultSingleEpsilon(global::Microsoft.Maui.Controls.BindableObject bindable)
-                {
-                    IsInitializingSingleEpsilon = true;
-                    try
+                    public static object CreateDefaultSingleEpsilon(global::Microsoft.Maui.Controls.BindableObject bindable)
                     {
-                        var defaultValue = ((TestView)bindable).SingleEpsilon;
+                        (({{defaultTestClassName}})bindable).__isInitializingSingleEpsilon = true;
+                        var defaultValue = (({{defaultTestClassName}})bindable).SingleEpsilon;
+                        (({{defaultTestClassName}})bindable).__isInitializingSingleEpsilon = false;
                         return defaultValue;
                     }
-                    finally
-                    {
-                        IsInitializingSingleEpsilon = false;
-                    }
-                }
 
-                [global::System.ThreadStatic]
-                public static bool IsInitializingCurrentTime;
-                public static object CreateDefaultCurrentTime(global::Microsoft.Maui.Controls.BindableObject bindable)
-                {
-                    IsInitializingCurrentTime = true;
-                    try
+                    public static object CreateDefaultCurrentTime(global::Microsoft.Maui.Controls.BindableObject bindable)
                     {
-                        var defaultValue = ((TestView)bindable).CurrentTime;
+                        (({{defaultTestClassName}})bindable).__isInitializingCurrentTime = true;
+                        var defaultValue = (({{defaultTestClassName}})bindable).CurrentTime;
+                        (({{defaultTestClassName}})bindable).__isInitializingCurrentTime = false;
                         return defaultValue;
-                    }
-                    finally
-                    {
-                        IsInitializingCurrentTime = false;
                     }
                 }
             }
@@ -731,73 +680,56 @@ public class BindablePropertyAttributeSourceGenerator_EdgeCaseTests : BaseBindab
 			namespace {{defaultTestNamespace}};
 			public partial class {{defaultTestClassName}}
 			{
+			    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+			    bool __isInitializingText;
 			    /// <summary>
 			    /// BindableProperty for the <see cref = "Text"/> property.
 			    /// </summary>
-			    internal static readonly global::Microsoft.Maui.Controls.BindableProperty TextProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Text", typeof(string), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultText);
-			    internal partial string Text { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingText ? field : (string)GetValue(TextProperty); set => SetValue(TextProperty, value); }
+			    internal static readonly global::Microsoft.Maui.Controls.BindableProperty TextProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Text", typeof(string), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __BindablePropertyInitHelpers.CreateDefaultText);
+			    internal partial string Text { get => __isInitializingText ? field : (string)GetValue(TextProperty); set => SetValue(TextProperty, value); }
 
+			    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+			    bool __isInitializingTime;
 			    /// <summary>
 			    /// BindableProperty for the <see cref = "Time"/> property.
 			    /// </summary>
-			    protected internal static readonly global::Microsoft.Maui.Controls.BindableProperty TimeProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Time", typeof(string), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultTime);
-			    protected internal partial string Time { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingTime ? field : (string)GetValue(TimeProperty); set => SetValue(TimeProperty, value); }
+			    protected internal static readonly global::Microsoft.Maui.Controls.BindableProperty TimeProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Time", typeof(string), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __BindablePropertyInitHelpers.CreateDefaultTime);
+			    protected internal partial string Time { get => __isInitializingTime ? field : (string)GetValue(TimeProperty); set => SetValue(TimeProperty, value); }
 
-			    static readonly global::Microsoft.Maui.Controls.BindablePropertyKey customDurationPropertyKey = global::Microsoft.Maui.Controls.BindableProperty.CreateReadOnly("CustomDuration", typeof(System.TimeSpan), typeof(TestNamespace.TestView), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __TestViewBindablePropertyInitHelpers.CreateDefaultCustomDuration);
+			    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+			    bool __isInitializingCustomDuration;
+			    static readonly global::Microsoft.Maui.Controls.BindablePropertyKey customDurationPropertyKey = global::Microsoft.Maui.Controls.BindableProperty.CreateReadOnly("CustomDuration", typeof(System.TimeSpan), typeof(TestNamespace.TestView), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __BindablePropertyInitHelpers.CreateDefaultCustomDuration);
 			    /// <summary>
 			    /// BindableProperty for the <see cref = "CustomDuration"/> property.
 			    /// </summary>
 			    internal static readonly global::Microsoft.Maui.Controls.BindableProperty CustomDurationProperty = customDurationPropertyKey.BindableProperty;
-			    internal partial System.TimeSpan CustomDuration { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingCustomDuration ? field : (System.TimeSpan)GetValue(CustomDurationProperty); private set => SetValue(customDurationPropertyKey, value); }
-			}
+			    internal partial System.TimeSpan CustomDuration { get => __isInitializingCustomDuration ? field : (System.TimeSpan)GetValue(CustomDurationProperty); private set => SetValue(customDurationPropertyKey, value); }
 
-			file static class __{{defaultTestClassName}}BindablePropertyInitHelpers
-			{
-			    [global::System.ThreadStatic]
-			    public static bool IsInitializingText;
-			    public static object CreateDefaultText(global::Microsoft.Maui.Controls.BindableObject bindable)
+			    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+			    static class __BindablePropertyInitHelpers
 			    {
-			        IsInitializingText = true;
-			        try
+			        public static object CreateDefaultText(global::Microsoft.Maui.Controls.BindableObject bindable)
 			        {
-			            var defaultValue = ((TestView)bindable).Text;
+			            (({{defaultTestClassName}})bindable).__isInitializingText = true;
+			            var defaultValue = (({{defaultTestClassName}})bindable).Text;
+			            (({{defaultTestClassName}})bindable).__isInitializingText = false;
 			            return defaultValue;
 			        }
-			        finally
-			        {
-			            IsInitializingText = false;
-			        }
-			    }
 
-			    [global::System.ThreadStatic]
-			    public static bool IsInitializingTime;
-			    public static object CreateDefaultTime(global::Microsoft.Maui.Controls.BindableObject bindable)
-			    {
-			        IsInitializingTime = true;
-			        try
+			        public static object CreateDefaultTime(global::Microsoft.Maui.Controls.BindableObject bindable)
 			        {
-			            var defaultValue = ((TestView)bindable).Time;
+			            (({{defaultTestClassName}})bindable).__isInitializingTime = true;
+			            var defaultValue = (({{defaultTestClassName}})bindable).Time;
+			            (({{defaultTestClassName}})bindable).__isInitializingTime = false;
 			            return defaultValue;
 			        }
-			        finally
+
+			        public static object CreateDefaultCustomDuration(global::Microsoft.Maui.Controls.BindableObject bindable)
 			        {
-			            IsInitializingTime = false;
-			        }
-			    }
-			
-			    [global::System.ThreadStatic]
-			    public static bool IsInitializingCustomDuration;
-			    public static object CreateDefaultCustomDuration(global::Microsoft.Maui.Controls.BindableObject bindable)
-			    {
-			        IsInitializingCustomDuration = true;
-			        try
-			        {
-			            var defaultValue = ((TestView)bindable).CustomDuration;
+			            (({{defaultTestClassName}})bindable).__isInitializingCustomDuration = true;
+			            var defaultValue = (({{defaultTestClassName}})bindable).CustomDuration;
+			            (({{defaultTestClassName}})bindable).__isInitializingCustomDuration = false;
 			            return defaultValue;
-			        }
-			        finally
-			        {
-			            IsInitializingCustomDuration = false;
 			        }
 			    }
 			}

--- a/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyAttributeSourceGeneratorTests/BindablePropertyAttributeSourceGenerator_EdgeCaseTests.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyAttributeSourceGeneratorTests/BindablePropertyAttributeSourceGenerator_EdgeCaseTests.cs
@@ -100,13 +100,20 @@ public class BindablePropertyAttributeSourceGenerator_EdgeCaseTests : BaseBindab
 
             file static class __{{defaultTestClassName}}BindablePropertyInitHelpers
             {
-                public static volatile bool IsInitializingInvoiceStatus = false;
+                [global::System.ThreadStatic]
+                public static bool IsInitializingInvoiceStatus;
                 public static object CreateDefaultInvoiceStatus(global::Microsoft.Maui.Controls.BindableObject bindable)
                 {
                     IsInitializingInvoiceStatus = true;
-                    var defaultValue = ((TestView)bindable).InvoiceStatus;
-                    IsInitializingInvoiceStatus = false;
-                    return defaultValue;
+                    try
+                    {
+                        var defaultValue = ((TestView)bindable).InvoiceStatus;
+                        return defaultValue;
+                    }
+                    finally
+                    {
+                        IsInitializingInvoiceStatus = false;
+                    }
                 }
             }
             """;
@@ -160,13 +167,20 @@ public class BindablePropertyAttributeSourceGenerator_EdgeCaseTests : BaseBindab
 
             file static class __{{defaultTestClassName}}BindablePropertyInitHelpers
             {
-                public static volatile bool IsInitializingInvoiceStatus = false;
+                [global::System.ThreadStatic]
+                public static bool IsInitializingInvoiceStatus;
                 public static object CreateDefaultInvoiceStatus(global::Microsoft.Maui.Controls.BindableObject bindable)
                 {
                     IsInitializingInvoiceStatus = true;
-                    var defaultValue = ((TestView)bindable).InvoiceStatus;
-                    IsInitializingInvoiceStatus = false;
-                    return defaultValue;
+                    try
+                    {
+                        var defaultValue = ((TestView)bindable).InvoiceStatus;
+                        return defaultValue;
+                    }
+                    finally
+                    {
+                        IsInitializingInvoiceStatus = false;
+                    }
                 }
             }
             """;
@@ -516,67 +530,116 @@ public class BindablePropertyAttributeSourceGenerator_EdgeCaseTests : BaseBindab
 
             file static class __{{defaultTestClassName}}BindablePropertyInitHelpers
             {
-                public static volatile bool IsInitializingIsEnabled = false;
+                [global::System.ThreadStatic]
+                public static bool IsInitializingIsEnabled;
                 public static object CreateDefaultIsEnabled(global::Microsoft.Maui.Controls.BindableObject bindable)
                 {
                     IsInitializingIsEnabled = true;
-                    var defaultValue = ((TestView)bindable).IsEnabled;
-                    IsInitializingIsEnabled = false;
-                    return defaultValue;
+                    try
+                    {
+                        var defaultValue = ((TestView)bindable).IsEnabled;
+                        return defaultValue;
+                    }
+                    finally
+                    {
+                        IsInitializingIsEnabled = false;
+                    }
                 }
 
-                public static volatile bool IsInitializingPi = false;
+                [global::System.ThreadStatic]
+                public static bool IsInitializingPi;
                 public static object CreateDefaultPi(global::Microsoft.Maui.Controls.BindableObject bindable)
                 {
                     IsInitializingPi = true;
-                    var defaultValue = ((TestView)bindable).Pi;
-                    IsInitializingPi = false;
-                    return defaultValue;
+                    try
+                    {
+                        var defaultValue = ((TestView)bindable).Pi;
+                        return defaultValue;
+                    }
+                    finally
+                    {
+                        IsInitializingPi = false;
+                    }
                 }
 
-                public static volatile bool IsInitializingLetter = false;
+                [global::System.ThreadStatic]
+                public static bool IsInitializingLetter;
                 public static object CreateDefaultLetter(global::Microsoft.Maui.Controls.BindableObject bindable)
                 {
                     IsInitializingLetter = true;
-                    var defaultValue = ((TestView)bindable).Letter;
-                    IsInitializingLetter = false;
-                    return defaultValue;
+                    try
+                    {
+                        var defaultValue = ((TestView)bindable).Letter;
+                        return defaultValue;
+                    }
+                    finally
+                    {
+                        IsInitializingLetter = false;
+                    }
                 }
 
-                public static volatile bool IsInitializingTimeSpent = false;
+                [global::System.ThreadStatic]
+                public static bool IsInitializingTimeSpent;
                 public static object CreateDefaultTimeSpent(global::Microsoft.Maui.Controls.BindableObject bindable)
                 {
                     IsInitializingTimeSpent = true;
-                    var defaultValue = ((TestView)bindable).TimeSpent;
-                    IsInitializingTimeSpent = false;
-                    return defaultValue;
+                    try
+                    {
+                        var defaultValue = ((TestView)bindable).TimeSpent;
+                        return defaultValue;
+                    }
+                    finally
+                    {
+                        IsInitializingTimeSpent = false;
+                    }
                 }
 
-                public static volatile bool IsInitializingDoubleEpsilon = false;
+                [global::System.ThreadStatic]
+                public static bool IsInitializingDoubleEpsilon;
                 public static object CreateDefaultDoubleEpsilon(global::Microsoft.Maui.Controls.BindableObject bindable)
                 {
                     IsInitializingDoubleEpsilon = true;
-                    var defaultValue = ((TestView)bindable).DoubleEpsilon;
-                    IsInitializingDoubleEpsilon = false;
-                    return defaultValue;
+                    try
+                    {
+                        var defaultValue = ((TestView)bindable).DoubleEpsilon;
+                        return defaultValue;
+                    }
+                    finally
+                    {
+                        IsInitializingDoubleEpsilon = false;
+                    }
                 }
 
-                public static volatile bool IsInitializingSingleEpsilon = false;
+                [global::System.ThreadStatic]
+                public static bool IsInitializingSingleEpsilon;
                 public static object CreateDefaultSingleEpsilon(global::Microsoft.Maui.Controls.BindableObject bindable)
                 {
                     IsInitializingSingleEpsilon = true;
-                    var defaultValue = ((TestView)bindable).SingleEpsilon;
-                    IsInitializingSingleEpsilon = false;
-                    return defaultValue;
+                    try
+                    {
+                        var defaultValue = ((TestView)bindable).SingleEpsilon;
+                        return defaultValue;
+                    }
+                    finally
+                    {
+                        IsInitializingSingleEpsilon = false;
+                    }
                 }
 
-                public static volatile bool IsInitializingCurrentTime = false;
+                [global::System.ThreadStatic]
+                public static bool IsInitializingCurrentTime;
                 public static object CreateDefaultCurrentTime(global::Microsoft.Maui.Controls.BindableObject bindable)
                 {
                     IsInitializingCurrentTime = true;
-                    var defaultValue = ((TestView)bindable).CurrentTime;
-                    IsInitializingCurrentTime = false;
-                    return defaultValue;
+                    try
+                    {
+                        var defaultValue = ((TestView)bindable).CurrentTime;
+                        return defaultValue;
+                    }
+                    finally
+                    {
+                        IsInitializingCurrentTime = false;
+                    }
                 }
             }
             """;
@@ -690,31 +753,52 @@ public class BindablePropertyAttributeSourceGenerator_EdgeCaseTests : BaseBindab
 
 			file static class __{{defaultTestClassName}}BindablePropertyInitHelpers
 			{
-			    public static volatile bool IsInitializingText = false;
+			    [global::System.ThreadStatic]
+			    public static bool IsInitializingText;
 			    public static object CreateDefaultText(global::Microsoft.Maui.Controls.BindableObject bindable)
 			    {
 			        IsInitializingText = true;
-			        var defaultValue = ((TestView)bindable).Text;
-			        IsInitializingText = false;
-			        return defaultValue;
+			        try
+			        {
+			            var defaultValue = ((TestView)bindable).Text;
+			            return defaultValue;
+			        }
+			        finally
+			        {
+			            IsInitializingText = false;
+			        }
 			    }
 
-			    public static volatile bool IsInitializingTime = false;
+			    [global::System.ThreadStatic]
+			    public static bool IsInitializingTime;
 			    public static object CreateDefaultTime(global::Microsoft.Maui.Controls.BindableObject bindable)
 			    {
 			        IsInitializingTime = true;
-			        var defaultValue = ((TestView)bindable).Time;
-			        IsInitializingTime = false;
-			        return defaultValue;
+			        try
+			        {
+			            var defaultValue = ((TestView)bindable).Time;
+			            return defaultValue;
+			        }
+			        finally
+			        {
+			            IsInitializingTime = false;
+			        }
 			    }
 			
-			    public static volatile bool IsInitializingCustomDuration = false;
+			    [global::System.ThreadStatic]
+			    public static bool IsInitializingCustomDuration;
 			    public static object CreateDefaultCustomDuration(global::Microsoft.Maui.Controls.BindableObject bindable)
 			    {
 			        IsInitializingCustomDuration = true;
-			        var defaultValue = ((TestView)bindable).CustomDuration;
-			        IsInitializingCustomDuration = false;
-			        return defaultValue;
+			        try
+			        {
+			            var defaultValue = ((TestView)bindable).CustomDuration;
+			            return defaultValue;
+			        }
+			        finally
+			        {
+			            IsInitializingCustomDuration = false;
+			        }
 			    }
 			}
 			""";

--- a/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyAttributeSourceGeneratorTests/BindablePropertyAttributeSourceGenerator_IntegrationTests.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyAttributeSourceGeneratorTests/BindablePropertyAttributeSourceGenerator_IntegrationTests.cs
@@ -159,29 +159,23 @@ public class BindablePropertyAttributeSourceGenerator_IntegrationTests : BaseBin
 		namespace {{defaultTestNamespace}};
 		public partial class {{defaultTestClassName}}<T, U>
 		{
+		    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
+		    bool __isInitializingValue;
 		    /// <summary>
 		    /// BindableProperty for the <see cref = "Value"/> property.
 		    /// </summary>
-		    public static readonly global::Microsoft.Maui.Controls.BindableProperty ValueProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Value", typeof(T), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}<T, U>), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultValue);
-		    public partial T? Value { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingValue ? field : (T? )GetValue(ValueProperty); set => SetValue(ValueProperty, value); }
+		    public static readonly global::Microsoft.Maui.Controls.BindableProperty ValueProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Value", typeof(T), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}<T, U>), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __BindablePropertyInitHelpers.CreateDefaultValue);
+		    public partial T? Value { get => __isInitializingValue ? field : (T? )GetValue(ValueProperty); set => SetValue(ValueProperty, value); }
 
 		    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-		    private static class __{{defaultTestClassName}}BindablePropertyInitHelpers
+		    static class __BindablePropertyInitHelpers
 		    {
-		        [global::System.ThreadStatic]
-		        public static bool IsInitializingValue;
 		        public static object CreateDefaultValue(global::Microsoft.Maui.Controls.BindableObject bindable)
 		        {
-		            IsInitializingValue = true;
-		            try
-		            {
-		                var defaultValue = (({{defaultTestClassName}}<T, U>)bindable).Value;
-		                return defaultValue;
-		            }
-		            finally
-		            {
-		                IsInitializingValue = false;
-		            }
+		            (({{defaultTestClassName}}<T, U>)bindable).__isInitializingValue = true;
+		            var defaultValue = (({{defaultTestClassName}}<T, U>)bindable).Value;
+		            (({{defaultTestClassName}}<T, U>)bindable).__isInitializingValue = false;
+		            return defaultValue;
 		        }
 		    }
 		}

--- a/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyAttributeSourceGeneratorTests/BindablePropertyAttributeSourceGenerator_IntegrationTests.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyAttributeSourceGeneratorTests/BindablePropertyAttributeSourceGenerator_IntegrationTests.cs
@@ -168,13 +168,20 @@ public class BindablePropertyAttributeSourceGenerator_IntegrationTests : BaseBin
 		    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
 		    private static class __{{defaultTestClassName}}BindablePropertyInitHelpers
 		    {
-		        public static volatile bool IsInitializingValue = false;
+		        [global::System.ThreadStatic]
+		        public static bool IsInitializingValue;
 		        public static object CreateDefaultValue(global::Microsoft.Maui.Controls.BindableObject bindable)
 		        {
 		            IsInitializingValue = true;
-		            var defaultValue = (({{defaultTestClassName}}<T, U>)bindable).Value;
-		            IsInitializingValue = false;
-		            return defaultValue;
+		            try
+		            {
+		                var defaultValue = (({{defaultTestClassName}}<T, U>)bindable).Value;
+		                return defaultValue;
+		            }
+		            finally
+		            {
+		                IsInitializingValue = false;
+		            }
 		        }
 		    }
 		}

--- a/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyModelTests.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyModelTests.cs
@@ -91,7 +91,7 @@ public class BindablePropertyModelTests : BaseTest
 		Assert.Equal(hasInitializer, model.HasInitializer);
 		Assert.Equal("TestPropertyProperty", model.BindablePropertyName);
 		Assert.Equal(defaultValueCreatorMethodName, model.EffectiveDefaultValueCreatorMethodName);
-		Assert.Equal("IsInitializingTestProperty", model.InitializingPropertyName);
+		Assert.Equal("__isInitializingTestProperty", model.InitializingPropertyName);
 		Assert.Equal(propertyAccessibility, model.PropertyAccessibility);
 	}
 

--- a/src/CommunityToolkit.Maui.SourceGenerators/Generators/BindablePropertyAttributeSourceGenerator.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Generators/BindablePropertyAttributeSourceGenerator.cs
@@ -142,8 +142,8 @@ public class BindablePropertyAttributeSourceGenerator : IIncrementalGenerator
 
 		sb.Append(value.ClassInformation.DeclaredAccessibility).Append(" partial class ").Append(classNameWithGenerics).Append("\n{\n\n");
 
-		// Prepare helper builder for file-static class members (static flags + default creators)
-		var fileStaticClassStringBuilder = new StringBuilder(256);
+		// Prepare helper builder for nested static class members (default value creators only)
+		var helperClassStringBuilder = new StringBuilder(256);
 		var helperNames = new HashSet<string>();
 
 		// Build fully-qualified declaring type name for helper method casts (include containing types)
@@ -151,10 +151,19 @@ public class BindablePropertyAttributeSourceGenerator : IIncrementalGenerator
 			? classNameWithGenerics
 			: string.Concat(value.ClassInformation.ContainingTypes, ".", classNameWithGenerics);
 
-		var bindablePropertyInitHelpersClassName = $"__{value.ClassInformation.ClassName}BindablePropertyInitHelpers";
+		var bindablePropertyInitHelpersClassName = "__BindablePropertyInitHelpers";
 
 		foreach (var info in value.BindableProperties)
 		{
+			if (info.ShouldUsePropertyInitializer)
+			{
+				// Emit the initializing flag as an instance field on the partial class
+				if (helperNames.Add(info.InitializingPropertyName))
+				{
+					AppendInstanceInitializingField(sb, in info);
+				}
+			}
+
 			if (info.IsReadOnlyBindableProperty)
 			{
 				GenerateReadOnlyBindableProperty(sb, in info, bindablePropertyInitHelpersClassName);
@@ -164,33 +173,26 @@ public class BindablePropertyAttributeSourceGenerator : IIncrementalGenerator
 				GenerateBindableProperty(sb, in info, bindablePropertyInitHelpersClassName);
 			}
 
+			GenerateProperty(sb, in info, bindablePropertyInitHelpersClassName);
+
 			if (info.ShouldUsePropertyInitializer)
 			{
-				// Generate only references within the class; actual static field and creator method
-				// will be placed inside the file static helper class below.
-				if (helperNames.Add(info.InitializingPropertyName))
-				{
-					AppendHelperInitializingField(fileStaticClassStringBuilder, in info);
-				}
+				// Collect the CreateDefault method for the nested helper class
 				if (helperNames.Add(info.EffectiveDefaultValueCreatorMethodName))
 				{
-					AppendHelperDefaultValueMethod(fileStaticClassStringBuilder, in info, fullDeclaringType);
+					AppendHelperDefaultValueMethod(helperClassStringBuilder, in info, fullDeclaringType);
 				}
 			}
-
-			GenerateProperty(sb, in info, bindablePropertyInitHelpersClassName);
 		}
 
-		// If we generated any helper members and the declaring class is generic,
-		// emit the helper class nested inside the generated partial class so
-		// generic type parameters are in scope for casts used by the helper.
-		if (fileStaticClassStringBuilder.Length > 0 && !string.IsNullOrEmpty(value.ClassInformation.GenericTypeParameters))
+		// Always emit the helper class nested inside the partial class
+		if (helperClassStringBuilder.Length > 0)
 		{
 			sb.Append("[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]");
 			sb.Append("\n");
-			sb.Append("private static class ").Append(bindablePropertyInitHelpersClassName).Append("\n{");
+			sb.Append("static class ").Append(bindablePropertyInitHelpersClassName).Append("\n{");
 			sb.Append("\n");
-			sb.Append(fileStaticClassStringBuilder.ToString());
+			sb.Append(helperClassStringBuilder.ToString());
 			sb.Append("}\n\n");
 		}
 
@@ -206,15 +208,6 @@ public class BindablePropertyAttributeSourceGenerator : IIncrementalGenerator
 			}
 		}
 
-		// If we generated any helper members and the declaring class is not generic,
-		// emit a file static class with them. Generic types have their helpers emitted
-		// nested inside the class above to ensure type parameter scope.
-		if (fileStaticClassStringBuilder.Length > 0 && string.IsNullOrEmpty(value.ClassInformation.GenericTypeParameters))
-		{
-			sb.Append("\n\nfile static class ").Append(bindablePropertyInitHelpersClassName).Append("\n{\n");
-			sb.Append(fileStaticClassStringBuilder.ToString());
-			sb.Append("}\n");
-		}
 
 		return sb.ToString();
 	}
@@ -346,8 +339,8 @@ public class BindablePropertyAttributeSourceGenerator : IIncrementalGenerator
 		{
 			if (info.ShouldUsePropertyInitializer)
 			{
-				// Now reference the static flag on the file static helper class
-				sb.Append(bindablePropertyInitHelpersClassName).Append(".").Append(info.InitializingPropertyName);
+				// Reference the instance field directly on the partial class
+				sb.Append(info.InitializingPropertyName);
 			}
 			else
 			{
@@ -591,48 +584,52 @@ public class BindablePropertyAttributeSourceGenerator : IIncrementalGenerator
 	}
 
 	/// <summary>
-	/// Appends the initializing flag into the file-static helper class.
+	/// Appends the initializing flag as an instance field on the generated partial class.
+	/// Using an instance field avoids cross-thread / cross-instance interference that
+	/// occurred when the flag was static.
 	/// </summary>
-	/// <param name="fileStaticClassStringBuilder">Helper StringBuilder used to collect helper members.</param>
+	/// <param name="sb">StringBuilder for the partial class body.</param>
 	/// <param name="info">Property model.</param>
-	static void AppendHelperInitializingField(StringBuilder fileStaticClassStringBuilder, in BindablePropertyModel info)
+	static void AppendInstanceInitializingField(StringBuilder sb, in BindablePropertyModel info)
 	{
-		// Use [ThreadStatic] so each thread has its own flag, preventing cross-thread
-		// interference when multiple instances resolve default values concurrently.
-		fileStaticClassStringBuilder.Append("[global::System.ThreadStatic]\npublic static bool ")
+		sb.Append("[global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]\n")
+			.Append("bool ")
 			.Append(info.InitializingPropertyName)
 			.Append(";\n");
 	}
 
 	/// <summary>
-	/// Appends a default value creator method into the file-static helper class.
-	/// The method sets the thread-static initializing flag, reads the property's initializer value by casting the bindable
-	/// to the declaring type, then clears the flag and returns the value.
+	/// Appends a default value creator method into the nested helper class.
+	/// The method sets the instance-level initializing flag on the bindable object, reads the property's initializer value
+	/// by casting the bindable to the declaring type, then clears the flag and returns the value.
 	/// </summary>
-	/// <param name="fileStaticClassStringBuilder">Helper StringBuilder used to collect helper members.</param>
+	/// <param name="helperClassStringBuilder">Helper StringBuilder used to collect helper methods.</param>
 	/// <param name="info">Property model.</param>
 	/// <param name="fullDeclaringType">Declaring type including containing types and generic parameters.</param>
-	static void AppendHelperDefaultValueMethod(StringBuilder fileStaticClassStringBuilder, in BindablePropertyModel info, string fullDeclaringType)
+	static void AppendHelperDefaultValueMethod(StringBuilder helperClassStringBuilder, in BindablePropertyModel info, string fullDeclaringType)
 	{
 		var sanitizedPropertyName = IsDotnetKeyword(info.PropertyName) ? string.Concat("@", info.PropertyName) : info.PropertyName;
 
-		fileStaticClassStringBuilder.Append("public static object ")
+		helperClassStringBuilder.Append("public static object ")
 			.Append(info.EffectiveDefaultValueCreatorMethodName)
 			.Append("(global::Microsoft.Maui.Controls.BindableObject bindable)\n")
 			.Append("{\n")
+			.Append("((")
+			.Append(fullDeclaringType)
+			.Append(")bindable).")
 			.Append(info.InitializingPropertyName)
 			.Append(" = true;\n")
-			.Append("try\n{\n")
 			.Append("var defaultValue = ((")
 			.Append(fullDeclaringType)
 			.Append(")bindable).")
 			.Append(sanitizedPropertyName)
 			.Append(";\n")
-			.Append("return defaultValue;\n")
-			.Append("}\nfinally\n{\n")
+			.Append("((")
+			.Append(fullDeclaringType)
+			.Append(")bindable).")
 			.Append(info.InitializingPropertyName)
 			.Append(" = false;\n")
-			.Append("}\n")
+			.Append("return defaultValue;\n")
 			.Append("}\n\n");
 	}
 }

--- a/src/CommunityToolkit.Maui.SourceGenerators/Generators/BindablePropertyAttributeSourceGenerator.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Generators/BindablePropertyAttributeSourceGenerator.cs
@@ -597,15 +597,16 @@ public class BindablePropertyAttributeSourceGenerator : IIncrementalGenerator
 	/// <param name="info">Property model.</param>
 	static void AppendHelperInitializingField(StringBuilder fileStaticClassStringBuilder, in BindablePropertyModel info)
 	{
-		// Make the flag public static so it can be referenced from the generated partial class in the same file.
-		fileStaticClassStringBuilder.Append("public static volatile bool ")
+		// Use [ThreadStatic] so each thread has its own flag, preventing cross-thread
+		// interference when multiple instances resolve default values concurrently.
+		fileStaticClassStringBuilder.Append("[global::System.ThreadStatic]\npublic static bool ")
 			.Append(info.InitializingPropertyName)
-			.Append(" = false;\n");
+			.Append(";\n");
 	}
 
 	/// <summary>
 	/// Appends a default value creator method into the file-static helper class.
-	/// The method sets the static initializing flag, reads the property's initializer value by casting the bindable
+	/// The method sets the thread-static initializing flag, reads the property's initializer value by casting the bindable
 	/// to the declaring type, then clears the flag and returns the value.
 	/// </summary>
 	/// <param name="fileStaticClassStringBuilder">Helper StringBuilder used to collect helper members.</param>
@@ -621,14 +622,17 @@ public class BindablePropertyAttributeSourceGenerator : IIncrementalGenerator
 			.Append("{\n")
 			.Append(info.InitializingPropertyName)
 			.Append(" = true;\n")
+			.Append("try\n{\n")
 			.Append("var defaultValue = ((")
 			.Append(fullDeclaringType)
 			.Append(")bindable).")
 			.Append(sanitizedPropertyName)
 			.Append(";\n")
+			.Append("return defaultValue;\n")
+			.Append("}\nfinally\n{\n")
 			.Append(info.InitializingPropertyName)
 			.Append(" = false;\n")
-			.Append("return defaultValue;\n")
+			.Append("}\n")
 			.Append("}\n\n");
 	}
 }

--- a/src/CommunityToolkit.Maui.SourceGenerators/Models/BindablePropertyRecords.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Models/BindablePropertyRecords.cs
@@ -10,7 +10,7 @@ public record BindablePropertyModel(string PropertyName, ITypeSymbol ReturnType,
 	public string BindablePropertyName => $"{PropertyName}Property";
 	public string BindablePropertyKeyName => $"{char.ToLower(PropertyName[0])}{PropertyName[1..]}PropertyKey";
 	public string EffectiveDefaultValueCreatorMethodName => ShouldUsePropertyInitializer ? $"CreateDefault{PropertyName}" : DefaultValueCreatorMethodName;
-	public string InitializingPropertyName => $"IsInitializing{PropertyName}";
+	public string InitializingPropertyName => $"__isInitializing{PropertyName}";
 }
 
 public record AttachedBindablePropertyModel(string PropertyName, ITypeSymbol ReturnType, ITypeSymbol DeclaringType, string DefaultValue, string DefaultBindingMode, string ValidateValueMethodName, string PropertyChangedMethodName, string PropertyChangingMethodName, string CoerceValueMethodName, string DefaultValueCreatorMethodName, string? GetterAccessibility, string? SetterAccessibility, string BindablePropertyAccessibility, bool IsDeclaringTypeNullable, string? BindablePropertyXmlDocumentation, string? GetterMethodXmlDocumentation, string? SetterMethodXmlDocumentation, bool IsReadOnlyBindableProperty)

--- a/src/CommunityToolkit.Maui.UnitTests/Views/LazyView/LazyViewTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/LazyView/LazyViewTests.cs
@@ -20,7 +20,10 @@ public class LazyViewTests : BaseViewTest
 		var lazyView = new LazyView<Button>();
 
 		// Ensure CancellationToken Expired
-		await Task.Delay(100, TestContext.Current.CancellationToken);
+		while (!cts.Token.IsCancellationRequested)
+		{
+			await Task.Delay(1, TestContext.Current.CancellationToken);
+		}
 
 		await Assert.ThrowsAsync<OperationCanceledException>(async () => await lazyView.LoadViewAsync(cts.Token));
 	}

--- a/src/CommunityToolkit.Maui/Behaviors/Validators/ValidationBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/Validators/ValidationBehavior.shared.cs
@@ -233,8 +233,15 @@ public abstract partial class ValidationBehavior : BaseBehavior<VisualElement>, 
 	/// <param name="newValue"></param>
 	protected static async void OnValidationPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 	{
-		var validationBehavior = (ValidationBehavior)bindable;
-		await validationBehavior.UpdateStateAsync(validationBehavior.View, validationBehavior.Flags, false).ConfigureAwait(false);
+		try
+		{
+			var validationBehavior = (ValidationBehavior)bindable;
+			await validationBehavior.UpdateStateAsync(validationBehavior.View, validationBehavior.Flags, false);
+		}
+		catch (Exception ex)
+		{
+			Trace.WriteLine(ex);
+		}
 	}
 
 	static void OnIsValidPropertyChanged(BindableObject bindable, object oldValue, object newValue)

--- a/src/CommunityToolkit.Maui/Behaviors/Validators/ValidationBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/Validators/ValidationBehavior.shared.cs
@@ -238,9 +238,9 @@ public abstract partial class ValidationBehavior : BaseBehavior<VisualElement>, 
 			var validationBehavior = (ValidationBehavior)bindable;
 			await validationBehavior.UpdateStateAsync(validationBehavior.View, validationBehavior.Flags, false);
 		}
-		catch (Exception ex)
+		catch (Exception ex) when (Options.ShouldSuppressExceptionsInBehaviors)
 		{
-			Trace.WriteLine(ex);
+			Trace.TraceInformation("{0}", ex);
 		}
 	}
 

--- a/src/CommunityToolkit.Maui/Behaviors/Validators/ValidationBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/Validators/ValidationBehavior.shared.cs
@@ -191,7 +191,7 @@ public abstract partial class ValidationBehavior : BaseBehavior<VisualElement>, 
 			currentStatus = ValidationFlags.ValidateOnAttaching;
 
 			OnValuePropertyNamePropertyChanged();
-			await UpdateStateAsync(View, Flags, false).ConfigureAwait(false);
+			await UpdateStateAsync(View, Flags, false);
 		}
 		finally
 		{
@@ -221,7 +221,7 @@ public abstract partial class ValidationBehavior : BaseBehavior<VisualElement>, 
 				false => ValidationFlags.ValidateOnUnfocused
 			};
 
-			await UpdateStateAsync(View, Flags, false).ConfigureAwait(false);
+			await UpdateStateAsync(View, Flags, false);
 		}
 	}
 


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->

This PR addresses two compounding issues in tests resulting in non-deterministic behaviour:

- Concurrency of builds in benchmarks
- Thread-pool context in `ValidationBehvaiour` property change handler

To resolve the first, build and run steps have been separated. The alternative would be to disallow parallelism which would add significant runtime. Separating the build allows multiple run instances without DLL locking issues.

The second is addressed by removing `ConfigurAwait(false)` from the `UpdateAsync` call in the property changed handler, as well as adding a `try`/`catch`.

Additionally, I added `try`/`finally` to the bindable property source generator when creating default values, to better mitigate these kinds of issues more broadly. For default value creation this should be safe as the issue is only caused by the static method, and throwing an exception on these failures is not a sensible default.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #3187 

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: No documentation changes as it is not a public facing API change, and I don't think there are docs that cover this yet anyway.

 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
