### PR TITLE
Add compile-time property initializer for default values in BindableProperty source generaor

### DIFF
--- a/.github/instructions/codestyle.instructions.md
+++ b/.github/instructions/codestyle.instructions.md
@@ -566,3 +566,16 @@ Within a class, struct, or interface, elements should be positioned in the follo
 11. Records
 12. Structs
 13. Classes
+
+### Try Pattern
+
+When a method name begins with `Try` and returns a variable, ensure it adheres to the Try Pattern.
+
+Here Key Components of the Try Pattern:
+1. Method Name: Begins with Try (e.g., TryParse, TryGetValue).
+2. Return Type: bool (indicating success or failure).
+3. Out Parameter: An out parameter to return the result if successful.
+4. Null Analysis Attribute: [NotNullWhen(true)] (or [MaybeNullWhen(false)]) informs the compiler that if the method returns true, the out parameter is guaranteed to be non-null. 
+
+This pattern allows for high-performance retrieval or parsing without throwing exceptions for expected failures. It also allows cleaner call sites by eliminating the need for null-checking the output variable within the if block, as seen in Dictionary<TKey, TValue>.TryGetValue. 
+```

--- a/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyAttributeSourceGeneratorTests/BindablePropertyAttributeSourceGenerator_CommonUsageTests.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyAttributeSourceGeneratorTests/BindablePropertyAttributeSourceGenerator_CommonUsageTests.cs
@@ -598,35 +598,14 @@ public class BindablePropertyAttributeSourceGenerator_CommonUsageTests : BaseBin
 			    /// <summary>
 			    /// BindableProperty for the <see cref = "Text"/> property.
 			    /// </summary>
-			    public static readonly global::Microsoft.Maui.Controls.BindableProperty TextProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Text", typeof(string), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultText);
-			    public partial string Text { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingText ? field : (string)GetValue(TextProperty); set => SetValue(TextProperty, value); }
+			    public static readonly global::Microsoft.Maui.Controls.BindableProperty TextProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Text", typeof(string), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), "Initial Value", (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, null);
+			    public partial string Text { get => false ? field : (string)GetValue(TextProperty); set => SetValue(TextProperty, value); }
 
 			    /// <summary>
 			    /// BindableProperty for the <see cref = "CustomDuration"/> property.
 			    /// </summary>
-			    public static readonly global::Microsoft.Maui.Controls.BindableProperty CustomDurationProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("CustomDuration", typeof(System.TimeSpan), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultCustomDuration);
-			    public partial System.TimeSpan CustomDuration { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingCustomDuration ? field : (System.TimeSpan)GetValue(CustomDurationProperty); set => SetValue(CustomDurationProperty, value); }
-			}
-
-			file static class __{{defaultTestClassName}}BindablePropertyInitHelpers
-			{
-			    public static volatile bool IsInitializingText = false;
-			    public static object CreateDefaultText(global::Microsoft.Maui.Controls.BindableObject bindable)
-			    {
-			        IsInitializingText = true;
-			        var defaultValue = ((TestView)bindable).Text;
-			        IsInitializingText = false;
-			        return defaultValue;
-			    }
-			
-			    public static volatile bool IsInitializingCustomDuration = false;
-			    public static object CreateDefaultCustomDuration(global::Microsoft.Maui.Controls.BindableObject bindable)
-			    {
-			        IsInitializingCustomDuration = true;
-			        var defaultValue = ((TestView)bindable).CustomDuration;
-			        IsInitializingCustomDuration = false;
-			        return defaultValue;
-			    }
+			    public static readonly global::Microsoft.Maui.Controls.BindableProperty CustomDurationProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("CustomDuration", typeof(System.TimeSpan), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), global::System.TimeSpan.FromSeconds(30), (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, null);
+			    public partial System.TimeSpan CustomDuration { get => false ? field : (System.TimeSpan)GetValue(CustomDurationProperty); set => SetValue(CustomDurationProperty, value); }
 			}
 			""";
 

--- a/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyAttributeSourceGeneratorTests/BindablePropertyAttributeSourceGenerator_CommonUsageTests.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyAttributeSourceGeneratorTests/BindablePropertyAttributeSourceGenerator_CommonUsageTests.cs
@@ -604,8 +604,20 @@ public class BindablePropertyAttributeSourceGenerator_CommonUsageTests : BaseBin
 			    /// <summary>
 			    /// BindableProperty for the <see cref = "CustomDuration"/> property.
 			    /// </summary>
-			    public static readonly global::Microsoft.Maui.Controls.BindableProperty CustomDurationProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("CustomDuration", typeof(System.TimeSpan), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), global::System.TimeSpan.FromSeconds(30), (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, null);
-			    public partial System.TimeSpan CustomDuration { get => false ? field : (System.TimeSpan)GetValue(CustomDurationProperty); set => SetValue(CustomDurationProperty, value); }
+			    public static readonly global::Microsoft.Maui.Controls.BindableProperty CustomDurationProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("CustomDuration", typeof(System.TimeSpan), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultCustomDuration);
+			    public partial System.TimeSpan CustomDuration { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingCustomDuration ? field : (System.TimeSpan)GetValue(CustomDurationProperty); set => SetValue(CustomDurationProperty, value); }
+			}
+
+			file static class __{{defaultTestClassName}}BindablePropertyInitHelpers
+			{
+			    public static volatile bool IsInitializingCustomDuration = false;
+			    public static object CreateDefaultCustomDuration(global::Microsoft.Maui.Controls.BindableObject bindable)
+			    {
+			        IsInitializingCustomDuration = true;
+			        var defaultValue = (({{defaultTestClassName}})bindable).CustomDuration;
+			        IsInitializingCustomDuration = false;
+			        return defaultValue;
+			    }
 			}
 			""";
 

--- a/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyAttributeSourceGeneratorTests/BindablePropertyAttributeSourceGenerator_EdgeCaseTests.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyAttributeSourceGeneratorTests/BindablePropertyAttributeSourceGenerator_EdgeCaseTests.cs
@@ -94,20 +94,8 @@ public class BindablePropertyAttributeSourceGenerator_EdgeCaseTests : BaseBindab
                 /// <summary>
                 /// BindableProperty for the <see cref = "InvoiceStatus"/> property.
                 /// </summary>
-                public static readonly global::Microsoft.Maui.Controls.BindableProperty InvoiceStatusProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("InvoiceStatus", typeof(TestNamespace.Status), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultInvoiceStatus);
-                public partial TestNamespace.Status InvoiceStatus { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingInvoiceStatus ? field : (TestNamespace.Status)GetValue(InvoiceStatusProperty); set => SetValue(InvoiceStatusProperty, value); }
-            }
-
-            file static class __{{defaultTestClassName}}BindablePropertyInitHelpers
-            {
-                public static volatile bool IsInitializingInvoiceStatus = false;
-                public static object CreateDefaultInvoiceStatus(global::Microsoft.Maui.Controls.BindableObject bindable)
-                {
-                    IsInitializingInvoiceStatus = true;
-                    var defaultValue = ((TestView)bindable).InvoiceStatus;
-                    IsInitializingInvoiceStatus = false;
-                    return defaultValue;
-                }
+                public static readonly global::Microsoft.Maui.Controls.BindableProperty InvoiceStatusProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("InvoiceStatus", typeof(TestNamespace.Status), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), global::TestNamespace.Status.Approved, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, null);
+                public partial TestNamespace.Status InvoiceStatus { get => false ? field : (TestNamespace.Status)GetValue(InvoiceStatusProperty); set => SetValue(InvoiceStatusProperty, value); }
             }
             """;
 
@@ -154,20 +142,8 @@ public class BindablePropertyAttributeSourceGenerator_EdgeCaseTests : BaseBindab
                 /// <summary>
                 /// BindableProperty for the <see cref = "InvoiceStatus"/> property.
                 /// </summary>
-                public static readonly global::Microsoft.Maui.Controls.BindableProperty InvoiceStatusProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("InvoiceStatus", typeof(TestNamespace.Status), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultInvoiceStatus);
-                public partial TestNamespace.Status InvoiceStatus { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingInvoiceStatus ? field : (TestNamespace.Status)GetValue(InvoiceStatusProperty); set => SetValue(InvoiceStatusProperty, value); }
-            }
-
-            file static class __{{defaultTestClassName}}BindablePropertyInitHelpers
-            {
-                public static volatile bool IsInitializingInvoiceStatus = false;
-                public static object CreateDefaultInvoiceStatus(global::Microsoft.Maui.Controls.BindableObject bindable)
-                {
-                    IsInitializingInvoiceStatus = true;
-                    var defaultValue = ((TestView)bindable).InvoiceStatus;
-                    IsInitializingInvoiceStatus = false;
-                    return defaultValue;
-                }
+                public static readonly global::Microsoft.Maui.Controls.BindableProperty InvoiceStatusProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("InvoiceStatus", typeof(TestNamespace.Status), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), global::TestNamespace.Status.Rejected, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, null);
+                public partial TestNamespace.Status InvoiceStatus { get => false ? field : (TestNamespace.Status)GetValue(InvoiceStatusProperty); set => SetValue(InvoiceStatusProperty, value); }
             }
             """;
 
@@ -453,7 +429,7 @@ public class BindablePropertyAttributeSourceGenerator_EdgeCaseTests : BaseBindab
                 public partial double DoubleEpsilon { get; set; } = double.Epsilon;
                 
                 [BindableProperty]
-                public partial double SingleEpsilon { get; set; } = float.Epsilon;
+                public partial float SingleEpsilon { get; set; } = float.Epsilon;
                 
                 [BindableProperty]
                 public partial DateTimeOffset CurrentTime { get; set; } = DateTimeOffset.UtcNow;
@@ -474,110 +450,44 @@ public class BindablePropertyAttributeSourceGenerator_EdgeCaseTests : BaseBindab
                 /// <summary>
                 /// BindableProperty for the <see cref = "IsEnabled"/> property.
                 /// </summary>
-                public static readonly global::Microsoft.Maui.Controls.BindableProperty IsEnabledProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("IsEnabled", typeof(bool), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultIsEnabled);
-                public partial bool IsEnabled { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingIsEnabled ? field : (bool)GetValue(IsEnabledProperty); set => SetValue(IsEnabledProperty, value); }
+                public static readonly global::Microsoft.Maui.Controls.BindableProperty IsEnabledProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("IsEnabled", typeof(bool), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), true, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, null);
+                public partial bool IsEnabled { get => false ? field : (bool)GetValue(IsEnabledProperty); set => SetValue(IsEnabledProperty, value); }
 
                 /// <summary>
                 /// BindableProperty for the <see cref = "Pi"/> property.
                 /// </summary>
-                public static readonly global::Microsoft.Maui.Controls.BindableProperty PiProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Pi", typeof(double), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultPi);
-                public partial double Pi { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingPi ? field : (double)GetValue(PiProperty); set => SetValue(PiProperty, value); }
+                public static readonly global::Microsoft.Maui.Controls.BindableProperty PiProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Pi", typeof(double), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), 3.14, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, null);
+                public partial double Pi { get => false ? field : (double)GetValue(PiProperty); set => SetValue(PiProperty, value); }
 
                 /// <summary>
                 /// BindableProperty for the <see cref = "Letter"/> property.
                 /// </summary>
-                public static readonly global::Microsoft.Maui.Controls.BindableProperty LetterProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Letter", typeof(char), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultLetter);
-                public partial char Letter { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingLetter ? field : (char)GetValue(LetterProperty); set => SetValue(LetterProperty, value); }
+                public static readonly global::Microsoft.Maui.Controls.BindableProperty LetterProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Letter", typeof(char), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), 'A', (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, null);
+                public partial char Letter { get => false ? field : (char)GetValue(LetterProperty); set => SetValue(LetterProperty, value); }
             
                 /// <summary>
                 /// BindableProperty for the <see cref = "TimeSpent"/> property.
                 /// </summary>
-                public static readonly global::Microsoft.Maui.Controls.BindableProperty TimeSpentProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("TimeSpent", typeof(System.TimeSpan), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultTimeSpent);
-                public partial System.TimeSpan TimeSpent { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingTimeSpent ? field : (System.TimeSpan)GetValue(TimeSpentProperty); set => SetValue(TimeSpentProperty, value); }
+                public static readonly global::Microsoft.Maui.Controls.BindableProperty TimeSpentProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("TimeSpent", typeof(System.TimeSpan), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), global::System.TimeSpan.Zero, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, null);
+                public partial System.TimeSpan TimeSpent { get => false ? field : (System.TimeSpan)GetValue(TimeSpentProperty); set => SetValue(TimeSpentProperty, value); }
             
                 /// <summary>
                 /// BindableProperty for the <see cref = "DoubleEpsilon"/> property.
                 /// </summary>
-                public static readonly global::Microsoft.Maui.Controls.BindableProperty DoubleEpsilonProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("DoubleEpsilon", typeof(double), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultDoubleEpsilon);
-                public partial double DoubleEpsilon { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingDoubleEpsilon ? field : (double)GetValue(DoubleEpsilonProperty); set => SetValue(DoubleEpsilonProperty, value); }
+                public static readonly global::Microsoft.Maui.Controls.BindableProperty DoubleEpsilonProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("DoubleEpsilon", typeof(double), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), double.Epsilon, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, null);
+                public partial double DoubleEpsilon { get => false ? field : (double)GetValue(DoubleEpsilonProperty); set => SetValue(DoubleEpsilonProperty, value); }
             
                 /// <summary>
                 /// BindableProperty for the <see cref = "SingleEpsilon"/> property.
                 /// </summary>
-                public static readonly global::Microsoft.Maui.Controls.BindableProperty SingleEpsilonProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("SingleEpsilon", typeof(double), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultSingleEpsilon);
-                public partial double SingleEpsilon { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingSingleEpsilon ? field : (double)GetValue(SingleEpsilonProperty); set => SetValue(SingleEpsilonProperty, value); }
+                public static readonly global::Microsoft.Maui.Controls.BindableProperty SingleEpsilonProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("SingleEpsilon", typeof(float), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), float.Epsilon, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, null);
+                public partial float SingleEpsilon { get => false ? field : (float)GetValue(SingleEpsilonProperty); set => SetValue(SingleEpsilonProperty, value); }
             
                 /// <summary>
                 /// BindableProperty for the <see cref = "CurrentTime"/> property.
                 /// </summary>
-                public static readonly global::Microsoft.Maui.Controls.BindableProperty CurrentTimeProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("CurrentTime", typeof(System.DateTimeOffset), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultCurrentTime);
-                public partial System.DateTimeOffset CurrentTime { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingCurrentTime ? field : (System.DateTimeOffset)GetValue(CurrentTimeProperty); set => SetValue(CurrentTimeProperty, value); }
-            }
-
-            file static class __{{defaultTestClassName}}BindablePropertyInitHelpers
-            {
-                public static volatile bool IsInitializingIsEnabled = false;
-                public static object CreateDefaultIsEnabled(global::Microsoft.Maui.Controls.BindableObject bindable)
-                {
-                    IsInitializingIsEnabled = true;
-                    var defaultValue = ((TestView)bindable).IsEnabled;
-                    IsInitializingIsEnabled = false;
-                    return defaultValue;
-                }
-
-                public static volatile bool IsInitializingPi = false;
-                public static object CreateDefaultPi(global::Microsoft.Maui.Controls.BindableObject bindable)
-                {
-                    IsInitializingPi = true;
-                    var defaultValue = ((TestView)bindable).Pi;
-                    IsInitializingPi = false;
-                    return defaultValue;
-                }
-
-                public static volatile bool IsInitializingLetter = false;
-                public static object CreateDefaultLetter(global::Microsoft.Maui.Controls.BindableObject bindable)
-                {
-                    IsInitializingLetter = true;
-                    var defaultValue = ((TestView)bindable).Letter;
-                    IsInitializingLetter = false;
-                    return defaultValue;
-                }
-
-                public static volatile bool IsInitializingTimeSpent = false;
-                public static object CreateDefaultTimeSpent(global::Microsoft.Maui.Controls.BindableObject bindable)
-                {
-                    IsInitializingTimeSpent = true;
-                    var defaultValue = ((TestView)bindable).TimeSpent;
-                    IsInitializingTimeSpent = false;
-                    return defaultValue;
-                }
-
-                public static volatile bool IsInitializingDoubleEpsilon = false;
-                public static object CreateDefaultDoubleEpsilon(global::Microsoft.Maui.Controls.BindableObject bindable)
-                {
-                    IsInitializingDoubleEpsilon = true;
-                    var defaultValue = ((TestView)bindable).DoubleEpsilon;
-                    IsInitializingDoubleEpsilon = false;
-                    return defaultValue;
-                }
-
-                public static volatile bool IsInitializingSingleEpsilon = false;
-                public static object CreateDefaultSingleEpsilon(global::Microsoft.Maui.Controls.BindableObject bindable)
-                {
-                    IsInitializingSingleEpsilon = true;
-                    var defaultValue = ((TestView)bindable).SingleEpsilon;
-                    IsInitializingSingleEpsilon = false;
-                    return defaultValue;
-                }
-
-                public static volatile bool IsInitializingCurrentTime = false;
-                public static object CreateDefaultCurrentTime(global::Microsoft.Maui.Controls.BindableObject bindable)
-                {
-                    IsInitializingCurrentTime = true;
-                    var defaultValue = ((TestView)bindable).CurrentTime;
-                    IsInitializingCurrentTime = false;
-                    return defaultValue;
-                }
+                public static readonly global::Microsoft.Maui.Controls.BindableProperty CurrentTimeProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("CurrentTime", typeof(System.DateTimeOffset), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), global::System.DateTimeOffset.UtcNow, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, null);
+                public partial System.DateTimeOffset CurrentTime { get => false ? field : (System.DateTimeOffset)GetValue(CurrentTimeProperty); set => SetValue(CurrentTimeProperty, value); }
             }
             """;
 
@@ -671,51 +581,21 @@ public class BindablePropertyAttributeSourceGenerator_EdgeCaseTests : BaseBindab
 			    /// <summary>
 			    /// BindableProperty for the <see cref = "Text"/> property.
 			    /// </summary>
-			    internal static readonly global::Microsoft.Maui.Controls.BindableProperty TextProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Text", typeof(string), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultText);
-			    internal partial string Text { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingText ? field : (string)GetValue(TextProperty); set => SetValue(TextProperty, value); }
+			    internal static readonly global::Microsoft.Maui.Controls.BindableProperty TextProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Text", typeof(string), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), "Initial Value", (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, null);
+			    internal partial string Text { get => false ? field : (string)GetValue(TextProperty); set => SetValue(TextProperty, value); }
 
 			    /// <summary>
 			    /// BindableProperty for the <see cref = "Time"/> property.
 			    /// </summary>
-			    protected internal static readonly global::Microsoft.Maui.Controls.BindableProperty TimeProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Time", typeof(string), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultTime);
-			    protected internal partial string Time { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingTime ? field : (string)GetValue(TimeProperty); set => SetValue(TimeProperty, value); }
+			    protected internal static readonly global::Microsoft.Maui.Controls.BindableProperty TimeProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Time", typeof(string), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), string.Empty, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, null);
+			    protected internal partial string Time { get => false ? field : (string)GetValue(TimeProperty); set => SetValue(TimeProperty, value); }
 
-			    static readonly global::Microsoft.Maui.Controls.BindablePropertyKey customDurationPropertyKey = global::Microsoft.Maui.Controls.BindableProperty.CreateReadOnly("CustomDuration", typeof(System.TimeSpan), typeof(TestNamespace.TestView), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __TestViewBindablePropertyInitHelpers.CreateDefaultCustomDuration);
+			    static readonly global::Microsoft.Maui.Controls.BindablePropertyKey customDurationPropertyKey = global::Microsoft.Maui.Controls.BindableProperty.CreateReadOnly("CustomDuration", typeof(System.TimeSpan), typeof(TestNamespace.TestView), global::System.TimeSpan.FromSeconds(30), (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, null);
 			    /// <summary>
 			    /// BindableProperty for the <see cref = "CustomDuration"/> property.
 			    /// </summary>
 			    internal static readonly global::Microsoft.Maui.Controls.BindableProperty CustomDurationProperty = customDurationPropertyKey.BindableProperty;
-			    internal partial System.TimeSpan CustomDuration { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingCustomDuration ? field : (System.TimeSpan)GetValue(CustomDurationProperty); private set => SetValue(customDurationPropertyKey, value); }
-			}
-
-			file static class __{{defaultTestClassName}}BindablePropertyInitHelpers
-			{
-			    public static volatile bool IsInitializingText = false;
-			    public static object CreateDefaultText(global::Microsoft.Maui.Controls.BindableObject bindable)
-			    {
-			        IsInitializingText = true;
-			        var defaultValue = ((TestView)bindable).Text;
-			        IsInitializingText = false;
-			        return defaultValue;
-			    }
-
-			    public static volatile bool IsInitializingTime = false;
-			    public static object CreateDefaultTime(global::Microsoft.Maui.Controls.BindableObject bindable)
-			    {
-			        IsInitializingTime = true;
-			        var defaultValue = ((TestView)bindable).Time;
-			        IsInitializingTime = false;
-			        return defaultValue;
-			    }
-			
-			    public static volatile bool IsInitializingCustomDuration = false;
-			    public static object CreateDefaultCustomDuration(global::Microsoft.Maui.Controls.BindableObject bindable)
-			    {
-			        IsInitializingCustomDuration = true;
-			        var defaultValue = ((TestView)bindable).CustomDuration;
-			        IsInitializingCustomDuration = false;
-			        return defaultValue;
-			    }
+			    internal partial System.TimeSpan CustomDuration { get => false ? field : (System.TimeSpan)GetValue(CustomDurationProperty); private set => SetValue(customDurationPropertyKey, value); }
 			}
 			""";
 

--- a/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyAttributeSourceGeneratorTests/BindablePropertyAttributeSourceGenerator_EdgeCaseTests.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyAttributeSourceGeneratorTests/BindablePropertyAttributeSourceGenerator_EdgeCaseTests.cs
@@ -486,8 +486,20 @@ public class BindablePropertyAttributeSourceGenerator_EdgeCaseTests : BaseBindab
                 /// <summary>
                 /// BindableProperty for the <see cref = "CurrentTime"/> property.
                 /// </summary>
-                public static readonly global::Microsoft.Maui.Controls.BindableProperty CurrentTimeProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("CurrentTime", typeof(System.DateTimeOffset), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), global::System.DateTimeOffset.UtcNow, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, null);
-                public partial System.DateTimeOffset CurrentTime { get => false ? field : (System.DateTimeOffset)GetValue(CurrentTimeProperty); set => SetValue(CurrentTimeProperty, value); }
+                public static readonly global::Microsoft.Maui.Controls.BindableProperty CurrentTimeProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("CurrentTime", typeof(System.DateTimeOffset), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultCurrentTime);
+                public partial System.DateTimeOffset CurrentTime { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingCurrentTime ? field : (System.DateTimeOffset)GetValue(CurrentTimeProperty); set => SetValue(CurrentTimeProperty, value); }
+            }
+
+            file static class __{{defaultTestClassName}}BindablePropertyInitHelpers
+            {
+                public static volatile bool IsInitializingCurrentTime = false;
+                public static object CreateDefaultCurrentTime(global::Microsoft.Maui.Controls.BindableObject bindable)
+                {
+                    IsInitializingCurrentTime = true;
+                    var defaultValue = (({{defaultTestClassName}})bindable).CurrentTime;
+                    IsInitializingCurrentTime = false;
+                    return defaultValue;
+                }
             }
             """;
 

--- a/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyAttributeSourceGeneratorTests/BindablePropertyAttributeSourceGenerator_EdgeCaseTests.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyAttributeSourceGeneratorTests/BindablePropertyAttributeSourceGenerator_EdgeCaseTests.cs
@@ -602,12 +602,24 @@ public class BindablePropertyAttributeSourceGenerator_EdgeCaseTests : BaseBindab
 			    protected internal static readonly global::Microsoft.Maui.Controls.BindableProperty TimeProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Time", typeof(string), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}), string.Empty, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, null);
 			    protected internal partial string Time { get => false ? field : (string)GetValue(TimeProperty); set => SetValue(TimeProperty, value); }
 
-			    static readonly global::Microsoft.Maui.Controls.BindablePropertyKey customDurationPropertyKey = global::Microsoft.Maui.Controls.BindableProperty.CreateReadOnly("CustomDuration", typeof(System.TimeSpan), typeof(TestNamespace.TestView), global::System.TimeSpan.FromSeconds(30), (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, null);
+			    static readonly global::Microsoft.Maui.Controls.BindablePropertyKey customDurationPropertyKey = global::Microsoft.Maui.Controls.BindableProperty.CreateReadOnly("CustomDuration", typeof(System.TimeSpan), typeof(TestNamespace.TestView), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultCustomDuration);
 			    /// <summary>
 			    /// BindableProperty for the <see cref = "CustomDuration"/> property.
 			    /// </summary>
 			    internal static readonly global::Microsoft.Maui.Controls.BindableProperty CustomDurationProperty = customDurationPropertyKey.BindableProperty;
-			    internal partial System.TimeSpan CustomDuration { get => false ? field : (System.TimeSpan)GetValue(CustomDurationProperty); private set => SetValue(customDurationPropertyKey, value); }
+			    internal partial System.TimeSpan CustomDuration { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingCustomDuration ? field : (System.TimeSpan)GetValue(CustomDurationProperty); private set => SetValue(customDurationPropertyKey, value); }
+			}
+
+			file static class __{{defaultTestClassName}}BindablePropertyInitHelpers
+			{
+			    public static volatile bool IsInitializingCustomDuration = false;
+			    public static object CreateDefaultCustomDuration(global::Microsoft.Maui.Controls.BindableObject bindable)
+			    {
+			        IsInitializingCustomDuration = true;
+			        var defaultValue = (({{defaultTestClassName}})bindable).CustomDuration;
+			        IsInitializingCustomDuration = false;
+			        return defaultValue;
+			    }
 			}
 			""";
 

--- a/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyAttributeSourceGeneratorTests/BindablePropertyAttributeSourceGenerator_IntegrationTests.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyAttributeSourceGeneratorTests/BindablePropertyAttributeSourceGenerator_IntegrationTests.cs
@@ -162,21 +162,8 @@ public class BindablePropertyAttributeSourceGenerator_IntegrationTests : BaseBin
 		    /// <summary>
 		    /// BindableProperty for the <see cref = "Value"/> property.
 		    /// </summary>
-		    public static readonly global::Microsoft.Maui.Controls.BindableProperty ValueProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Value", typeof(T), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}<T, U>), null, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, __{{defaultTestClassName}}BindablePropertyInitHelpers.CreateDefaultValue);
-		    public partial T? Value { get => __{{defaultTestClassName}}BindablePropertyInitHelpers.IsInitializingValue ? field : (T? )GetValue(ValueProperty); set => SetValue(ValueProperty, value); }
-
-		    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
-		    private static class __{{defaultTestClassName}}BindablePropertyInitHelpers
-		    {
-		        public static volatile bool IsInitializingValue = false;
-		        public static object CreateDefaultValue(global::Microsoft.Maui.Controls.BindableObject bindable)
-		        {
-		            IsInitializingValue = true;
-		            var defaultValue = (({{defaultTestClassName}}<T, U>)bindable).Value;
-		            IsInitializingValue = false;
-		            return defaultValue;
-		        }
-		    }
+		    public static readonly global::Microsoft.Maui.Controls.BindableProperty ValueProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Value", typeof(T), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}<T, U>), default, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, null);
+		    public partial T? Value { get => false ? field : (T? )GetValue(ValueProperty); set => SetValue(ValueProperty, value); }
 		}
 		""";
 

--- a/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyAttributeSourceGeneratorTests/BindablePropertyAttributeSourceGenerator_IntegrationTests.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyAttributeSourceGeneratorTests/BindablePropertyAttributeSourceGenerator_IntegrationTests.cs
@@ -162,7 +162,7 @@ public class BindablePropertyAttributeSourceGenerator_IntegrationTests : BaseBin
 		    /// <summary>
 		    /// BindableProperty for the <see cref = "Value"/> property.
 		    /// </summary>
-		    public static readonly global::Microsoft.Maui.Controls.BindableProperty ValueProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Value", typeof(T), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}<T, U>), default, (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, null);
+		    public static readonly global::Microsoft.Maui.Controls.BindableProperty ValueProperty = global::Microsoft.Maui.Controls.BindableProperty.Create("Value", typeof(T), typeof({{defaultTestNamespace}}.{{defaultTestClassName}}<T, U>), default(T), (Microsoft.Maui.Controls.BindingMode)0, null, null, null, null, null);
 		    public partial T? Value { get => false ? field : (T? )GetValue(ValueProperty); set => SetValue(ValueProperty, value); }
 		}
 		""";

--- a/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyModelTests.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators.UnitTests/BindablePropertyModelTests.cs
@@ -30,7 +30,8 @@ public class BindablePropertyModelTests : BaseTest
 			true, // IsReadOnlyBindableProperty
 			string.Empty, // SetterAccessibility
 			false,
-			"null"
+			"null",
+			null
 		);
 
 		// Act
@@ -74,7 +75,8 @@ public class BindablePropertyModelTests : BaseTest
 			true, // IsReadOnlyBindableProperty
 			string.Empty, // SetterAccessibility
 			hasInitializer,
-			propertyAccessibility
+			propertyAccessibility,
+			null
 		);
 
 		// Assert
@@ -135,7 +137,8 @@ public class BindablePropertyModelTests : BaseTest
 			true, // IsReadOnlyBindableProperty
 			string.Empty, // SetterAccessibilityText
 			false,
-			"public"
+			"public",
+			null
 		);
 
 		var bindableProperties = new[] { bindableProperty }.ToImmutableArray();
@@ -194,7 +197,8 @@ public class BindablePropertyModelTests : BaseTest
 			true,
 			string.Empty,
 			hasInitializer,
-			"public"
+			"public",
+			null
 		);
 
 		// Act
@@ -234,7 +238,8 @@ public class BindablePropertyModelTests : BaseTest
 			true,
 			string.Empty,
 			hasInitializer,
-			"public"
+			"public",
+			null
 		);
 
 		// Act

--- a/src/CommunityToolkit.Maui.SourceGenerators/Generators/BindablePropertyAttributeSourceGenerator.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Generators/BindablePropertyAttributeSourceGenerator.cs
@@ -237,7 +237,7 @@ public class BindablePropertyAttributeSourceGenerator : IIncrementalGenerator
 			.Append(GetFormattedReturnType(nonNullableReturnType))
 			.Append("), typeof(")
 			.Append(info.DeclaringType)
-			.Append("), null, ")
+			.Append("), ").Append(info.ResolvedInitializerExpression ?? "null").Append(", ")
 			.Append(info.DefaultBindingMode)
 			.Append(", ")
 			.Append(info.ValidateValueMethodName)
@@ -304,7 +304,7 @@ public class BindablePropertyAttributeSourceGenerator : IIncrementalGenerator
 			.Append(GetFormattedReturnType(nonNullableReturnType))
 			.Append("), typeof(")
 			.Append(info.DeclaringType)
-			.Append("), null, ")
+			.Append("), ").Append(info.ResolvedInitializerExpression ?? "null").Append(", ")
 			.Append(info.DefaultBindingMode)
 			.Append(", ")
 			.Append(info.ValidateValueMethodName)
@@ -408,8 +408,16 @@ public class BindablePropertyAttributeSourceGenerator : IIncrementalGenerator
 
 		var propertyAccessibility = GetPropertyAccessibility(propertySymbol);
 
+		// Resolve initializer expression to a fully qualified string for use as defaultValue
+		string? resolvedInitializer = null;
+		if (hasInitializer && propertyDeclarationSyntax.Initializer is not null)
+		{
+			resolvedInitializer = Helpers.InitializerExpressionResolver.TryResolve(
+				propertyDeclarationSyntax.Initializer.Value, semanticModel);
+		}
+
 		var attributeData = context.Attributes[0];
-		bindablePropertyModels[0] = CreateBindablePropertyModel(attributeData, propertySymbol.ContainingType, propertySymbol.Name, returnType, doesContainNewKeyword, isReadOnlyBindableProperty, setterAccessibility, hasInitializer, propertyAccessibility);
+		bindablePropertyModels[0] = CreateBindablePropertyModel(attributeData, propertySymbol.ContainingType, propertySymbol.Name, returnType, doesContainNewKeyword, isReadOnlyBindableProperty, setterAccessibility, hasInitializer, propertyAccessibility, resolvedInitializer);
 
 		return new(propertyInfo, ImmutableArray.Create(bindablePropertyModels));
 	}
@@ -517,7 +525,7 @@ public class BindablePropertyAttributeSourceGenerator : IIncrementalGenerator
 		return sb.ToString();
 	}
 
-	static BindablePropertyModel CreateBindablePropertyModel(in AttributeData attributeData, in INamedTypeSymbol declaringType, in string propertyName, in ITypeSymbol returnType, in bool doesContainNewKeyword, in bool isReadOnly, in string? setterAccessibility, in bool hasInitializer, in string? propertyAccessibility)
+	static BindablePropertyModel CreateBindablePropertyModel(in AttributeData attributeData, in INamedTypeSymbol declaringType, in string propertyName, in ITypeSymbol returnType, in bool doesContainNewKeyword, in bool isReadOnly, in string? setterAccessibility, in bool hasInitializer, in string? propertyAccessibility, in string? resolvedInitializerExpression)
 	{
 		if (attributeData.AttributeClass is null)
 		{
@@ -532,7 +540,10 @@ public class BindablePropertyAttributeSourceGenerator : IIncrementalGenerator
 		var validateValueMethodName = attributeData.GetNamedMethodGroupArgumentsAttributeValueByNameAsString(nameof(BindablePropertyModel.ValidateValueMethodName));
 		var newKeywordText = doesContainNewKeyword ? "new " : string.Empty;
 
-		return new BindablePropertyModel(propertyName, returnType, declaringType, defaultBindingMode, validateValueMethodName, propertyChangedMethodName, propertyChangingMethodName, coerceValueMethodName, defaultValueCreatorMethodName, newKeywordText, isReadOnly, setterAccessibility, hasInitializer, propertyAccessibility);
+		// Only use the resolved initializer when there's no explicit DefaultValueCreatorMethodName
+		var effectiveResolvedInitializer = defaultValueCreatorMethodName is "null" ? resolvedInitializerExpression : null;
+
+		return new BindablePropertyModel(propertyName, returnType, declaringType, defaultBindingMode, validateValueMethodName, propertyChangedMethodName, propertyChangingMethodName, coerceValueMethodName, defaultValueCreatorMethodName, newKeywordText, isReadOnly, setterAccessibility, hasInitializer, propertyAccessibility, effectiveResolvedInitializer);
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/CommunityToolkit.Maui.SourceGenerators/Generators/BindablePropertyAttributeSourceGenerator.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Generators/BindablePropertyAttributeSourceGenerator.cs
@@ -237,7 +237,9 @@ public class BindablePropertyAttributeSourceGenerator : IIncrementalGenerator
 			.Append(GetFormattedReturnType(nonNullableReturnType))
 			.Append("), typeof(")
 			.Append(info.DeclaringType)
-			.Append("), ").Append(info.ResolvedInitializerExpression ?? "null").Append(", ")
+			.Append("), ")
+			.Append(info.ResolvedInitializerExpression ?? "null")
+			.Append(", ")
 			.Append(info.DefaultBindingMode)
 			.Append(", ")
 			.Append(info.ValidateValueMethodName)
@@ -304,7 +306,9 @@ public class BindablePropertyAttributeSourceGenerator : IIncrementalGenerator
 			.Append(GetFormattedReturnType(nonNullableReturnType))
 			.Append("), typeof(")
 			.Append(info.DeclaringType)
-			.Append("), ").Append(info.ResolvedInitializerExpression ?? "null").Append(", ")
+			.Append("), ")
+			.Append(info.ResolvedInitializerExpression ?? "null")
+			.Append(", ")
 			.Append(info.DefaultBindingMode)
 			.Append(", ")
 			.Append(info.ValidateValueMethodName)
@@ -412,8 +416,7 @@ public class BindablePropertyAttributeSourceGenerator : IIncrementalGenerator
 		string? resolvedInitializer = null;
 		if (hasInitializer && propertyDeclarationSyntax.Initializer is not null)
 		{
-			resolvedInitializer = Helpers.InitializerExpressionResolver.TryResolve(
-				propertyDeclarationSyntax.Initializer.Value, semanticModel);
+			InitializerExpressionResolver.TryResolve(propertyDeclarationSyntax.Initializer.Value, semanticModel, out resolvedInitializer);
 		}
 
 		var attributeData = context.Attributes[0];

--- a/src/CommunityToolkit.Maui.SourceGenerators/Helpers/InitializerExpressionResolver.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Helpers/InitializerExpressionResolver.cs
@@ -101,6 +101,11 @@ static class InitializerExpressionResolver
 				return TryResolveInvocation(invocation, semanticModel);
 
 			case ObjectCreationExpressionSyntax objectCreation:
+				var objectCreationType = semanticModel.GetTypeInfo(objectCreation).Type;
+				if (objectCreationType is null || !objectCreationType.IsValueType)
+				{
+					return null;
+				}
 				return TryResolveObjectCreation(objectCreation, semanticModel);
 
 			default:

--- a/src/CommunityToolkit.Maui.SourceGenerators/Helpers/InitializerExpressionResolver.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Helpers/InitializerExpressionResolver.cs
@@ -39,6 +39,14 @@ static class InitializerExpressionResolver
 		switch (expression)
 		{
 			case LiteralExpressionSyntax literal:
+				if (literal.IsKind(SyntaxKind.DefaultLiteralExpression))
+				{
+					var defaultLiteralType = semanticModel.GetTypeInfo(literal).Type;
+					if (defaultLiteralType is not null)
+					{
+						return $"default({defaultLiteralType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)})";
+					}
+				}
 				return literal.Token.Text;
 
 			case PrefixUnaryExpressionSyntax prefixUnary:

--- a/src/CommunityToolkit.Maui.SourceGenerators/Helpers/InitializerExpressionResolver.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Helpers/InitializerExpressionResolver.cs
@@ -182,13 +182,13 @@ static class InitializerExpressionResolver
 				return false; // Reject properties, non-readonly fields, methods, etc.
 		}
 
-		if (!TryResolveExpression(memberAccess.Expression, semanticModel, out var receiver))
+		if (!TryResolveExpression(memberAccess.Expression, semanticModel, out _))
 		{
 			memberAccessString = null;
 			return false;
 		}
 
-		memberAccessString = $"{receiver}.{memberAccess.Name.Identifier.Text}";
+		memberAccessString = symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
 		return true;
 	}
 

--- a/src/CommunityToolkit.Maui.SourceGenerators/Helpers/InitializerExpressionResolver.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Helpers/InitializerExpressionResolver.cs
@@ -1,0 +1,287 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace CommunityToolkit.Maui.SourceGenerators.Helpers;
+
+/// <summary>
+/// Resolves property initializer expressions to fully qualified C# code suitable for use
+/// as the <c>defaultValue</c> parameter in <c>BindableProperty.Create</c>.
+/// </summary>
+static class InitializerExpressionResolver
+{
+	/// <summary>
+	/// Attempts to resolve an initializer expression to a fully qualified C# expression string.
+	/// Returns <c>null</c> if the expression cannot be resolved (e.g. collection expressions, complex lambdas).
+	/// </summary>
+	public static string? TryResolve(ExpressionSyntax expression, SemanticModel semanticModel)
+	{
+		// Try symbolic resolution first, preserves readable identifiers like float.Epsilon
+		var resolved = TryResolveExpression(expression, semanticModel);
+		if (resolved is not null)
+		{
+			return resolved;
+		}
+
+		// Fall back to constant folding, handles nameof(), some compiler-reduced expressions
+		var constantValue = semanticModel.GetConstantValue(expression);
+		if (constantValue.HasValue)
+		{
+			var typeInfo = semanticModel.GetTypeInfo(expression);
+			return FormatConstantValue(constantValue.Value, typeInfo.Type);
+		}
+
+		return null;
+	}
+
+	static string? TryResolveExpression(ExpressionSyntax expression, SemanticModel semanticModel)
+	{
+		switch (expression)
+		{
+			case LiteralExpressionSyntax literal:
+				return literal.Token.Text;
+
+			case PrefixUnaryExpressionSyntax prefixUnary:
+				var operand = TryResolveExpression(prefixUnary.Operand, semanticModel);
+				if (operand is null)
+				{
+					return null;
+				}
+				return $"{prefixUnary.OperatorToken.Text}{operand}";
+
+			case MemberAccessExpressionSyntax memberAccess:
+				return TryResolveMemberAccess(memberAccess, semanticModel);
+
+			case IdentifierNameSyntax identifier:
+				return TryResolveIdentifier(identifier, semanticModel);
+
+			case PredefinedTypeSyntax:
+				// Keywords like int, double, string, valid as-is in generated code
+				return expression.ToString();
+
+			case CastExpressionSyntax castExpression:
+				var innerExpr = TryResolveExpression(castExpression.Expression, semanticModel);
+				if (innerExpr is null)
+				{
+					return null;
+				}
+				var castType = semanticModel.GetTypeInfo(castExpression.Type).Type;
+				if (castType is null)
+				{
+					return null;
+				}
+				var qualifiedCastType = castType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+				return $"({qualifiedCastType}){innerExpr}";
+
+			case ParenthesizedExpressionSyntax paren:
+				var inner = TryResolveExpression(paren.Expression, semanticModel);
+				return inner is not null ? $"({inner})" : null;
+
+			case BinaryExpressionSyntax binary:
+				var left = TryResolveExpression(binary.Left, semanticModel);
+				var right = TryResolveExpression(binary.Right, semanticModel);
+				if (left is null || right is null)
+				{
+					return null;
+				}
+				return $"{left} {binary.OperatorToken.Text} {right}";
+
+			case DefaultExpressionSyntax defaultExpr:
+				if (defaultExpr.Type is not null)
+				{
+					var defType = semanticModel.GetTypeInfo(defaultExpr.Type).Type;
+					if (defType is not null)
+					{
+						return $"default({defType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)})";
+					}
+				}
+				return "default";
+
+			case InvocationExpressionSyntax invocation:
+				return TryResolveInvocation(invocation, semanticModel);
+
+			case ObjectCreationExpressionSyntax objectCreation:
+				return TryResolveObjectCreation(objectCreation, semanticModel);
+
+			default:
+				// Collection expressions, lambdas, etc., cannot resolve
+				return null;
+		}
+	}
+
+	static string? TryResolveMemberAccess(MemberAccessExpressionSyntax memberAccess, SemanticModel semanticModel)
+	{
+		var receiver = TryResolveExpression(memberAccess.Expression, semanticModel);
+		if (receiver is null)
+		{
+			return null;
+		}
+
+		return $"{receiver}.{memberAccess.Name.Identifier.Text}";
+	}
+
+	static string? TryResolveIdentifier(IdentifierNameSyntax identifier, SemanticModel semanticModel)
+	{
+		var symbolInfo = semanticModel.GetSymbolInfo(identifier);
+		var symbol = symbolInfo.Symbol;
+
+		if (symbol is null)
+		{
+			return null;
+		}
+
+		// For type references (e.g. the "ValidationBehaviorDefaults" in "ValidationBehaviorDefaults.Flags")
+		if (symbol is INamedTypeSymbol typeSymbol)
+		{
+			return typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+		}
+
+		// For namespace references (e.g. "System" in "System.TimeSpan.Zero")
+		if (symbol is INamespaceSymbol namespaceSymbol)
+		{
+			return namespaceSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+		}
+
+		// For static field/property references used as standalone identifiers
+		if (symbol is IFieldSymbol { IsStatic: true } or IPropertySymbol { IsStatic: true })
+		{
+			var containingType = symbol.ContainingType;
+			if (containingType is not null)
+			{
+				return $"{containingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}.{symbol.Name}";
+			}
+		}
+
+		return null;
+	}
+
+	static string? TryResolveInvocation(InvocationExpressionSyntax invocation, SemanticModel semanticModel)
+	{
+		var methodExpr = TryResolveExpression(invocation.Expression, semanticModel);
+		if (methodExpr is null)
+		{
+			return null;
+		}
+
+		// Resolve type arguments if present
+		var symbolInfo = semanticModel.GetSymbolInfo(invocation);
+		if (symbolInfo.Symbol is IMethodSymbol methodSymbol && methodSymbol.IsGenericMethod)
+		{
+			var typeArgs = string.Join(", ", methodSymbol.TypeArguments.Select(
+				t => t.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)));
+			// Replace the method name with the generic version
+			var lastDot = methodExpr.LastIndexOf('.');
+			if (lastDot >= 0)
+			{
+				methodExpr = $"{methodExpr[..lastDot]}.{methodSymbol.Name}<{typeArgs}>";
+			}
+			else
+			{
+				methodExpr = $"{methodSymbol.Name}<{typeArgs}>";
+			}
+		}
+
+		var args = new List<string>(invocation.ArgumentList.Arguments.Count);
+		foreach (var arg in invocation.ArgumentList.Arguments)
+		{
+			var resolved = TryResolveExpression(arg.Expression, semanticModel);
+			if (resolved is null)
+			{
+				return null;
+			}
+			args.Add(resolved);
+		}
+
+		return $"{methodExpr}({string.Join(", ", args)})";
+	}
+
+	static string? TryResolveObjectCreation(ObjectCreationExpressionSyntax objectCreation, SemanticModel semanticModel)
+	{
+		var typeInfo = semanticModel.GetTypeInfo(objectCreation);
+		if (typeInfo.Type is null)
+		{
+			return null;
+		}
+
+		var qualifiedTypeName = typeInfo.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+
+		if (objectCreation.ArgumentList is null || objectCreation.ArgumentList.Arguments.Count is 0)
+		{
+			return $"new {qualifiedTypeName}()";
+		}
+
+		var args = new List<string>(objectCreation.ArgumentList.Arguments.Count);
+		foreach (var arg in objectCreation.ArgumentList.Arguments)
+		{
+			var resolved = TryResolveExpression(arg.Expression, semanticModel);
+			if (resolved is null)
+			{
+				return null;
+			}
+			args.Add(resolved);
+		}
+
+		return $"new {qualifiedTypeName}({string.Join(", ", args)})";
+	}
+
+	static string FormatConstantValue(object? value, ITypeSymbol? typeSymbol)
+	{
+		if (value is null)
+		{
+			return "null";
+		}
+
+		// For enum types, cast the underlying value to the enum type
+		if (typeSymbol is INamedTypeSymbol { TypeKind: TypeKind.Enum } enumType)
+		{
+			var qualifiedType = enumType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+			return $"({qualifiedType}){FormatPrimitiveValue(value)}";
+		}
+
+		return FormatPrimitiveValue(value);
+	}
+
+	static string FormatPrimitiveValue(object value) => value switch
+	{
+		bool b => b ? "true" : "false",
+		char c => $"'{EscapeChar(c)}'",
+		string s => $"\"{EscapeString(s)}\"",
+		float f => float.IsPositiveInfinity(f) ? "float.PositiveInfinity"
+			: float.IsNegativeInfinity(f) ? "float.NegativeInfinity"
+			: float.IsNaN(f) ? "float.NaN"
+			: $"{f}f",
+		double d => double.IsPositiveInfinity(d) ? "double.PositiveInfinity"
+			: double.IsNegativeInfinity(d) ? "double.NegativeInfinity"
+			: double.IsNaN(d) ? "double.NaN"
+			: FormattableString.Invariant($"{d}d"),
+		decimal m => FormattableString.Invariant($"{m}m"),
+		byte b => b.ToString(),
+		sbyte sb => sb.ToString(),
+		short s => s.ToString(),
+		ushort us => us.ToString(),
+		int i => i.ToString(),
+		uint u => $"{u}u",
+		long l => $"{l}L",
+		ulong ul => $"{ul}UL",
+		_ => value.ToString() ?? "null"
+	};
+
+	static string EscapeChar(char c) => c switch
+	{
+		'\'' => @"\'",
+		'\\' => @"\\",
+		'\0' => @"\0",
+		'\n' => @"\n",
+		'\r' => @"\r",
+		'\t' => @"\t",
+		_ => c.ToString()
+	};
+
+	static string EscapeString(string s) => s
+		.Replace("\\", @"\\")
+		.Replace("\"", @"\""")
+		.Replace("\n", @"\n")
+		.Replace("\r", @"\r")
+		.Replace("\t", @"\t")
+		.Replace("\0", @"\0");
+}

--- a/src/CommunityToolkit.Maui.SourceGenerators/Helpers/InitializerExpressionResolver.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Helpers/InitializerExpressionResolver.cs
@@ -182,13 +182,13 @@ static class InitializerExpressionResolver
 				return false; // Reject properties, non-readonly fields, methods, etc.
 		}
 
-		if (!TryResolveExpression(memberAccess.Expression, semanticModel, out _))
+		if (!TryResolveExpression(memberAccess.Expression, semanticModel, out var receiver))
 		{
 			memberAccessString = null;
 			return false;
 		}
 
-		memberAccessString = symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+		memberAccessString = $"{receiver}.{memberAccess.Name.Identifier.Text}";
 		return true;
 	}
 

--- a/src/CommunityToolkit.Maui.SourceGenerators/Helpers/InitializerExpressionResolver.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Helpers/InitializerExpressionResolver.cs
@@ -254,7 +254,7 @@ static class InitializerExpressionResolver
 		float f => float.IsPositiveInfinity(f) ? "float.PositiveInfinity"
 			: float.IsNegativeInfinity(f) ? "float.NegativeInfinity"
 			: float.IsNaN(f) ? "float.NaN"
-			: $"{f}f",
+			: global::System.FormattableString.Invariant($"{f}f"),
 		double d => double.IsPositiveInfinity(d) ? "double.PositiveInfinity"
 			: double.IsNegativeInfinity(d) ? "double.NegativeInfinity"
 			: double.IsNaN(d) ? "double.NaN"

--- a/src/CommunityToolkit.Maui.SourceGenerators/Helpers/InitializerExpressionResolver.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Helpers/InitializerExpressionResolver.cs
@@ -105,8 +105,10 @@ static class InitializerExpressionResolver
 				}
 				return "default";
 
-			case InvocationExpressionSyntax invocation:
-				return TryResolveInvocation(invocation, semanticModel);
+			case InvocationExpressionSyntax:
+				// Invocations (e.g. Guid.NewGuid(), TimeSpan.FromSeconds(5)) may return different
+				// values per call; resolve only if GetConstantValue can fold them (e.g. nameof()).
+				return null;
 
 			case ObjectCreationExpressionSyntax objectCreation:
 				var objectCreationType = semanticModel.GetTypeInfo(objectCreation).Type;
@@ -124,6 +126,24 @@ static class InitializerExpressionResolver
 
 	static string? TryResolveMemberAccess(MemberAccessExpressionSyntax memberAccess, SemanticModel semanticModel)
 	{
+		// Only resolve member accesses that are provably safe to evaluate once and share
+		// across all instances (type/namespace navigation, const fields, static readonly fields).
+		// Reject static properties (e.g. DateTimeOffset.UtcNow) which may return different
+		// values per call or have side effects.
+		var symbol = semanticModel.GetSymbolInfo(memberAccess).Symbol;
+		switch (symbol)
+		{
+			case INamedTypeSymbol:
+			case INamespaceSymbol:
+				break; // Type/namespace navigation, always safe
+			case IFieldSymbol { IsConst: true }:
+				break; // Compile-time constants (including enum members)
+			case IFieldSymbol { IsStatic: true, IsReadOnly: true }:
+				break; // Static readonly fields (e.g. TimeSpan.Zero)
+			default:
+				return null; // Reject properties, non-readonly fields, methods, etc.
+		}
+
 		var receiver = TryResolveExpression(memberAccess.Expression, semanticModel);
 		if (receiver is null)
 		{
@@ -155,8 +175,8 @@ static class InitializerExpressionResolver
 			return namespaceSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
 		}
 
-		// For static field/property references used as standalone identifiers
-		if (symbol is IFieldSymbol { IsStatic: true } or IPropertySymbol { IsStatic: true })
+		// For const or static readonly field references used as standalone identifiers
+		if (symbol is IFieldSymbol { IsConst: true } or IFieldSymbol { IsStatic: true, IsReadOnly: true })
 		{
 			var containingType = symbol.ContainingType;
 			if (containingType is not null)

--- a/src/CommunityToolkit.Maui.SourceGenerators/Helpers/InitializerExpressionResolver.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Helpers/InitializerExpressionResolver.cs
@@ -188,46 +188,6 @@ static class InitializerExpressionResolver
 		return null;
 	}
 
-	static string? TryResolveInvocation(InvocationExpressionSyntax invocation, SemanticModel semanticModel)
-	{
-		var methodExpr = TryResolveExpression(invocation.Expression, semanticModel);
-		if (methodExpr is null)
-		{
-			return null;
-		}
-
-		// Resolve type arguments if present
-		var symbolInfo = semanticModel.GetSymbolInfo(invocation);
-		if (symbolInfo.Symbol is IMethodSymbol methodSymbol && methodSymbol.IsGenericMethod)
-		{
-			var typeArgs = string.Join(", ", methodSymbol.TypeArguments.Select(
-				t => t.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)));
-			// Replace the method name with the generic version
-			var lastDot = methodExpr.LastIndexOf('.');
-			if (lastDot >= 0)
-			{
-				methodExpr = $"{methodExpr[..lastDot]}.{methodSymbol.Name}<{typeArgs}>";
-			}
-			else
-			{
-				methodExpr = $"{methodSymbol.Name}<{typeArgs}>";
-			}
-		}
-
-		var args = new List<string>(invocation.ArgumentList.Arguments.Count);
-		foreach (var arg in invocation.ArgumentList.Arguments)
-		{
-			var resolved = TryResolveExpression(arg.Expression, semanticModel);
-			if (resolved is null)
-			{
-				return null;
-			}
-			args.Add(resolved);
-		}
-
-		return $"{methodExpr}({string.Join(", ", args)})";
-	}
-
 	static string? TryResolveObjectCreation(ObjectCreationExpressionSyntax objectCreation, SemanticModel semanticModel)
 	{
 		var typeInfo = semanticModel.GetTypeInfo(objectCreation);

--- a/src/CommunityToolkit.Maui.SourceGenerators/Helpers/InitializerExpressionResolver.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Helpers/InitializerExpressionResolver.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -14,13 +15,13 @@ static class InitializerExpressionResolver
 	/// Attempts to resolve an initializer expression to a fully qualified C# expression string.
 	/// Returns <c>null</c> if the expression cannot be resolved (e.g. collection expressions, complex lambdas).
 	/// </summary>
-	public static string? TryResolve(ExpressionSyntax expression, SemanticModel semanticModel)
+	public static bool TryResolve(ExpressionSyntax expression, SemanticModel semanticModel, [NotNullWhen(true)] out string? resolvedExpressionString)
 	{
 		// Try symbolic resolution first, preserves readable identifiers like float.Epsilon
-		var resolved = TryResolveExpression(expression, semanticModel);
-		if (resolved is not null)
+		if (TryResolveExpression(expression, semanticModel, out var resolved))
 		{
-			return resolved;
+			resolvedExpressionString = resolved;
+			return true;
 		}
 
 		// Fall back to constant folding, handles nameof(), some compiler-reduced expressions
@@ -28,13 +29,15 @@ static class InitializerExpressionResolver
 		if (constantValue.HasValue)
 		{
 			var typeInfo = semanticModel.GetTypeInfo(expression);
-			return FormatConstantValue(constantValue.Value, typeInfo.Type);
+			resolvedExpressionString = FormatConstantValue(constantValue.Value, typeInfo.Type);
+			return true;
 		}
 
-		return null;
+		resolvedExpressionString = null;
+		return false;
 	}
 
-	static string? TryResolveExpression(ExpressionSyntax expression, SemanticModel semanticModel)
+	static bool TryResolveExpression(ExpressionSyntax expression, SemanticModel semanticModel, [NotNullWhen(true)] out string? resolvedExpressionString)
 	{
 		switch (expression)
 		{
@@ -44,55 +47,73 @@ static class InitializerExpressionResolver
 					var defaultLiteralType = semanticModel.GetTypeInfo(literal).Type;
 					if (defaultLiteralType is not null)
 					{
-						return $"default({defaultLiteralType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)})";
+						resolvedExpressionString = $"default({defaultLiteralType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)})";
+						return true;
 					}
 				}
-				return literal.Token.Text;
+
+				resolvedExpressionString = literal.Token.Text;
+				return true;
 
 			case PrefixUnaryExpressionSyntax prefixUnary:
-				var operand = TryResolveExpression(prefixUnary.Operand, semanticModel);
-				if (operand is null)
+				if (!TryResolveExpression(prefixUnary.Operand, semanticModel, out var operand))
 				{
-					return null;
+					resolvedExpressionString = null;
+					return false;
 				}
-				return $"{prefixUnary.OperatorToken.Text}{operand}";
+
+				resolvedExpressionString = $"{prefixUnary.OperatorToken.Text}{operand}";
+				return true;
 
 			case MemberAccessExpressionSyntax memberAccess:
-				return TryResolveMemberAccess(memberAccess, semanticModel);
+				return TryResolveMemberAccess(memberAccess, semanticModel, out resolvedExpressionString);
 
 			case IdentifierNameSyntax identifier:
-				return TryResolveIdentifier(identifier, semanticModel);
+				return TryResolveIdentifier(identifier, semanticModel, out resolvedExpressionString);
 
 			case PredefinedTypeSyntax:
 				// Keywords like int, double, string, valid as-is in generated code
-				return expression.ToString();
+				resolvedExpressionString = expression.ToString();
+				return true;
 
 			case CastExpressionSyntax castExpression:
-				var innerExpr = TryResolveExpression(castExpression.Expression, semanticModel);
-				if (innerExpr is null)
+				if (!TryResolveExpression(castExpression.Expression, semanticModel, out var innerExpression))
 				{
-					return null;
+					resolvedExpressionString = null;
+					return false;
 				}
+
 				var castType = semanticModel.GetTypeInfo(castExpression.Type).Type;
 				if (castType is null)
 				{
-					return null;
+					resolvedExpressionString = null;
+					return false;
 				}
+
 				var qualifiedCastType = castType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-				return $"({qualifiedCastType}){innerExpr}";
+				resolvedExpressionString = $"({qualifiedCastType}){innerExpression}";
+
+				return true;
 
 			case ParenthesizedExpressionSyntax paren:
-				var inner = TryResolveExpression(paren.Expression, semanticModel);
-				return inner is not null ? $"({inner})" : null;
+				if (!TryResolveExpression(paren.Expression, semanticModel, out var inner))
+				{
+					resolvedExpressionString = null;
+					return false;
+				}
+
+				resolvedExpressionString = $"({inner})";
+				return true;
 
 			case BinaryExpressionSyntax binary:
-				var left = TryResolveExpression(binary.Left, semanticModel);
-				var right = TryResolveExpression(binary.Right, semanticModel);
-				if (left is null || right is null)
+				if (!TryResolveExpression(binary.Left, semanticModel, out var left) || !TryResolveExpression(binary.Right, semanticModel, out var right))
 				{
-					return null;
+					resolvedExpressionString = null;
+					return false;
 				}
-				return $"{left} {binary.OperatorToken.Text} {right}";
+
+				resolvedExpressionString = $"{left} {binary.OperatorToken.Text} {right}";
+				return true;
 
 			case DefaultExpressionSyntax defaultExpr:
 				if (defaultExpr.Type is not null)
@@ -100,38 +121,47 @@ static class InitializerExpressionResolver
 					var defType = semanticModel.GetTypeInfo(defaultExpr.Type).Type;
 					if (defType is not null)
 					{
-						return $"default({defType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)})";
+						resolvedExpressionString = $"default({defType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)})";
+						return true;
 					}
 				}
-				return "default";
+
+				resolvedExpressionString = "default";
+				return true;
 
 			case InvocationExpressionSyntax:
 				// Invocations (e.g. Guid.NewGuid(), TimeSpan.FromSeconds(5)) may return different
 				// values per call; resolve only if GetConstantValue can fold them (e.g. nameof()).
-				return null;
+				resolvedExpressionString = null;
+				return false;
 
 			case ObjectCreationExpressionSyntax objectCreation:
 				var objectCreationType = semanticModel.GetTypeInfo(objectCreation).Type;
 				if (objectCreationType is null || !objectCreationType.IsValueType)
 				{
-					return null;
+					resolvedExpressionString = null;
+					return false;
 				}
+
 				// Could incorrectly drop the initializer block if present, so early exit in that case
 				// to avoid this. If required can add a traversal to resolve the initializer block,
 				// but probably a rare case so not worth the complexity for now.
 				if (objectCreation.Initializer is not null)
 				{
-					return null;
+					resolvedExpressionString = null;
+					return false;
 				}
-				return TryResolveObjectCreation(objectCreation, semanticModel);
+
+				return TryResolveObjectCreation(objectCreation, semanticModel, out resolvedExpressionString);
 
 			default:
 				// Collection expressions, lambdas, etc., cannot resolve
-				return null;
+				resolvedExpressionString = null;
+				return false;
 		}
 	}
 
-	static string? TryResolveMemberAccess(MemberAccessExpressionSyntax memberAccess, SemanticModel semanticModel)
+	static bool TryResolveMemberAccess(MemberAccessExpressionSyntax memberAccess, SemanticModel semanticModel, [NotNullWhen(true)] out string? memberAccessString)
 	{
 		// Only resolve member accesses that are provably safe to evaluate once and share
 		// across all instances (type/namespace navigation, const fields, static readonly fields).
@@ -148,38 +178,43 @@ static class InitializerExpressionResolver
 			case IFieldSymbol { IsStatic: true, IsReadOnly: true }:
 				break; // Static readonly fields (e.g. TimeSpan.Zero)
 			default:
-				return null; // Reject properties, non-readonly fields, methods, etc.
+				memberAccessString = null;
+				return false; // Reject properties, non-readonly fields, methods, etc.
 		}
 
-		var receiver = TryResolveExpression(memberAccess.Expression, semanticModel);
-		if (receiver is null)
+		if (!TryResolveExpression(memberAccess.Expression, semanticModel, out var receiver))
 		{
-			return null;
+			memberAccessString = null;
+			return false;
 		}
 
-		return $"{receiver}.{memberAccess.Name.Identifier.Text}";
+		memberAccessString = $"{receiver}.{memberAccess.Name.Identifier.Text}";
+		return true;
 	}
 
-	static string? TryResolveIdentifier(IdentifierNameSyntax identifier, SemanticModel semanticModel)
+	static bool TryResolveIdentifier(IdentifierNameSyntax identifier, SemanticModel semanticModel, [NotNullWhen(true)] out string? identifierString)
 	{
 		var symbolInfo = semanticModel.GetSymbolInfo(identifier);
 		var symbol = symbolInfo.Symbol;
 
 		if (symbol is null)
 		{
-			return null;
+			identifierString = null;
+			return false;
 		}
 
 		// For type references (e.g. the "ValidationBehaviorDefaults" in "ValidationBehaviorDefaults.Flags")
 		if (symbol is INamedTypeSymbol typeSymbol)
 		{
-			return typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+			identifierString = typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+			return true;
 		}
 
 		// For namespace references (e.g. "System" in "System.TimeSpan.Zero")
 		if (symbol is INamespaceSymbol namespaceSymbol)
 		{
-			return namespaceSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+			identifierString = namespaceSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+			return true;
 		}
 
 		// For const or static readonly field references used as standalone identifiers
@@ -188,40 +223,48 @@ static class InitializerExpressionResolver
 			var containingType = symbol.ContainingType;
 			if (containingType is not null)
 			{
-				return $"{containingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}.{symbol.Name}";
+				identifierString = $"{containingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}.{symbol.Name}";
+				return true;
 			}
 		}
 
-		return null;
+		identifierString = null;
+		return false;
 	}
 
-	static string? TryResolveObjectCreation(ObjectCreationExpressionSyntax objectCreation, SemanticModel semanticModel)
+	static bool TryResolveObjectCreation(ObjectCreationExpressionSyntax objectCreation, SemanticModel semanticModel, [NotNullWhen(true)] out string? objectCreationString)
 	{
 		var typeInfo = semanticModel.GetTypeInfo(objectCreation);
 		if (typeInfo.Type is null)
 		{
-			return null;
+			objectCreationString = null;
+			return false;
 		}
 
 		var qualifiedTypeName = typeInfo.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
 
 		if (objectCreation.ArgumentList is null || objectCreation.ArgumentList.Arguments.Count is 0)
 		{
-			return $"new {qualifiedTypeName}()";
+			objectCreationString = $"new {qualifiedTypeName}()";
+			return true;
 		}
 
 		var args = new List<string>(objectCreation.ArgumentList.Arguments.Count);
 		foreach (var arg in objectCreation.ArgumentList.Arguments)
 		{
-			var resolved = TryResolveExpression(arg.Expression, semanticModel);
-			if (resolved is null)
+			if (TryResolveExpression(arg.Expression, semanticModel, out var resolved))
 			{
-				return null;
+				args.Add(resolved);
 			}
-			args.Add(resolved);
+			else
+			{
+				objectCreationString = null;
+				return false;
+			}
 		}
 
-		return $"new {qualifiedTypeName}({string.Join(", ", args)})";
+		objectCreationString = $"new {qualifiedTypeName}({string.Join(", ", args)})";
+		return true;
 	}
 
 	static string FormatConstantValue(object? value, ITypeSymbol? typeSymbol)

--- a/src/CommunityToolkit.Maui.SourceGenerators/Helpers/InitializerExpressionResolver.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Helpers/InitializerExpressionResolver.cs
@@ -116,6 +116,13 @@ static class InitializerExpressionResolver
 				{
 					return null;
 				}
+				// Could incorrectly drop the initializer block if present, so early exit in that case
+				// to avoid this. If required can add a traversal to resolve the initializer block,
+				// but probably a rare case so not worth the complexity for now.
+				if (objectCreation.Initializer is not null)
+				{
+					return null;
+				}
 				return TryResolveObjectCreation(objectCreation, semanticModel);
 
 			default:

--- a/src/CommunityToolkit.Maui.SourceGenerators/Models/BindablePropertyRecords.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Models/BindablePropertyRecords.cs
@@ -3,10 +3,11 @@ using Microsoft.CodeAnalysis;
 
 namespace CommunityToolkit.Maui.SourceGenerators.Models;
 
-public record BindablePropertyModel(string PropertyName, ITypeSymbol ReturnType, ITypeSymbol DeclaringType, string DefaultBindingMode, string ValidateValueMethodName, string PropertyChangedMethodName, string PropertyChangingMethodName, string CoerceValueMethodName, string DefaultValueCreatorMethodName, string NewKeywordText, bool IsReadOnlyBindableProperty, string? SetterAccessibility, bool HasInitializer, string? PropertyAccessibility)
+public record BindablePropertyModel(string PropertyName, ITypeSymbol ReturnType, ITypeSymbol DeclaringType, string DefaultBindingMode, string ValidateValueMethodName, string PropertyChangedMethodName, string PropertyChangingMethodName, string CoerceValueMethodName, string DefaultValueCreatorMethodName, string NewKeywordText, bool IsReadOnlyBindableProperty, string? SetterAccessibility, bool HasInitializer, string? PropertyAccessibility, string? ResolvedInitializerExpression = null)
 {
 	// When both a DefaultValueCreatorMethodName and an initializer are provided, we implement the DefaultValueCreator method and the ignore the partial Property initializer
-	public bool ShouldUsePropertyInitializer => HasInitializer && DefaultValueCreatorMethodName is "null";
+	public bool ShouldUsePropertyInitializer => HasInitializer && DefaultValueCreatorMethodName is "null" && ResolvedInitializerExpression is null;
+	public bool ShouldUseDirectDefaultValue => ResolvedInitializerExpression is not null;
 	public string BindablePropertyName => $"{PropertyName}Property";
 	public string BindablePropertyKeyName => $"{char.ToLower(PropertyName[0])}{PropertyName[1..]}PropertyKey";
 	public string EffectiveDefaultValueCreatorMethodName => ShouldUsePropertyInitializer ? $"CreateDefault{PropertyName}" : DefaultValueCreatorMethodName;

--- a/src/CommunityToolkit.Maui.SourceGenerators/Models/BindablePropertyRecords.cs
+++ b/src/CommunityToolkit.Maui.SourceGenerators/Models/BindablePropertyRecords.cs
@@ -3,7 +3,7 @@ using Microsoft.CodeAnalysis;
 
 namespace CommunityToolkit.Maui.SourceGenerators.Models;
 
-public record BindablePropertyModel(string PropertyName, ITypeSymbol ReturnType, ITypeSymbol DeclaringType, string DefaultBindingMode, string ValidateValueMethodName, string PropertyChangedMethodName, string PropertyChangingMethodName, string CoerceValueMethodName, string DefaultValueCreatorMethodName, string NewKeywordText, bool IsReadOnlyBindableProperty, string? SetterAccessibility, bool HasInitializer, string? PropertyAccessibility, string? ResolvedInitializerExpression = null)
+public record BindablePropertyModel(string PropertyName, ITypeSymbol ReturnType, ITypeSymbol DeclaringType, string DefaultBindingMode, string ValidateValueMethodName, string PropertyChangedMethodName, string PropertyChangingMethodName, string CoerceValueMethodName, string DefaultValueCreatorMethodName, string NewKeywordText, bool IsReadOnlyBindableProperty, string? SetterAccessibility, bool HasInitializer, string? PropertyAccessibility, string? ResolvedInitializerExpression)
 {
 	// When both a DefaultValueCreatorMethodName and an initializer are provided, we implement the DefaultValueCreator method and the ignore the partial Property initializer
 	public bool ShouldUsePropertyInitializer => HasInitializer && DefaultValueCreatorMethodName is "null" && ResolvedInitializerExpression is null;

--- a/src/CommunityToolkit.Maui.UnitTests/Services/PopupServiceTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Services/PopupServiceTests.cs
@@ -653,12 +653,12 @@ class MockSelfClosingPopup : Popup<object?>, IQueryAttributable, IDisposable
 		}
 
 		Console.WriteLine(
-			$@"{DateTime.Now:O} Closing {BindingContext.GetType().Name} - {Application.Current?.Windows[0].Page?.Navigation.ModalStack.Count}");
+			$@"{DateTime.Now:O} Closing {BindingContext.GetType().Name} - {Application.Current?.Windows.FirstOrDefault()?.Page?.Navigation.ModalStack.Count}");
 
 		await CloseAsync(Result, cancellationTokenSource?.Token ?? TestContext.Current.CancellationToken);
 
 		Console.WriteLine(
-			$@"{DateTime.Now:O} Closed {BindingContext.GetType().Name} - {Application.Current?.Windows[0].Page?.Navigation.ModalStack.Count}");
+			$@"{DateTime.Now:O} Closed {BindingContext.GetType().Name} - {Application.Current?.Windows.FirstOrDefault()?.Page?.Navigation.ModalStack.Count}");
 
 		popupClosedTCS.SetResult();
 	}

--- a/src/CommunityToolkit.Maui/Behaviors/Validators/ValidationBehavior.shared.cs
+++ b/src/CommunityToolkit.Maui/Behaviors/Validators/ValidationBehavior.shared.cs
@@ -191,7 +191,7 @@ public abstract partial class ValidationBehavior : BaseBehavior<VisualElement>, 
 			currentStatus = ValidationFlags.ValidateOnAttaching;
 
 			OnValuePropertyNamePropertyChanged();
-			await UpdateStateAsync(View, Flags, false).ConfigureAwait(false);
+			await UpdateStateAsync(View, Flags, false);
 		}
 		finally
 		{
@@ -221,7 +221,7 @@ public abstract partial class ValidationBehavior : BaseBehavior<VisualElement>, 
 				false => ValidationFlags.ValidateOnUnfocused
 			};
 
-			await UpdateStateAsync(View, Flags, false).ConfigureAwait(false);
+			await UpdateStateAsync(View, Flags, false);
 		}
 	}
 
@@ -233,8 +233,15 @@ public abstract partial class ValidationBehavior : BaseBehavior<VisualElement>, 
 	/// <param name="newValue"></param>
 	protected static async void OnValidationPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 	{
-		var validationBehavior = (ValidationBehavior)bindable;
-		await validationBehavior.UpdateStateAsync(validationBehavior.View, validationBehavior.Flags, false).ConfigureAwait(false);
+		try
+		{
+			var validationBehavior = (ValidationBehavior)bindable;
+			await validationBehavior.UpdateStateAsync(validationBehavior.View, validationBehavior.Flags, false);
+		}
+		catch (Exception ex) when (Options.ShouldSuppressExceptionsInBehaviors)
+		{
+			Trace.TraceInformation("{0}", ex);
+		}
 	}
 
 	static void OnIsValidPropertyChanged(BindableObject bindable, object oldValue, object newValue)


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

 <!-- Describe your changes here. This only needs to be brief as the linked issues below will already cover the detailed changes. -->

The source generator wraps all property initializers in a `defaultValueCreator` delegate. This causes intermittent failures in unit tests:

```
ArgumentException: An item with the same key has already been added. Key: Microsoft.Maui.Controls.BindableProperty
``` 

This could also theoretically surface in production code with concurrent property access, which is highly unlikely as test context differs in some important ways (specifically having a UI thread/synchronization context), but possible.

**Root cause:**

This was quite hard to track down. `BindableProperty.Create` with `defaultValueCreator:` uses a lazy-initialization path, that eventually hits `BindableObject.GetValue()` that performs a dictionary write on first access. `Dictionary` is not threadsafe, and when multiple threads access the property concurrently before it has been initialized, the dictionary write races and throws. Hand-written BindableProperties using `defaultValue:` follow a pure-read path and never hit this race.

I note that there were some protections against this in the code already (`volatile` on the init flag), but this wasn't working as expected. The [documentation for the `volatile` keyword](https://learn.microsoft.com/dotnet/csharp/language-reference/keywords/volatile) notes that the affected field is excluded from certain optimizations to help with concurrency, but warnings highlight that higher-level alternatives are recommended, and specifically:

> On a multiprocessor system, a volatile read operation doesn't guarantee to obtain the latest value written to that memory location by any processor. Similarly, a volatile write operation doesn't guarantee that the value written is immediately visible to other processors.

Presumably this is the scenario encountered during tests.

Two other changes attempted to address this:

* Removing `ConfigureAwait(false)`: this is correct as in UI bound operations the bindable property has thread affinity, and the operation should always return to the caller, but while this seemed to help, it didn't resolve the issue.
* Adding `[ThreadStatic]` to the initialized flag: appeared to resolve the problem at first and had a bigger impact, but was not reliably consistent. As mentioned above, eventually we hit the internal values dictionary in `BindableObject.GetValue()` and there's no way around this if using `defaultValueCreator`.

**Solution:**

The fundamental problem is using static values in bindable property generators in multi-threaded scenarios (as noted in #3096, see below  linked issues). This was required in some scenarios (and still is, the current approach is retained as a fallback), but it's also possible to infer the default value at compile time.

A new resolver/helper parses the initializer expression and generates fully-qualified C# code at compile time. This completely eliminates the issue as the code path that hits the `BindableObject.GetValue` method at runtime never encounters an empty value. The bindable properties in the toolkit have been updated to use this, which resolves all build issues. I've successfully re-run this several times with no failed builds.

**Summary of changes:**

* **New `InitializerExpressionResolver`**: This is the core of the change. A helper resolves property initializer expressions (literals, enum members, `default`, `new T()`, static field/property references, casts, etc.) to fully-qualified C# code at compile time. Unresolvable expressions (collection expressions `[]`, lambdas, complex method calls) return `null` and fall back to the existing `defaultValueCreator` path.

* **Updated `BindablePropertyAttributeSourceGenerator`**: When the resolver succeeds, emits the resolved expression directly as the `defaultValue:` parameter instead of wrapping it in a `defaultValueCreator` delegate. When it cannot resolve (or when the user explicitly sets `DefaultValueCreatorMethodName`), behavior is unchanged.

* **ValidationBehavior fix**: Removed `.ConfigureAwait(false)` from three `async void` override methods (`OnAttachedTo`, `OnViewPropertyChanged`, `OnValidationPropertyChanged`). In `async void` methods, `.ConfigureAwait(false)` can cause continuations to run on thread pool threads, leading to race conditions in test environments without a `SynchronizationContext`. Added try/catch to `OnValidationPropertyChanged` with `Options.ShouldSuppressExceptionsInBehaviors` guard.

* **PopupServiceTests fix**: Changed `Windows[0]` to `Windows.FirstOrDefault()` in debug logging to prevent `ArgumentOutOfRangeException` when no windows exist during test teardown. (Unrelated issue but was the only thing blocking a clean build so I added this).


 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #3187
  - **Note**: Complementary to #3096 which adds an analyzer (MCT003) warning when `DefaultValueCreatorMethodName` unnecessarily wraps a static value. This PR addresses the same underlying problem from the generator side, preventing unnecessary `defaultValueCreator` delegates from being emitted in the first place.

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: No documentation changes as it is not a public facing API change, and I don't think there are docs that cover this yet anyway.

 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
