### PR TITLE
Fix Windows DrawingView image rendering so exported/rendered strokes use the correct (round) line caps

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Views/DrawingView/Service/DrawingViewService.windows.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/DrawingView/Service/DrawingViewService.windows.cs
@@ -1,6 +1,7 @@
 ﻿using System.Numerics;
 using Microsoft.Graphics.Canvas;
 using Microsoft.Graphics.Canvas.Brushes;
+using Microsoft.Graphics.Canvas.Geometry;
 using Microsoft.Maui.Platform;
 using Windows.Storage.Streams;
 using Windows.UI.Input.Inking;
@@ -155,6 +156,12 @@ public static partial class DrawingViewService
 		return offscreen;
 	}
 
+	static readonly CanvasStrokeStyle defaultCanvasStrokeStyle = new()
+	{
+		StartCap = CanvasCapStyle.Round,
+		EndCap = CanvasCapStyle.Round,
+	};
+
 	static void DrawInk(this CanvasDrawingSession session, IEnumerable<InkStroke> strokes)
 	{
 		foreach (var stroke in strokes)
@@ -167,7 +174,8 @@ public static partial class DrawingViewService
 				session.DrawLine(
 					new Vector2((float)currentPoint.X, (float)currentPoint.Y),
 					new Vector2((float)nextPoint.X, (float)nextPoint.Y),
-					stroke.DrawingAttributes.Color, (float)stroke.DrawingAttributes.Size.Width);
+					stroke.DrawingAttributes.Color, (float)stroke.DrawingAttributes.Size.Width,
+					defaultCanvasStrokeStyle);
 			}
 		}
 	}

--- a/src/CommunityToolkit.Maui.Core/Views/DrawingView/Service/DrawingViewService.windows.cs
+++ b/src/CommunityToolkit.Maui.Core/Views/DrawingView/Service/DrawingViewService.windows.cs
@@ -156,7 +156,7 @@ public static partial class DrawingViewService
 		return offscreen;
 	}
 
-	static readonly CanvasStrokeStyle defaultCanvasStrokeStyle = new()
+	static readonly CanvasStrokeStyle roundStartEndCapCanvasStrokeStyle = new()
 	{
 		StartCap = CanvasCapStyle.Round,
 		EndCap = CanvasCapStyle.Round,
@@ -175,7 +175,7 @@ public static partial class DrawingViewService
 					new Vector2((float)currentPoint.X, (float)currentPoint.Y),
 					new Vector2((float)nextPoint.X, (float)nextPoint.Y),
 					stroke.DrawingAttributes.Color, (float)stroke.DrawingAttributes.Size.Width,
-					defaultCanvasStrokeStyle);
+					roundStartEndCapCanvasStrokeStyle);
 			}
 		}
 	}


### PR DESCRIPTION
 ### Description of Change ###

Fixes rendering final image of `DrawingView` that was using wrong line cap style on Windows.

 ### Linked Issues ###

 - Fixes #3215

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->

 ### Additional information ###

No tests, as it can't be tested automatically. No documentation, as it's a bugfix.
