### PR TITLE
Prevent Race Condition Allowing Simultaneous Calling of `Navigation.PushModalAsync()` / `Shell.GotoAsync()` in `PopupExtensions`

### DIFF
--- a/src/CommunityToolkit.Maui.UnitTests/Extensions/PopupExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Extensions/PopupExtensionsTests.cs
@@ -1513,6 +1513,231 @@ public class PopupExtensionsTests : BaseViewTest
 		Assert.Equal(expectedResult, popupResult.Result);
 		Assert.False(popupResult.WasDismissedByTappingOutsideOfPopup);
 	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public void ShowPopup_INavigation_SemaphoreReleasedAfterDisplay_AllowsAdditionalPopups()
+	{
+		// Arrange
+		Assert.Empty(navigation.ModalStack);
+
+		// Act - The first ShowPopup acquires the semaphore, pushes the popup and releases the semaphore
+		navigation.ShowPopup(new Grid());
+
+		// Assert
+		Assert.Single(navigation.ModalStack);
+
+		// Act - The second ShowPopup can only display if the semaphore was released after the first push
+		navigation.ShowPopup(new Grid());
+
+		// Assert
+		Assert.Equal(2, navigation.ModalStack.Count);
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task ShowPopupAsync_INavigation_SemaphoreReleasedAfterPush_AllowsAdditionalPopupWhileFirstIsOpen()
+	{
+		// Arrange
+		Assert.Empty(navigation.ModalStack);
+
+		// Act - Display the first popup but do not close it; the semaphore is released after the push, not after the popup closes
+		var firstShowPopupTask = navigation.ShowPopupAsync<object?>(new Popup(), PopupOptions.Empty, TestContext.Current.CancellationToken);
+
+		// Assert
+		Assert.Single(navigation.ModalStack);
+
+		// Act - Display a second popup while the first is still open; this proves the semaphore was released after the first push
+		var secondShowPopupTask = navigation.ShowPopupAsync<object?>(new Popup(), PopupOptions.Empty, TestContext.Current.CancellationToken);
+
+		// Assert
+		Assert.Equal(2, navigation.ModalStack.Count);
+
+		// Act - Close both popups and ensure both awaiting tasks complete
+		await navigation.ClosePopupAsync(TestContext.Current.CancellationToken);
+		await secondShowPopupTask;
+		await navigation.ClosePopupAsync(TestContext.Current.CancellationToken);
+		await firstShowPopupTask;
+
+		// Assert
+		Assert.Empty(navigation.ModalStack);
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public void ShowPopup_Shell_SemaphoreReleasedAfterDisplay_NullParameters_AllowsAdditionalPopups()
+	{
+		// Arrange
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+		Assert.Empty(shellNavigation.ModalStack);
+
+		// Act - Exercises the `shellParameters is null` branch which acquires and releases the semaphore around GoToAsync
+		shell.ShowPopup(new Popup());
+
+		// Assert
+		Assert.Single(shellNavigation.ModalStack);
+
+		// Act - The second display proves the semaphore was released by the null-parameters branch
+		shell.ShowPopup(new Popup());
+
+		// Assert
+		Assert.Equal(2, shellNavigation.ModalStack.Count);
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public void ShowPopup_Shell_SemaphoreReleasedAfterDisplay_WithParameters_AllowsAdditionalPopups()
+	{
+		// Arrange
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+		Assert.Empty(shellNavigation.ModalStack);
+
+		var firstView = new ViewWithIQueryAttributable(new ViewModelWithIQueryAttributable());
+		var secondView = new ViewWithIQueryAttributable(new ViewModelWithIQueryAttributable());
+
+		// Act - Exercises the `shellParameters is not null` branch which acquires and releases the semaphore around GoToAsync
+		shell.ShowPopup(firstView, PopupOptions.Empty, shellParameters);
+
+		// Assert
+		Assert.Single(shellNavigation.ModalStack);
+
+		// Act - The second display proves the semaphore was released by the with-parameters branch
+		shell.ShowPopup(secondView, PopupOptions.Empty, shellParameters);
+
+		// Assert
+		Assert.Equal(2, shellNavigation.ModalStack.Count);
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task ShowPopupAsync_INavigation_SemaphoreReleasedAfterCancellation_AllowsSubsequentPopup()
+	{
+		// Arrange
+		var cts = new CancellationTokenSource();
+		await cts.CancelAsync();
+
+		// Act - A canceled token forces ShowPopupAsync to throw; the semaphore must not be leaked
+		await Assert.ThrowsAsync<OperationCanceledException>(() => navigation.ShowPopupAsync(new Popup(), PopupOptions.Empty, cts.Token));
+
+		// Assert - Canceling must not leave a popup on the modal stack
+		Assert.Empty(navigation.ModalStack);
+
+		// Act - A subsequent display can only succeed if the semaphore was released after cancellation
+		navigation.ShowPopup(new Grid());
+
+		// Assert
+		Assert.Single(navigation.ModalStack);
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task ShowPopupAsync_Shell_SemaphoreReleasedAfterCancellation_WithParameters_AllowsSubsequentPopup()
+	{
+		// Arrange
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+		var view = new ViewWithIQueryAttributable(new ViewModelWithIQueryAttributable());
+
+		var cts = new CancellationTokenSource();
+		await cts.CancelAsync();
+
+		// Act - A canceled token forces ShowPopupAsync to throw; the semaphore must not be leaked
+		await Assert.ThrowsAsync<OperationCanceledException>(() => shell.ShowPopupAsync(view, PopupOptions.Empty, shellParameters, cts.Token));
+
+		// Assert - Canceling must not leave a popup on the modal stack
+		Assert.Empty(shellNavigation.ModalStack);
+
+		// Act - A subsequent display can only succeed if the semaphore was released after cancellation
+		shell.ShowPopup(new Popup());
+
+		// Assert
+		Assert.Single(shellNavigation.ModalStack);
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task ShowPopupAsync_Shell_SemaphoreReleasedAfterCancellation_NullParameters_AllowsSubsequentPopup()
+	{
+		// Arrange
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+		var view = new ViewWithIQueryAttributable(new ViewModelWithIQueryAttributable());
+
+		var cts = new CancellationTokenSource();
+		await cts.CancelAsync();
+
+		// Act - A canceled token (with null shellParameters) forces ShowPopupAsync to throw; the semaphore must not be leaked
+		await Assert.ThrowsAsync<OperationCanceledException>(() => shell.ShowPopupAsync(view, PopupOptions.Empty, shellParameters: null, cts.Token));
+
+		// Assert - Canceling must not leave a popup on the modal stack
+		Assert.Empty(shellNavigation.ModalStack);
+
+		// Act - A subsequent display can only succeed if the semaphore was released after cancellation
+		shell.ShowPopup(new Popup());
+
+		// Assert
+		Assert.Single(shellNavigation.ModalStack);
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task ShowPopupAsync_INavigation_CancellationLeavesModalStackEmptyAndSemaphoreReleased()
+	{
+		// Arrange
+		var cts = new CancellationTokenSource();
+		await cts.CancelAsync();
+
+		// Act - Cancel the awaitable display
+		await Assert.ThrowsAsync<OperationCanceledException>(() => navigation.ShowPopupAsync(new Popup(), PopupOptions.Empty, cts.Token));
+
+		// Assert - The canceled call must leave a clean modal stack
+		Assert.Empty(navigation.ModalStack);
+
+		// Act - The awaitable path must also recover; the semaphore was released by the finally block
+		var showPopupTask = navigation.ShowPopupAsync<object?>(new Popup(), PopupOptions.Empty, TestContext.Current.CancellationToken);
+
+		// Assert
+		Assert.Single(navigation.ModalStack);
+
+		// Act - Close the popup and ensure the task completes
+		await navigation.ClosePopupAsync(TestContext.Current.CancellationToken);
+		await showPopupTask;
+
+		// Assert
+		Assert.Empty(navigation.ModalStack);
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public void ShowPopup_INavigation_SemaphoreSerializesMultipleDisplays_AllDisplayed()
+	{
+		// Arrange
+		const int popupCount = 5;
+		Assert.Empty(navigation.ModalStack);
+
+		// Act - Each display must acquire the semaphore, push the popup and release the semaphore.
+		// If the semaphore were not released after each push, the later popups would never be displayed.
+		for (var i = 0; i < popupCount; i++)
+		{
+			navigation.ShowPopup(new Grid());
+		}
+
+		// Assert
+		Assert.Equal(popupCount, navigation.ModalStack.Count);
+	}
 }
 
 sealed class ViewWithIQueryAttributable : Button, IQueryAttributable

--- a/src/CommunityToolkit.Maui.UnitTests/Extensions/PopupExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Extensions/PopupExtensionsTests.cs
@@ -1722,7 +1722,7 @@ public class PopupExtensionsTests : BaseViewTest
 	}
 
 	[Fact(Timeout = (int)TestDuration.Short)]
-	public void ShowPopup_INavigation_SemaphoreSerializesMultipleDisplays_AllDisplayed()
+	public async Task ShowPopup_INavigation_SemaphoreSerializesMultipleDisplays_AllDisplayed()
 	{
 		// Arrange
 		const int popupCount = 5;
@@ -1735,8 +1735,19 @@ public class PopupExtensionsTests : BaseViewTest
 			navigation.ShowPopup(new Grid());
 		}
 
+		await WaitForModalStackCountAsync(popupCount, TestContext.Current.CancellationToken);
+
 		// Assert
 		Assert.Equal(popupCount, navigation.ModalStack.Count);
+
+		async Task WaitForModalStackCountAsync(int expectedCount, CancellationToken token)
+		{
+			while (navigation.ModalStack.Count < expectedCount)
+			{
+				token.ThrowIfCancellationRequested();
+				await Task.Delay(10, token);
+			}
+		}
 	}
 }
 

--- a/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
@@ -157,6 +157,7 @@ public static class PopupExtensions
 		{
 			showPopupSemaphoreSlim.Release();
 		}
+
 		return await taskCompletionSource.Task.WaitAsync(token);
 
 		void HandlePopupClosed(object? sender, IPopupResult e)
@@ -193,9 +194,10 @@ public static class PopupExtensions
 
 		try
 		{
+			await showPopupSemaphoreSlim.WaitAsync(token);
+			
 			if (shellParameters is null)
 			{
-				await showPopupSemaphoreSlim.WaitAsync(token);
 				try
 				{
 					await shell.GoToAsync(popupPageRoute).WaitAsync(token);
@@ -207,7 +209,6 @@ public static class PopupExtensions
 			}
 			else
 			{
-				await showPopupSemaphoreSlim.WaitAsync(token);
 				try
 				{
 					await shell.GoToAsync(popupPageRoute, shellParameters).WaitAsync(token);

--- a/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
@@ -195,7 +195,7 @@ public static class PopupExtensions
 		try
 		{
 			await showPopupSemaphoreSlim.WaitAsync(token);
-			
+
 			if (shellParameters is null)
 			{
 				try

--- a/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
@@ -8,6 +8,8 @@ namespace CommunityToolkit.Maui.Extensions;
 /// </summary>
 public static class PopupExtensions
 {
+	static readonly SemaphoreSlim showPopupSemaphoreSlim = new(1, 1);
+
 	/// <summary>
 	/// Shows a popup with the specified options.
 	/// </summary>
@@ -36,7 +38,16 @@ public static class PopupExtensions
 
 		var popupPage = new PopupPage(view, options);
 
-		await navigation.PushModalAsync(popupPage, false);
+		await showPopupSemaphoreSlim.WaitAsync();
+
+		try
+		{
+			await navigation.PushModalAsync(popupPage, false);
+		}
+		finally
+		{
+			showPopupSemaphoreSlim.Release();
+		}
 	}
 
 	/// <summary>
@@ -136,7 +147,16 @@ public static class PopupExtensions
 		var popupPage = new PopupPage(view, options);
 		popupPage.PopupClosed += HandlePopupClosed;
 
-		await navigation.PushModalAsync(popupPage, false).WaitAsync(token);
+		await showPopupSemaphoreSlim.WaitAsync(token);
+
+		try
+		{
+			await navigation.PushModalAsync(popupPage, false).WaitAsync(token);
+		}
+		finally
+		{
+			showPopupSemaphoreSlim.Release();
+		}
 		return await taskCompletionSource.Task.WaitAsync(token);
 
 		void HandlePopupClosed(object? sender, IPopupResult e)
@@ -175,11 +195,27 @@ public static class PopupExtensions
 		{
 			if (shellParameters is null)
 			{
-				await shell.GoToAsync(popupPageRoute).WaitAsync(token);
+				await showPopupSemaphoreSlim.WaitAsync(token);
+				try
+				{
+					await shell.GoToAsync(popupPageRoute).WaitAsync(token);
+				}
+				finally
+				{
+					showPopupSemaphoreSlim.Release();
+				}
 			}
 			else
 			{
-				await shell.GoToAsync(popupPageRoute, shellParameters).WaitAsync(token);
+				await showPopupSemaphoreSlim.WaitAsync(token);
+				try
+				{
+					await shell.GoToAsync(popupPageRoute, shellParameters).WaitAsync(token);
+				}
+				finally
+				{
+					showPopupSemaphoreSlim.Release();
+				}
 			}
 
 			return await taskCompletionSource.Task.WaitAsync(token);

--- a/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
@@ -151,7 +151,8 @@ public static class PopupExtensions
 
 		try
 		{
-			await navigation.PushModalAsync(popupPage, false).WaitAsync(token);
+			token.ThrowIfCancellationRequested();
+			await navigation.PushModalAsync(popupPage, false);
 		}
 		finally
 		{
@@ -200,7 +201,8 @@ public static class PopupExtensions
 			{
 				try
 				{
-					await shell.GoToAsync(popupPageRoute).WaitAsync(token);
+					token.ThrowIfCancellationRequested();
+					await shell.GoToAsync(popupPageRoute);
 				}
 				finally
 				{
@@ -211,7 +213,8 @@ public static class PopupExtensions
 			{
 				try
 				{
-					await shell.GoToAsync(popupPageRoute, shellParameters).WaitAsync(token);
+					token.ThrowIfCancellationRequested();
+					await shell.GoToAsync(popupPageRoute, shellParameters);
 				}
 				finally
 				{


### PR DESCRIPTION
<!--
 Hello, and thank you for your interest in contributing to the .NET MAUI Toolkit! 

 Before you submit please check that this work relates to one of the following:
 - Bug fix
    If you haven't yet opened an Issue that reports the bug in detail, provides a reproduction sample, and has been verified + reproduced by a member of the .NET MAUI Toolkit core team, please do that before submitting a Pull Request.
 - Feature/Proposal
    If you haven't yet submitted a Proposal that has been Championed by a .NET MAUI core team member, please instead open a Discussion at https://github.com/communitytoolkit/maui/discussions/new where we can discuss the pros/cons of the feature and its implementation. 
 Any PR submitted that does not fit with the above options will be closed.
 -->

 ### Description of Change ###

This PR fixes the race condition where `PopupExtensions` could call `Navigation.PushModalAsync()` / `Shell.GotoAsync()` to display a `Popup` while a previously-called `Navigation.PushModalAsync()` / `Shell.GotoAsync()` could actively be running. 

To avoid this race condition, I added `SemaphoreSlim showPopupSemaphoreSlim = new(1, 1);` and now call `showPopupSemaphoreSlim.WaitAsync()` before each `Navigation.PushModalAsync()` / `Shell.GotoAsync()` method call. This ensures we wait until the modal page has finished pushing before we ask MAUI to push a new modal page.

 ### Linked Issues ###
 <!-- Provide links to issues here (#35 will link to issue number 35). Ensure that a GitHub issue was created for your bug/proposal and it has been approved/Championed. -->

 - Fixes #3192

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)

 ### Additional information ###

 <!-- 
 Please use this to aid the reviewer, this could include stating which platform(s) have been tested
 -->
 
This is more likely a bug internally in MAUI, as this `SemaphoreSlim` is not needed on Android. 