### PR TITLE
CameraView torch support

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/Pages/Views/CameraView/CameraViewPage.xaml
+++ b/samples/CommunityToolkit.Maui.Sample/Pages/Views/CameraView/CameraViewPage.xaml
@@ -14,6 +14,7 @@
             x:Name="Camera"
             Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Grid.RowSpan="3"
             CameraFlashMode="{Binding FlashMode}"
+            IsTorchOn="{Binding IsTorchOn, Mode=TwoWay}"
             ZoomFactor="{Binding CurrentZoom}"
             ImageCaptureResolution="{Binding SelectedResolution}"
             SelectedCamera="{Binding SelectedCamera}"/>
@@ -71,6 +72,11 @@
                     IsVisible="{Binding Path=SelectedCamera.IsFlashSupported, FallbackValue=false}"
                     ItemsSource="{Binding FlashModes}"
                     SelectedItem="{Binding FlashMode}" />
+
+                <HorizontalStackLayout>
+                    <CheckBox IsChecked="{Binding IsTorchOn, Mode=TwoWay}" />
+                    <Label Text="Torch" VerticalOptions="Center" />
+                </HorizontalStackLayout>
 
                 <Button Command="{Binding StartCameraPreviewCommand, Source={x:Reference Camera}, x:DataType=toolkit:CameraView}"
                         CommandParameter="{Binding Token}"

--- a/samples/CommunityToolkit.Maui.Sample/ViewModels/Views/CameraView/CameraViewViewModel.cs
+++ b/samples/CommunityToolkit.Maui.Sample/ViewModels/Views/CameraView/CameraViewViewModel.cs
@@ -25,6 +25,9 @@ public partial class CameraViewViewModel : BaseViewModel
 	public partial CameraFlashMode FlashMode { get; set; }
 
 	[ObservableProperty]
+	public partial bool IsTorchOn { get; set; }
+
+	[ObservableProperty]
 	public partial CameraInfo? SelectedCamera { get; set; }
 
 	[ObservableProperty]

--- a/src/CommunityToolkit.Maui.Camera/CameraManager.android.cs
+++ b/src/CommunityToolkit.Maui.Camera/CameraManager.android.cs
@@ -136,6 +136,16 @@ partial class CameraManager
 		imageCapture.FlashMode = flashMode.ToPlatform();
 	}
 
+	public partial void UpdateIsTorchOn(bool isTorchOn)
+	{
+		if (cameraControl is null)
+		{
+			return;
+		}
+
+		cameraControl.EnableTorch(isTorchOn);
+	}
+
 	public partial void UpdateZoom(float zoomLevel)
 	{
 		cameraControl?.SetZoomRatio(zoomLevel);

--- a/src/CommunityToolkit.Maui.Camera/CameraManager.macios.cs
+++ b/src/CommunityToolkit.Maui.Camera/CameraManager.macios.cs
@@ -97,6 +97,31 @@ partial class CameraManager
 		this.flashMode = flashMode.ToPlatform();
 	}
 
+	public partial void UpdateIsTorchOn(bool isTorchOn)
+	{
+		if (!isInitialized ||
+			captureDevice is null ||
+			!captureDevice.TorchAvailable)
+		{
+			return;
+		}
+
+		bool isCurrentlyOn = captureDevice.TorchActive;
+
+		if (isCurrentlyOn != isTorchOn)
+		{
+			captureDevice.LockForConfiguration(out NSError? error);
+			if (error is not null)
+			{
+				Trace.WriteLine(error);
+				return;
+			}
+
+			captureDevice.TorchMode = isTorchOn ? AVCaptureTorchMode.On : AVCaptureTorchMode.Off;
+			captureDevice.UnlockForConfiguration();
+		}
+	}
+
 	public partial void UpdateZoom(float zoomLevel)
 	{
 		if (!isInitialized || captureDevice is null)

--- a/src/CommunityToolkit.Maui.Camera/CameraManager.net.cs
+++ b/src/CommunityToolkit.Maui.Camera/CameraManager.net.cs
@@ -10,6 +10,8 @@ sealed partial class CameraManager
 
 	public partial void UpdateFlashMode(CameraFlashMode flashMode) => throw new NotSupportedException(notSupportedMessage);
 
+	public partial void UpdateIsTorchOn(bool isTorchOn) => throw new NotSupportedException(notSupportedMessage);
+
 	public partial void UpdateZoom(float zoomLevel) => throw new NotSupportedException(notSupportedMessage);
 
 	public partial ValueTask UpdateCaptureResolution(Size resolution, CancellationToken token) => throw new NotSupportedException(notSupportedMessage);

--- a/src/CommunityToolkit.Maui.Camera/CameraManager.shared.cs
+++ b/src/CommunityToolkit.Maui.Camera/CameraManager.shared.cs
@@ -108,6 +108,12 @@ sealed partial class CameraManager(
 	public partial void UpdateFlashMode(CameraFlashMode flashMode);
 
 	/// <summary>
+	/// Updates if the torch of the camera is on.
+	/// </summary>
+	/// <param name="isTorchOn">The new <see cref="bool"/> value to set.</param>
+	public partial void UpdateIsTorchOn(bool isTorchOn);
+
+	/// <summary>
 	/// Updates the zoom level of the camera.
 	/// </summary>
 	/// <param name="zoomLevel">The new zoom level to set.</param>
@@ -122,7 +128,7 @@ sealed partial class CameraManager(
 	public partial ValueTask UpdateCaptureResolution(Size resolution, CancellationToken token);
 
 	/// <summary>
-	/// Performs the capturing of a picture at the platform-specific level. 
+	/// Performs the capturing of a picture at the platform-specific level.
 	/// </summary>
 	/// <param name="token">A <see cref="CancellationToken"/> that can be used to cancel the work.</param>
 	/// <returns>A <see cref="ValueTask"/> that can be awaited.</returns>

--- a/src/CommunityToolkit.Maui.Camera/CameraManager.tizen.cs
+++ b/src/CommunityToolkit.Maui.Camera/CameraManager.tizen.cs
@@ -10,6 +10,8 @@ partial class CameraManager
 
 	public partial void UpdateFlashMode(CameraFlashMode flashMode) => throw new NotSupportedException(notSupportedMessage);
 
+	public partial void UpdateIsTorchOn(bool isTorchOn) => throw new NotSupportedException(notSupportedMessage);
+
 	public partial void UpdateZoom(float zoomLevel) => throw new NotSupportedException(notSupportedMessage);
 
 	public partial ValueTask UpdateCaptureResolution(Size resolution, CancellationToken token) => throw new NotSupportedException(notSupportedMessage);

--- a/src/CommunityToolkit.Maui.Camera/CameraManager.windows.cs
+++ b/src/CommunityToolkit.Maui.Camera/CameraManager.windows.cs
@@ -58,7 +58,8 @@ partial class CameraManager
 
 	public partial void UpdateIsTorchOn(bool isTorchOn)
 	{
-		if (mediaCapture is null ||
+		if (!isInitialized ||
+			mediaCapture is null ||
 			!(mediaCapture.VideoDeviceController?.TorchControl?.Supported ?? false))
 		{
 			return;

--- a/src/CommunityToolkit.Maui.Camera/CameraManager.windows.cs
+++ b/src/CommunityToolkit.Maui.Camera/CameraManager.windows.cs
@@ -56,6 +56,22 @@ partial class CameraManager
 
 	}
 
+	public partial void UpdateIsTorchOn(bool isTorchOn)
+	{
+		if (mediaCapture is null ||
+			!(mediaCapture.VideoDeviceController?.TorchControl?.Supported ?? false))
+		{
+			return;
+		}
+
+		bool isCurrentlyOn = mediaCapture.VideoDeviceController.TorchControl.Enabled;
+
+		if (isTorchOn != isCurrentlyOn)
+		{
+			mediaCapture.VideoDeviceController.TorchControl.Enabled = isTorchOn;
+		}
+	}
+
 	public partial void UpdateZoom(float zoomLevel)
 	{
 		if (!isInitialized || mediaCapture is null || !mediaCapture.VideoDeviceController.ZoomControl.Supported)

--- a/src/CommunityToolkit.Maui.Camera/Handlers/CameraViewHandler.shared.cs
+++ b/src/CommunityToolkit.Maui.Camera/Handlers/CameraViewHandler.shared.cs
@@ -76,6 +76,7 @@ public partial class CameraViewHandler : ViewHandler<ICameraView, NativePlatform
 		void Init(ICameraView view)
 		{
 			MapCameraFlashMode(this, view);
+			MapIsTorchOn(this, view);
 			view.ZoomFactor = 1.0f;
 		}
 	}

--- a/src/CommunityToolkit.Maui.Camera/Handlers/CameraViewHandler.shared.cs
+++ b/src/CommunityToolkit.Maui.Camera/Handlers/CameraViewHandler.shared.cs
@@ -10,11 +10,12 @@ public partial class CameraViewHandler : ViewHandler<ICameraView, NativePlatform
 {
 	/// <summary>
 	/// The currently defined mappings between properties on the <see cref="ICameraView"/> and
-	/// properties on the <see cref="NativePlatformCameraPreviewView"/>. 
+	/// properties on the <see cref="NativePlatformCameraPreviewView"/>.
 	/// </summary>
 	public static IPropertyMapper<ICameraView, CameraViewHandler> PropertyMapper = new PropertyMapper<ICameraView, CameraViewHandler>(ViewMapper)
 	{
 		[nameof(ICameraView.CameraFlashMode)] = MapCameraFlashMode,
+		[nameof(ICameraView.IsTorchOn)] = MapIsTorchOn,
 		[nameof(ICameraView.IsAvailable)] = MapIsAvailable,
 		[nameof(ICameraView.ZoomFactor)] = MapZoomFactor,
 		[nameof(ICameraView.ImageCaptureResolution)] = MapImageCaptureResolution,
@@ -23,7 +24,7 @@ public partial class CameraViewHandler : ViewHandler<ICameraView, NativePlatform
 
 	/// <summary>
 	/// The currently defined mappings between commands on the <see cref="ICameraView"/> and
-	/// commands on the <see cref="NativePlatformCameraPreviewView"/>. 
+	/// commands on the <see cref="NativePlatformCameraPreviewView"/>.
 	/// </summary>
 	public static CommandMapper<ICameraView, CameraViewHandler> CommandMapper = new(ViewCommandMapper);
 
@@ -144,6 +145,11 @@ public partial class CameraViewHandler : ViewHandler<ICameraView, NativePlatform
 	static void MapCameraFlashMode(CameraViewHandler handler, ICameraView view)
 	{
 		handler.CameraManager.UpdateFlashMode(view.CameraFlashMode);
+	}
+
+	static void MapIsTorchOn(CameraViewHandler handler, ICameraView view)
+	{
+		handler.CameraManager.UpdateIsTorchOn(view.IsTorchOn);
 	}
 
 	static void MapZoomFactor(CameraViewHandler handler, ICameraView view)


### PR DESCRIPTION
 ### Description of Change ###

This implements the property mapper for the `CameraView` property `IsTorchOn`.  I based the property mapper on the code in the `ZXing.Net.MAUI` repository.

Tests were omitted, since this is not possible to test automatically. It has a sample, though. I didn't create a Documentation PR, since the property is already documented:
https://github.com/MicrosoftDocs/CommunityToolkit/blob/07e8463e67e4e24ed93d67490197cf4548537b71/docs/maui/views/camera-view.md?plain=1#L749

 ### Linked Issues ###

 - Fixes #1992
 - Fixes #2360

 ### PR Checklist ###

 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->

 ### Additional information ###

I tested this with an Android device. I will test it also on an iOS device, as soon as I figure out my deployment problems. Unfortunately I don't have a Windows device with integrated flash, so I couldn't test it on that platform.