### PR TITLE
Add `TryShowPopupAsync` and `TryClosePopupAsync`

### DIFF
--- a/src/CommunityToolkit.Maui.Core/Essentials/FileSaver/FileSaverResult.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Essentials/FileSaver/FileSaverResult.shared.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.ExceptionServices;
+using CommunityToolkit.Maui.Core;
 
 namespace CommunityToolkit.Maui.Storage;
 
@@ -8,23 +9,14 @@ namespace CommunityToolkit.Maui.Storage;
 /// </summary>
 /// <param name="FilePath">The saved file path</param>
 /// <param name="Exception">Exception if operation failed</param>
-public record FileSaverResult(string? FilePath, Exception? Exception)
+public record FileSaverResult(string? FilePath, Exception? Exception) : IResult
 {
-	/// <summary>
-	/// Check if the operation was successful.
-	/// </summary>
+	/// <inheritdoc/>
 	[MemberNotNullWhen(true, nameof(FilePath))]
 	[MemberNotNullWhen(false, nameof(Exception))]
 	public bool IsSuccessful => Exception is null;
 
-	/// <summary>
-	/// Check if the operation was cancelled.
-	/// </summary>
-	public bool IsCancelled => Exception is OperationCanceledException;
-
-	/// <summary>
-	/// Check if the operation was successful.
-	/// </summary>
+	/// <inheritdoc/>
 	[MemberNotNull(nameof(FilePath))]
 	public void EnsureSuccess()
 	{

--- a/src/CommunityToolkit.Maui.Core/Essentials/FolderPicker/FolderPickerImplementation.android.cs
+++ b/src/CommunityToolkit.Maui.Core/Essentials/FolderPicker/FolderPickerImplementation.android.cs
@@ -5,7 +5,7 @@ using Android.Content;
 using Android.Provider;
 using CommunityToolkit.Maui.Core.Essentials;
 using CommunityToolkit.Maui.Core.Extensions;
-using CommunityToolkit.Maui.Core.Primitives;
+using CommunityToolkit.Maui.Core;
 using Microsoft.Maui.ApplicationModel;
 using AndroidUri = Android.Net.Uri;
 

--- a/src/CommunityToolkit.Maui.Core/Essentials/FolderPicker/FolderPickerImplementation.macios.cs
+++ b/src/CommunityToolkit.Maui.Core/Essentials/FolderPicker/FolderPickerImplementation.macios.cs
@@ -1,5 +1,5 @@
 using System.Runtime.Versioning;
-using CommunityToolkit.Maui.Core.Primitives;
+using CommunityToolkit.Maui.Core;
 using Microsoft.Maui.ApplicationModel;
 using UniformTypeIdentifiers;
 

--- a/src/CommunityToolkit.Maui.Core/Essentials/FolderPicker/FolderPickerImplementation.net.cs
+++ b/src/CommunityToolkit.Maui.Core/Essentials/FolderPicker/FolderPickerImplementation.net.cs
@@ -1,4 +1,4 @@
-using CommunityToolkit.Maui.Core.Primitives;
+using CommunityToolkit.Maui.Core;
 
 namespace CommunityToolkit.Maui.Storage;
 

--- a/src/CommunityToolkit.Maui.Core/Essentials/FolderPicker/FolderPickerImplementation.tizen.cs
+++ b/src/CommunityToolkit.Maui.Core/Essentials/FolderPicker/FolderPickerImplementation.tizen.cs
@@ -1,4 +1,4 @@
-using CommunityToolkit.Maui.Core.Primitives;
+using CommunityToolkit.Maui.Core;
 using Microsoft.Maui.ApplicationModel;
 
 namespace CommunityToolkit.Maui.Storage;

--- a/src/CommunityToolkit.Maui.Core/Essentials/FolderPicker/FolderPickerImplementation.windows.cs
+++ b/src/CommunityToolkit.Maui.Core/Essentials/FolderPicker/FolderPickerImplementation.windows.cs
@@ -1,4 +1,4 @@
-using CommunityToolkit.Maui.Core.Primitives;
+using CommunityToolkit.Maui.Core;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.UI;
 using Microsoft.Windows.AppLifecycle;

--- a/src/CommunityToolkit.Maui.Core/Essentials/FolderPicker/FolderPickerResult.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Essentials/FolderPicker/FolderPickerResult.shared.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.ExceptionServices;
-using CommunityToolkit.Maui.Core.Primitives;
+using CommunityToolkit.Maui.Core;
 
 namespace CommunityToolkit.Maui.Storage;
 
@@ -9,23 +9,14 @@ namespace CommunityToolkit.Maui.Storage;
 /// </summary>
 /// <param name="Folder"><see cref="Folder"/></param>
 /// <param name="Exception">Exception if operation failed</param>
-public record FolderPickerResult(Folder? Folder, Exception? Exception)
+public record FolderPickerResult(Folder? Folder, Exception? Exception): IResult
 {
-	/// <summary>
-	/// Check if operation was successful.
-	/// </summary>
+	/// <inheritdoc/>
 	[MemberNotNullWhen(true, nameof(Folder))]
 	[MemberNotNullWhen(false, nameof(Exception))]
 	public bool IsSuccessful => Exception is null;
 
-	/// <summary>
-	/// Check if the operation was cancelled.
-	/// </summary>
-	public bool IsCancelled => Exception is OperationCanceledException;
-
-	/// <summary>
-	/// Check if operation was successful.
-	/// </summary>
+	/// <inheritdoc/>
 	[MemberNotNull(nameof(Folder))]
 	public void EnsureSuccess()
 	{

--- a/src/CommunityToolkit.Maui.Core/Interfaces/IClosePopupResult.cs
+++ b/src/CommunityToolkit.Maui.Core/Interfaces/IClosePopupResult.cs
@@ -1,0 +1,19 @@
+namespace CommunityToolkit.Maui.Core;
+
+/// <summary>
+/// The result returned when the popup is closed programmatically.
+/// </summary>
+/// <remarks>
+/// Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup"/> value to determine how the popup was closed.
+/// This will always return <c>null</c> when <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup"/> is <c>true</c>.
+/// </remarks>
+public interface IClosePopupResult : IPopupResult, IResult;
+
+/// <summary>
+/// The result returned when the popup is closed programmatically.
+/// </summary>
+/// <remarks>
+/// Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup"/> value to determine how the popup was closed.
+/// This will always return <c>null</c> when <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup"/> is <c>true</c>.
+/// </remarks>
+public interface IClosePopupResult<out T> : IPopupResult<T>, IResult;

--- a/src/CommunityToolkit.Maui.Core/Interfaces/IResult.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Interfaces/IResult.shared.cs
@@ -10,7 +10,7 @@ public interface IResult
 {
 	/// <summary>
 	/// Exception if operation failed
-	/// /// </summary>
+	/// </summary>
 	Exception? Exception { get; }
 
 	/// <summary>

--- a/src/CommunityToolkit.Maui.Core/Interfaces/IResult.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Interfaces/IResult.shared.cs
@@ -1,0 +1,40 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.ExceptionServices;
+
+namespace CommunityToolkit.Maui.Core;
+
+/// <summary>
+/// The resulting information from a Try* method in the .NET MAUI Community Toolkit
+/// </summary>
+public interface IResult
+{
+	/// <summary>
+	/// Exception if operation failed
+	/// /// </summary>
+	Exception? Exception { get; }
+
+	/// <summary>
+	/// Check if operation was successful.
+	/// </summary>
+	[MemberNotNullWhen(false, nameof(Exception))]
+	bool IsSuccessful => Exception is null;
+
+	/// <summary>
+	/// Check if the operation was cancelled.
+	/// </summary>
+	bool IsCancelled => Exception is OperationCanceledException;
+
+	/// <summary>
+	/// Check if operation was successful.
+	/// </summary>
+	/// <remarks>
+	/// Throws <see cref="Exception"/> when not <see langword="null"/> 
+	/// </remarks>
+	void EnsureSuccess()
+	{
+		if (!IsSuccessful)
+		{
+			ExceptionDispatchInfo.Throw(Exception);
+		}
+	}
+}

--- a/src/CommunityToolkit.Maui.Core/Interfaces/IShowPopupResult.cs
+++ b/src/CommunityToolkit.Maui.Core/Interfaces/IShowPopupResult.cs
@@ -1,0 +1,11 @@
+namespace CommunityToolkit.Maui.Core;
+
+/// <summary>
+/// Represents a result that can be returned when a popup is opened
+/// </summary>
+public interface IShowPopupResult : IPopupResult, IResult;
+
+/// <summary>
+/// Represents a result that can be returned when a popup is opened.
+/// </summary>
+public interface IShowPopupResult<out T> : IPopupResult<T>, IResult;

--- a/src/CommunityToolkit.Maui.Core/Primitives/Folder.shared.cs
+++ b/src/CommunityToolkit.Maui.Core/Primitives/Folder.shared.cs
@@ -1,4 +1,4 @@
-namespace CommunityToolkit.Maui.Core.Primitives;
+namespace CommunityToolkit.Maui.Core;
 
 /// <summary>
 /// Represents a folder in the file system.

--- a/src/CommunityToolkit.Maui.UnitTests/Essentials/FileSaverTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Essentials/FileSaverTests.cs
@@ -1,4 +1,5 @@
-﻿using CommunityToolkit.Maui.Storage;
+﻿using CommunityToolkit.Maui.Core;
+using CommunityToolkit.Maui.Storage;
 using CommunityToolkit.Maui.UnitTests.Mocks;
 using FluentAssertions;
 using Xunit;
@@ -62,5 +63,29 @@ public class FileSaverTests : BaseTest
 		result.FilePath.Should().BeNull();
 		result.IsSuccessful.Should().BeFalse();
 		Assert.Throws<NotImplementedException>(result.EnsureSuccess);
+	}
+
+	[Fact]
+	public void FileSaverResult_ShouldReportCancelled_WhenOperationCancelledExceptionIsSet()
+	{
+		// Arrange
+		IResult result = new FileSaverResult(null, new OperationCanceledException("canceled"));
+
+		// Assert
+		result.IsSuccessful.Should().BeFalse();
+		result.IsCancelled.Should().BeTrue();
+		Assert.Throws<OperationCanceledException>(result.EnsureSuccess);
+	}
+
+	[Fact]
+	public void FileSaverResult_ShouldReportSuccessful_WhenFilePathExistsAndExceptionIsNull()
+	{
+		// Arrange
+		IResult result = new FileSaverResult("path/to/file.txt", null);
+
+		// Assert
+		result.IsSuccessful.Should().BeTrue();
+		result.IsCancelled.Should().BeFalse();
+		result.EnsureSuccess();
 	}
 }

--- a/src/CommunityToolkit.Maui.UnitTests/Essentials/FolderPickerTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Essentials/FolderPickerTests.cs
@@ -1,4 +1,5 @@
-﻿using CommunityToolkit.Maui.Storage;
+﻿using CommunityToolkit.Maui.Core;
+using CommunityToolkit.Maui.Storage;
 using CommunityToolkit.Maui.UnitTests.Mocks;
 using FluentAssertions;
 using Xunit;
@@ -38,5 +39,30 @@ public class FolderPickerTests : BaseTest
 		result.Folder.Should().BeNull();
 		result.IsSuccessful.Should().BeFalse();
 		Assert.Throws<NotImplementedException>(result.EnsureSuccess);
+	}
+
+	[Fact]
+	public void FolderPickerResult_ShouldReportCancelled_WhenOperationCancelledExceptionIsSet()
+	{
+		// Arrange
+		IResult result = new FolderPickerResult(null, new OperationCanceledException("canceled"));
+
+		// Assert
+		result.IsSuccessful.Should().BeFalse();
+		result.IsCancelled.Should().BeTrue();
+		Assert.Throws<OperationCanceledException>(result.EnsureSuccess);
+	}
+
+	[Fact]
+	public void FolderPickerResult_ShouldReportSuccessful_WhenFolderExistsAndExceptionIsNull()
+	{
+		// Arrange
+		var folder = new Folder("path/to/folder", "folder");
+		IResult result = new FolderPickerResult(folder, null);
+
+		// Assert
+		result.IsSuccessful.Should().BeTrue();
+		result.IsCancelled.Should().BeFalse();
+		result.EnsureSuccess();
 	}
 }

--- a/src/CommunityToolkit.Maui.UnitTests/Extensions/PopupExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Extensions/PopupExtensionsTests.cs
@@ -1436,6 +1436,601 @@ public class PopupExtensionsTests : BaseViewTest
 	}
 
 	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryShowPopupAsync_ShouldReturnSuccessfulResult_WhenPopupIsClosed()
+	{
+		// Arrange
+		var showPopupTask = navigation.TryShowPopupAsync(new Popup(), PopupOptions.Empty, TestContext.Current.CancellationToken);
+		var popupPage = (PopupPage)navigation.ModalStack.Last();
+
+		// Act
+		await popupPage.CloseAsync(new PopupResult(false), TestContext.Current.CancellationToken);
+		var result = await showPopupTask;
+
+		// Assert
+		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
+		Assert.Null(result.Exception);
+		Assert.True(result.IsSuccessful);
+		Assert.False(result.IsCancelled);
+		result.EnsureSuccess();
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryShowPopupAsync_Page_ShouldReturnSuccessfulResult_WhenPopupIsClosed()
+	{
+		// Arrange
+		if (Application.Current?.Windows[0].Page is not Page page)
+		{
+			throw new InvalidOperationException("Page cannot be null");
+		}
+
+		var showPopupTask = page.TryShowPopupAsync(new Popup(), PopupOptions.Empty, TestContext.Current.CancellationToken);
+		var popupPage = (PopupPage)navigation.ModalStack.Last();
+
+		// Act
+		await popupPage.CloseAsync(new PopupResult(false), TestContext.Current.CancellationToken);
+		var result = await showPopupTask;
+
+		// Assert
+		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
+		Assert.Null(result.Exception);
+		Assert.True(result.IsSuccessful);
+		Assert.False(result.IsCancelled);
+		result.EnsureSuccess();
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryShowPopupAsync_Shell_ShouldReturnSuccessfulResult_WhenPopupIsClosed()
+	{
+		// Arrange
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+		var showPopupTask = shell.TryShowPopupAsync(new Popup(), PopupOptions.Empty, shellParameters, TestContext.Current.CancellationToken);
+		var popupPage = (PopupPage)shellNavigation.ModalStack.Last();
+
+		// Act
+		await popupPage.CloseAsync(new PopupResult(false), TestContext.Current.CancellationToken);
+		var result = await showPopupTask;
+
+		// Assert
+		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
+		Assert.Null(result.Exception);
+		Assert.True(result.IsSuccessful);
+		Assert.False(result.IsCancelled);
+		result.EnsureSuccess();
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryShowPopupAsyncT_ShouldReturnSuccessfulTypedResult_WhenPopupIsClosed()
+	{
+		// Arrange
+		const int expectedResult = 7;
+		var showPopupTask = navigation.TryShowPopupAsync<int>(new Grid(), PopupOptions.Empty, TestContext.Current.CancellationToken);
+		var popupPage = (PopupPage)navigation.ModalStack.Last();
+
+		// Act
+		await popupPage.CloseAsync(new PopupResult<int>(expectedResult, false), TestContext.Current.CancellationToken);
+		var result = await showPopupTask;
+
+		// Assert
+		Assert.Equal(expectedResult, result.Result);
+		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
+		Assert.Null(result.Exception);
+		Assert.True(result.IsSuccessful);
+		Assert.False(result.IsCancelled);
+		result.EnsureSuccess();
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryShowPopupAsyncT_Page_ShouldReturnSuccessfulTypedResult_WhenPopupIsClosed()
+	{
+		// Arrange
+		const int expectedResult = 11;
+
+		if (Application.Current?.Windows[0].Page is not Page page)
+		{
+			throw new InvalidOperationException("Page cannot be null");
+		}
+
+		var showPopupTask = page.TryShowPopupAsync<int>(new Grid(), PopupOptions.Empty, TestContext.Current.CancellationToken);
+		var popupPage = (PopupPage)navigation.ModalStack.Last();
+
+		// Act
+		await popupPage.CloseAsync(new PopupResult<int>(expectedResult, false), TestContext.Current.CancellationToken);
+		var result = await showPopupTask;
+
+		// Assert
+		Assert.Equal(expectedResult, result.Result);
+		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
+		Assert.Null(result.Exception);
+		Assert.True(result.IsSuccessful);
+		Assert.False(result.IsCancelled);
+		result.EnsureSuccess();
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryShowPopupAsyncT_Shell_ShouldReturnSuccessfulTypedResult_WhenPopupIsClosed()
+	{
+		// Arrange
+		const int expectedResult = 13;
+
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var shellNavigation = Shell.Current.Navigation;
+		var showPopupTask = shell.TryShowPopupAsync<int>(new ViewWithIQueryAttributable(new ViewModelWithIQueryAttributable()), PopupOptions.Empty, shellParameters, TestContext.Current.CancellationToken);
+		var popupPage = (PopupPage)shellNavigation.ModalStack.Last();
+
+		// Act
+		await popupPage.CloseAsync(new PopupResult<int>(expectedResult, false), TestContext.Current.CancellationToken);
+		var result = await showPopupTask;
+
+		// Assert
+		Assert.Equal(expectedResult, result.Result);
+		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
+		Assert.Null(result.Exception);
+		Assert.True(result.IsSuccessful);
+		Assert.False(result.IsCancelled);
+		result.EnsureSuccess();
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryShowPopupAsync_ShouldReturnCancelledResult_WhenTokenIsCancelled()
+	{
+		// Arrange
+		var cancellationTokenSource = new CancellationTokenSource();
+		await cancellationTokenSource.CancelAsync();
+
+		// Act
+		var result = await navigation.TryShowPopupAsync(new Popup(), PopupOptions.Empty, cancellationTokenSource.Token);
+
+		// Assert
+		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
+		Assert.NotNull(result.Exception);
+		Assert.IsType<OperationCanceledException>(result.Exception);
+		Assert.False(result.IsSuccessful);
+		Assert.True(result.IsCancelled);
+		Assert.Throws<OperationCanceledException>(result.EnsureSuccess);
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryShowPopupAsync_Page_ShouldReturnCancelledResult_WhenTokenIsCancelled()
+	{
+		// Arrange
+		if (Application.Current?.Windows[0].Page is not Page page)
+		{
+			throw new InvalidOperationException("Page cannot be null");
+		}
+
+		var cancellationTokenSource = new CancellationTokenSource();
+		await cancellationTokenSource.CancelAsync();
+
+		// Act
+		var result = await page.TryShowPopupAsync(new Popup(), PopupOptions.Empty, cancellationTokenSource.Token);
+
+		// Assert
+		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
+		Assert.NotNull(result.Exception);
+		Assert.IsType<OperationCanceledException>(result.Exception);
+		Assert.False(result.IsSuccessful);
+		Assert.True(result.IsCancelled);
+		Assert.Throws<OperationCanceledException>(result.EnsureSuccess);
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryShowPopupAsync_Shell_ShouldReturnCancelledResult_WhenTokenIsCancelled()
+	{
+		// Arrange
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var cancellationTokenSource = new CancellationTokenSource();
+		await cancellationTokenSource.CancelAsync();
+
+		// Act
+		var result = await shell.TryShowPopupAsync(new Popup(), PopupOptions.Empty, shellParameters, cancellationTokenSource.Token);
+
+		// Assert
+		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
+		Assert.NotNull(result.Exception);
+		Assert.IsType<OperationCanceledException>(result.Exception);
+		Assert.False(result.IsSuccessful);
+		Assert.True(result.IsCancelled);
+		Assert.Throws<OperationCanceledException>(result.EnsureSuccess);
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryShowPopupAsyncT_ShouldReturnCancelledResult_WhenTokenIsCancelled()
+	{
+		// Arrange
+		var cancellationTokenSource = new CancellationTokenSource();
+		await cancellationTokenSource.CancelAsync();
+
+		// Act
+		var result = await navigation.TryShowPopupAsync<int>(new Grid(), PopupOptions.Empty, cancellationTokenSource.Token);
+
+		// Assert
+		Assert.Equal(default, result.Result);
+		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
+		Assert.NotNull(result.Exception);
+		Assert.IsType<OperationCanceledException>(result.Exception);
+		Assert.False(result.IsSuccessful);
+		Assert.True(result.IsCancelled);
+		Assert.Throws<OperationCanceledException>(result.EnsureSuccess);
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryShowPopupAsyncT_Page_ShouldReturnCancelledResult_WhenTokenIsCancelled()
+	{
+		// Arrange
+		if (Application.Current?.Windows[0].Page is not Page page)
+		{
+			throw new InvalidOperationException("Page cannot be null");
+		}
+
+		var cancellationTokenSource = new CancellationTokenSource();
+		await cancellationTokenSource.CancelAsync();
+
+		// Act
+		var result = await page.TryShowPopupAsync<int>(new Grid(), PopupOptions.Empty, cancellationTokenSource.Token);
+
+		// Assert
+		Assert.Equal(default, result.Result);
+		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
+		Assert.NotNull(result.Exception);
+		Assert.IsType<OperationCanceledException>(result.Exception);
+		Assert.False(result.IsSuccessful);
+		Assert.True(result.IsCancelled);
+		Assert.Throws<OperationCanceledException>(result.EnsureSuccess);
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryShowPopupAsyncT_Shell_ShouldReturnCancelledResult_WhenTokenIsCancelled()
+	{
+		// Arrange
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		var cancellationTokenSource = new CancellationTokenSource();
+		await cancellationTokenSource.CancelAsync();
+
+		// Act
+		var result = await shell.TryShowPopupAsync<int>(new ViewWithIQueryAttributable(new ViewModelWithIQueryAttributable()), PopupOptions.Empty, shellParameters, cancellationTokenSource.Token);
+
+		// Assert
+		Assert.Equal(default, result.Result);
+		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
+		Assert.NotNull(result.Exception);
+		Assert.IsType<OperationCanceledException>(result.Exception);
+		Assert.False(result.IsSuccessful);
+		Assert.True(result.IsCancelled);
+		Assert.Throws<OperationCanceledException>(result.EnsureSuccess);
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryShowPopupAsync_NullNavigation_ShouldThrowArgumentNullException()
+	{
+		// Arrange / Act / Assert
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		await Assert.ThrowsAsync<ArgumentNullException>(() => PopupExtensions.TryShowPopupAsync((INavigation?)null, new Popup(), PopupOptions.Empty, TestContext.Current.CancellationToken));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryShowPopupAsync_NullView_ShouldThrowArgumentNullException()
+	{
+		// Arrange / Act / Assert
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		await Assert.ThrowsAsync<ArgumentNullException>(() => navigation.TryShowPopupAsync((View?)null, PopupOptions.Empty, TestContext.Current.CancellationToken));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryShowPopupAsync_Page_NullPage_ShouldThrowArgumentNullException()
+	{
+		// Arrange / Act / Assert
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		await Assert.ThrowsAsync<ArgumentNullException>(() => PopupExtensions.TryShowPopupAsync((Page?)null, new Popup(), PopupOptions.Empty, TestContext.Current.CancellationToken));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryShowPopupAsync_Shell_NullShell_ShouldThrowArgumentNullException()
+	{
+		// Arrange / Act / Assert
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		await Assert.ThrowsAsync<ArgumentNullException>(() => PopupExtensions.TryShowPopupAsync((Shell?)null, new Popup(), PopupOptions.Empty, shellParameters, TestContext.Current.CancellationToken));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryShowPopupAsync_Shell_NullView_ShouldThrowArgumentNullException()
+	{
+		// Arrange
+		var shell = new Shell();
+		shell.Items.Add(new MockPage(new MockPageViewModel()));
+
+		Assert.NotNull(Application.Current);
+		Application.Current.Windows[0].Page = shell;
+
+		// Act / Assert
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		await Assert.ThrowsAsync<ArgumentNullException>(() => shell.TryShowPopupAsync((View?)null, PopupOptions.Empty, shellParameters, TestContext.Current.CancellationToken));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryClosePopupAsync_ShouldClosePopupUsingNavigationAndReturnSuccessfulResult()
+	{
+		// Arrange
+		navigation.ShowPopup(new Popup());
+
+		// Act
+		var result = await navigation.TryClosePopupAsync(TestContext.Current.CancellationToken);
+
+		// Assert
+		Assert.Empty(navigation.ModalStack);
+		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
+		Assert.Null(result.Exception);
+		Assert.True(result.IsSuccessful);
+		Assert.False(result.IsCancelled);
+		result.EnsureSuccess();
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryClosePopupAsync_Page_ShouldClosePopupUsingPageAndReturnSuccessfulResult()
+	{
+		// Arrange
+		if (Application.Current?.Windows[0].Page is not Page page)
+		{
+			throw new InvalidOperationException("Page cannot be null");
+		}
+
+		page.ShowPopup(new Popup());
+
+		// Act
+		var result = await page.TryClosePopupAsync(TestContext.Current.CancellationToken);
+
+		// Assert
+		Assert.Empty(page.Navigation.ModalStack);
+		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
+		Assert.Null(result.Exception);
+		Assert.True(result.IsSuccessful);
+		Assert.False(result.IsCancelled);
+		result.EnsureSuccess();
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryClosePopupAsyncT_ShouldClosePopupUsingNavigationAndReturnSuccessfulTypedResult()
+	{
+		// Arrange
+		const int expectedResult = 21;
+		navigation.ShowPopup(new Popup());
+
+		// Act
+		var result = await navigation.TryClosePopupAsync(expectedResult, TestContext.Current.CancellationToken);
+
+		// Assert
+		Assert.Empty(navigation.ModalStack);
+		Assert.Equal(expectedResult, result.Result);
+		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
+		Assert.Null(result.Exception);
+		Assert.True(result.IsSuccessful);
+		Assert.False(result.IsCancelled);
+		result.EnsureSuccess();
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryClosePopupAsyncT_Page_ShouldClosePopupUsingPageAndReturnSuccessfulTypedResult()
+	{
+		// Arrange
+		const int expectedResult = 34;
+
+		if (Application.Current?.Windows[0].Page is not Page page)
+		{
+			throw new InvalidOperationException("Page cannot be null");
+		}
+
+		page.ShowPopup(new Popup());
+
+		// Act
+		var result = await page.TryClosePopupAsync(expectedResult, TestContext.Current.CancellationToken);
+
+		// Assert
+		Assert.Empty(page.Navigation.ModalStack);
+		Assert.Equal(expectedResult, result.Result);
+		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
+		Assert.Null(result.Exception);
+		Assert.True(result.IsSuccessful);
+		Assert.False(result.IsCancelled);
+		result.EnsureSuccess();
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryClosePopupAsync_ShouldReturnFailedResult_WhenNoPopupExists()
+	{
+		// Arrange
+
+		// Act
+		var result = await navigation.TryClosePopupAsync(TestContext.Current.CancellationToken);
+
+		// Assert
+		Assert.NotNull(result.Exception);
+		Assert.IsType<PopupNotFoundException>(result.Exception);
+		Assert.False(result.IsSuccessful);
+		Assert.False(result.IsCancelled);
+		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
+		Assert.Throws<PopupNotFoundException>(result.EnsureSuccess);
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryClosePopupAsync_Page_ShouldReturnFailedResult_WhenNoPopupExists()
+	{
+		// Arrange
+		if (Application.Current?.Windows[0].Page is not Page page)
+		{
+			throw new InvalidOperationException("Page cannot be null");
+		}
+
+		// Act
+		var result = await page.TryClosePopupAsync(TestContext.Current.CancellationToken);
+
+		// Assert
+		Assert.NotNull(result.Exception);
+		Assert.IsType<PopupNotFoundException>(result.Exception);
+		Assert.False(result.IsSuccessful);
+		Assert.False(result.IsCancelled);
+		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
+		Assert.Throws<PopupNotFoundException>(result.EnsureSuccess);
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryClosePopupAsync_ShouldReturnCancelledResult_WhenTokenIsCancelled()
+	{
+		// Arrange
+		var cancellationTokenSource = new CancellationTokenSource();
+		await cancellationTokenSource.CancelAsync();
+
+		// Act
+		var result = await navigation.TryClosePopupAsync(cancellationTokenSource.Token);
+
+		// Assert
+		Assert.NotNull(result.Exception);
+		Assert.IsType<OperationCanceledException>(result.Exception);
+		Assert.False(result.IsSuccessful);
+		Assert.True(result.IsCancelled);
+		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
+		Assert.Throws<OperationCanceledException>(result.EnsureSuccess);
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryClosePopupAsyncT_ShouldReturnFailedResult_WhenNoPopupExists()
+	{
+		// Arrange
+		const int expectedInputResult = 55;
+
+		// Act
+		var result = await navigation.TryClosePopupAsync(expectedInputResult, TestContext.Current.CancellationToken);
+
+		// Assert
+		Assert.Equal(expectedInputResult, result.Result);
+		Assert.NotNull(result.Exception);
+		Assert.IsType<PopupNotFoundException>(result.Exception);
+		Assert.False(result.IsSuccessful);
+		Assert.False(result.IsCancelled);
+		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
+		Assert.Throws<PopupNotFoundException>(result.EnsureSuccess);
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryClosePopupAsyncT_ShouldReturnCancelledResult_WhenTokenIsCancelled()
+	{
+		// Arrange
+		const int expectedInputResult = 89;
+		var cancellationTokenSource = new CancellationTokenSource();
+		await cancellationTokenSource.CancelAsync();
+
+		// Act
+		var result = await navigation.TryClosePopupAsync(expectedInputResult, cancellationTokenSource.Token);
+
+		// Assert
+		Assert.Equal(expectedInputResult, result.Result);
+		Assert.NotNull(result.Exception);
+		Assert.IsType<OperationCanceledException>(result.Exception);
+		Assert.False(result.IsSuccessful);
+		Assert.True(result.IsCancelled);
+		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
+		Assert.Throws<OperationCanceledException>(result.EnsureSuccess);
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryClosePopupAsync_NullNavigation_ShouldThrowArgumentNullException()
+	{
+		// Arrange / Act / Assert
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		await Assert.ThrowsAsync<ArgumentNullException>(() => PopupExtensions.TryClosePopupAsync((INavigation?)null, TestContext.Current.CancellationToken));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryClosePopupAsync_Page_NullPage_ShouldThrowArgumentNullException()
+	{
+		// Arrange / Act / Assert
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		await Assert.ThrowsAsync<ArgumentNullException>(() => PopupExtensions.TryClosePopupAsync((Page?)null, TestContext.Current.CancellationToken));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryClosePopupAsyncT_NullNavigation_ShouldThrowArgumentNullException()
+	{
+		// Arrange / Act / Assert
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		await Assert.ThrowsAsync<ArgumentNullException>(() => PopupExtensions.TryClosePopupAsync((INavigation?)null, 5, TestContext.Current.CancellationToken));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryClosePopupAsyncT_Page_NullPage_ShouldThrowArgumentNullException()
+	{
+		// Arrange / Act / Assert
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		await Assert.ThrowsAsync<ArgumentNullException>(() => PopupExtensions.TryClosePopupAsync((Page?)null, 5, TestContext.Current.CancellationToken));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryClosePopupAsync_ShouldReturnFailedResult_WhenPopupIsBlocked()
+	{
+		// Arrange
+		navigation.ShowPopup(new Button());
+		await navigation.PushModalAsync(new ContentPage());
+
+		// Act
+		var result = await navigation.TryClosePopupAsync(TestContext.Current.CancellationToken);
+
+		// Assert
+		Assert.NotNull(result.Exception);
+		Assert.IsType<PopupBlockedException>(result.Exception);
+		Assert.False(result.IsSuccessful);
+		Assert.False(result.IsCancelled);
+		Assert.Throws<PopupBlockedException>(result.EnsureSuccess);
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task TryClosePopupAsyncT_ShouldReturnFailedResult_WhenPopupIsBlocked()
+	{
+		// Arrange
+		const int expectedInputResult = 2;
+		navigation.ShowPopup(new Button());
+		await navigation.PushModalAsync(new ContentPage());
+
+		// Act
+		var result = await navigation.TryClosePopupAsync(expectedInputResult, TestContext.Current.CancellationToken);
+
+		// Assert
+		Assert.Equal(expectedInputResult, result.Result);
+		Assert.NotNull(result.Exception);
+		Assert.IsType<PopupBlockedException>(result.Exception);
+		Assert.False(result.IsSuccessful);
+		Assert.False(result.IsCancelled);
+		Assert.Throws<PopupBlockedException>(result.EnsureSuccess);
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ClosePopupAsync_ShouldClosePopupUsingNavigationAndReturnResult()
 	{
 		// Arrange

--- a/src/CommunityToolkit.Maui.UnitTests/Mocks/FolderPickerImplementationMock.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Mocks/FolderPickerImplementationMock.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.Maui.Core.Primitives;
+﻿using CommunityToolkit.Maui.Core;
 using CommunityToolkit.Maui.Storage;
 
 namespace CommunityToolkit.Maui.UnitTests.Mocks;

--- a/src/CommunityToolkit.Maui.UnitTests/Services/PopupServiceTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Services/PopupServiceTests.cs
@@ -452,6 +452,57 @@ public class PopupServiceTests : BaseViewTest
 		await Assert.ThrowsAsync<OperationCanceledException>(() => popupService.ShowPopupAsync<ShortLivedSelfClosingPopup>(shell, PopupOptions.Empty, shellParameters, cts.Token));
 	}
 
+	[Fact]
+	public void Constructor_Default_ShouldCreateInstance_WhenPlatformServicesAvailable()
+	{
+		// Act
+		var popupService = new PopupService();
+
+		// Assert
+		Assert.NotNull(popupService);
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task ClosePopupAsync_UsingNavigation_ShouldThrowOperationCanceledException_WhenTokenIsCanceled()
+	{
+		// Arrange
+		var popupService = ServiceProvider.GetRequiredService<IPopupService>();
+		var cancellationTokenSource = new CancellationTokenSource();
+		await cancellationTokenSource.CancelAsync();
+
+		// Act / Assert
+		await Assert.ThrowsAsync<OperationCanceledException>(() => popupService.ClosePopupAsync(navigation, cancellationTokenSource.Token));
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task ClosePopupAsyncT_UsingNavigation_ShouldThrowOperationCanceledException_WhenTokenIsCanceled()
+	{
+		// Arrange
+		var popupService = ServiceProvider.GetRequiredService<IPopupService>();
+		var cancellationTokenSource = new CancellationTokenSource();
+		await cancellationTokenSource.CancelAsync();
+
+		// Act / Assert
+		await Assert.ThrowsAsync<OperationCanceledException>(() => popupService.ClosePopupAsync(navigation, 2, cancellationTokenSource.Token));
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task ClosePopupAsync_UsingPage_ShouldThrowOperationCanceledException_WhenTokenIsCanceled()
+	{
+		// Arrange
+		var popupService = ServiceProvider.GetRequiredService<IPopupService>();
+		var cancellationTokenSource = new CancellationTokenSource();
+		await cancellationTokenSource.CancelAsync();
+
+		if (Application.Current?.Windows[0].Page is not Page page)
+		{
+			throw new InvalidOperationException("Page cannot be null");
+		}
+
+		// Act / Assert
+		await Assert.ThrowsAsync<OperationCanceledException>(() => popupService.ClosePopupAsync(page, cancellationTokenSource.Token));
+	}
+
 	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task ClosePopupAsync_UsingPage_ShouldThrowArgumentNullException_WhenPageIsNull()
 	{

--- a/src/CommunityToolkit.Maui.UnitTests/Views/Popup/PopupPageTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/Popup/PopupPageTests.cs
@@ -531,6 +531,30 @@ public class PopupPageTests : BaseViewTest
 	}
 
 	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task ShowAsync_Shell_ShouldThrowArgumentNullException_WhenShellIsNull()
+	{
+		// Arrange
+		var popupPage = new PopupPage(new Label(), PopupOptions.Empty);
+
+		// Act / Assert
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+		await Assert.ThrowsAsync<ArgumentNullException>(() => popupPage.ShowAsync((Shell?)null, "route", token: TestContext.Current.CancellationToken));
+#pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task ShowAsync_Shell_ShouldThrowArgumentException_WhenRouteIsEmpty()
+	{
+		// Arrange
+		var shell = new Shell();
+		shell.Items.Add(new ContentPage());
+		var popupPage = new PopupPage(new Label(), PopupOptions.Empty);
+
+		// Act / Assert
+		await Assert.ThrowsAsync<ArgumentException>(() => popupPage.ShowAsync(shell, string.Empty, token: TestContext.Current.CancellationToken));
+	}
+
+	[Fact(Timeout = (int)TestDuration.Short)]
 	public async Task OnTappingOutsideOfPopup_ShouldClosePopupWhenCanBeDismissedIsTrue()
 	{
 		// Arrange
@@ -832,6 +856,51 @@ public class PopupPageTests : BaseViewTest
 
 		// Assert
 		Assert.Equal(popupValue, popup.PopupValue);
+		Assert.Equal(contentValue, popupContent.ContentValue);
+	}
+
+	[Fact]
+	public void ApplyQueryAttributes_ShouldForwardToPopupOnly_WhenContentDoesNotImplementIQueryAttributable()
+	{
+		// Arrange
+		const string popupValue = "popup-only";
+		var query = new Dictionary<string, object>
+		{
+			[nameof(QueryAttributablePopup.PopupValue)] = popupValue
+		};
+		var popup = new QueryAttributablePopup
+		{
+			Content = new ContentView()
+		};
+		var popupPage = new PopupPage(popup, PopupOptions.Empty);
+
+		// Act
+		((IQueryAttributable)popupPage).ApplyQueryAttributes(query);
+
+		// Assert
+		Assert.Equal(popupValue, popup.PopupValue);
+	}
+
+	[Fact]
+	public void ApplyQueryAttributes_ShouldForwardToPopupContentOnly_WhenPopupDoesNotImplementIQueryAttributable()
+	{
+		// Arrange
+		const string contentValue = "content-only";
+		var query = new Dictionary<string, object>
+		{
+			[nameof(QueryAttributableContentView.ContentValue)] = contentValue
+		};
+		var popupContent = new QueryAttributableContentView();
+		var popup = new Popup
+		{
+			Content = popupContent
+		};
+		var popupPage = new PopupPage(popup, PopupOptions.Empty);
+
+		// Act
+		((IQueryAttributable)popupPage).ApplyQueryAttributes(query);
+
+		// Assert
 		Assert.Equal(contentValue, popupContent.ContentValue);
 	}
 

--- a/src/CommunityToolkit.Maui.UnitTests/Views/Popup/PopupResultTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/Popup/PopupResultTests.cs
@@ -142,4 +142,42 @@ public class PopupResultTests : BaseTest
 		Assert.Equal(7, result.Result);
 		Assert.False(result.WasDismissedByTappingOutsideOfPopup);
 	}
+
+	[Fact]
+	public void IResult_DefaultImplementation_ShouldReportSuccessful_WhenExceptionIsNull()
+	{
+		// Arrange
+		IResult result = new TestResult(null);
+
+		// Assert
+		Assert.True(result.IsSuccessful);
+		Assert.False(result.IsCancelled);
+		result.EnsureSuccess();
+	}
+
+	[Fact]
+	public void IResult_DefaultImplementation_ShouldReportCancelled_WhenExceptionIsOperationCanceledException()
+	{
+		// Arrange
+		IResult result = new TestResult(new OperationCanceledException("canceled"));
+
+		// Assert
+		Assert.False(result.IsSuccessful);
+		Assert.True(result.IsCancelled);
+		Assert.Throws<OperationCanceledException>(result.EnsureSuccess);
+	}
+
+	[Fact]
+	public void IResult_DefaultImplementation_ShouldReportFailure_WhenExceptionIsNonCancellationException()
+	{
+		// Arrange
+		IResult result = new TestResult(new InvalidOperationException("failed"));
+
+		// Assert
+		Assert.False(result.IsSuccessful);
+		Assert.False(result.IsCancelled);
+		Assert.Throws<InvalidOperationException>(result.EnsureSuccess);
+	}
+
+	sealed record TestResult(Exception? Exception) : IResult;
 }

--- a/src/CommunityToolkit.Maui.UnitTests/Views/Popup/PopupTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Views/Popup/PopupTests.cs
@@ -187,6 +187,36 @@ public class PopupTests : BaseViewTest
 		Assert.Empty(page.Navigation.ModalStack);
 	}
 
+	[Fact(Timeout = (int)TestDuration.Short)]
+	public async Task ShowPopupAsyncT_TaskShouldCompleteWhenPopupTCloseAsyncWithResultIsCalled()
+	{
+		// Arrange
+		const string expectedResult = "typed-result";
+		Task<IPopupResult<string>> showPopupAsyncTask;
+		var popup = new Popup<string>();
+
+		if (Application.Current?.Windows[0].Page is not Page page)
+		{
+			throw new InvalidOperationException("Page cannot be null");
+		}
+
+		// Act
+		showPopupAsyncTask = page.ShowPopupAsync<string>(popup, token: TestContext.Current.CancellationToken);
+
+		// Assert
+		Assert.Single(page.Navigation.ModalStack);
+		Assert.IsType<PopupPage>(page.Navigation.ModalStack[0]);
+
+		// Act
+		await popup.CloseAsync(expectedResult, TestContext.Current.CancellationToken);
+		var popupResult = await showPopupAsyncTask;
+
+		// Assert
+		Assert.Empty(page.Navigation.ModalStack);
+		Assert.Equal(expectedResult, popupResult.Result);
+		Assert.False(popupResult.WasDismissedByTappingOutsideOfPopup);
+	}
+
 	[Fact]
 	public void PopupNotFoundException_Message_ShouldContainGuidance()
 	{

--- a/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
@@ -318,7 +318,7 @@ public static class PopupExtensions
 	}
 
 	/// <summary>
-	/// Closes the most recent popup and returns an <see cref="IPopupResult"/> that provides details about the closure.
+	/// Closes the most recent popup and returns an <see cref="IClosePopupResult"/> that provides details about the closure.
 	/// </summary>
 	public static Task<IClosePopupResult> TryClosePopupAsync(this Page page, CancellationToken token = default)
 	{

--- a/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
@@ -19,7 +19,7 @@ public static class PopupExtensions
 	{
 		ArgumentNullException.ThrowIfNull(page);
 
-		ShowPopup(page.Navigation, view, options);
+		page.Navigation.ShowPopup(view, options);
 	}
 
 	/// <summary>
@@ -54,6 +54,21 @@ public static class PopupExtensions
 
 		await shell.ShowPopupAsync(view, options, shellParameters);
 	}
+	
+	/// <summary>
+	/// Shows a popup with the specified options.
+	/// </summary>
+	/// <param name="page">The current page that provides access to the <see cref="INavigation"/> implementation.</param>
+	/// <param name="view">The <see cref="View"/> that will be displayed as the content in the popup.</param>
+	/// <param name="options">The <see cref="IPopupOptions"/> that enable support for customizing the display and behavior of the presented popup.</param>
+	/// <param name="token">A <see cref="CancellationToken"/> providing support for canceling the wait for a result to be returned. This will <b>not</b> close the popup.</param>
+	/// <returns>An <see cref="IShowPopupResult{TResult}"/> when the popup is closed or the <paramref name="token"/> is canceled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup"/> value to determine how the popup was closed.</returns>
+	public static Task<IShowPopupResult<TResult>> TryShowPopupAsync<TResult>(this Page page, View view, IPopupOptions? options = null, CancellationToken token = default)
+	{
+		ArgumentNullException.ThrowIfNull(page);
+
+		return page.Navigation.TryShowPopupAsync<TResult>(view, options, token);
+	}
 
 	/// <summary>
 	/// Shows a popup with the specified options.
@@ -69,6 +84,23 @@ public static class PopupExtensions
 
 		return page.Navigation.ShowPopupAsync<TResult>(view, options, token);
 	}
+	
+	/// <summary>
+	/// Shows a popup with the specified options.
+	/// </summary>
+	/// <param name="navigation">The <see cref="INavigation"/> implementation responsible for displaying the popup. Make sure to use the one associated with the <see cref="Window"/> that you wish the popup to be displayed on.</param>
+	/// <param name="view">The <see cref="View"/> that will be displayed as the content in the popup.</param>
+	/// <param name="options">The <see cref="IPopupOptions"/> that enable support for customizing the display and behavior of the presented popup.</param>
+	/// <param name="token">A <see cref="CancellationToken"/> providing support for canceling the wait for a result to be returned. This will <b>not</b> close the popup.</param>
+	/// <returns>An <see cref="IShowPopupResult{TResult}"/> when the popup is closed or the <paramref name="token"/> is canceled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup"/> value to determine how the popup was closed.</returns>
+	public static async Task<IShowPopupResult<TResult>> TryShowPopupAsync<TResult>(this INavigation navigation, View view, IPopupOptions? options = null, CancellationToken token = default)
+	{
+		var result = await navigation.TryShowPopupAsync(view, options, token);
+
+		var popupResult = GetPopupResult<TResult>(result);
+
+		return new ShowPopupResult<TResult>(popupResult, result.Exception); 
+	}
 
 	/// <summary>
 	/// Shows a popup with the specified options.
@@ -77,12 +109,30 @@ public static class PopupExtensions
 	/// <param name="view">The <see cref="View"/> that will be displayed as the content in the popup.</param>
 	/// <param name="options">The <see cref="IPopupOptions"/> that enable support for customizing the display and behavior of the presented popup.</param>
 	/// <param name="token">A <see cref="CancellationToken"/> providing support for canceling the wait for a result to be returned. This will <b>not</b> close the popup.</param>
-	/// <returns>An <see cref="IPopupResult{T}"/> when the popup is closed or the <paramref name="token"/> is canceled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup"/> value to determine how the popup was closed.</returns>
+	/// <returns>An <see cref="IPopupResult{TResult}"/> when the popup is closed or the <paramref name="token"/> is canceled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup"/> value to determine how the popup was closed.</returns>
 	public static async Task<IPopupResult<TResult>> ShowPopupAsync<TResult>(this INavigation navigation, View view, IPopupOptions? options = null, CancellationToken token = default)
 	{
-		var result = await ShowPopupAsync(navigation, view, options, token);
+		var result = await navigation.ShowPopupAsync(view, options, token);
 
 		return GetPopupResult<TResult>(result);
+	}
+	
+	/// <summary>
+	/// Shows a popup with the specified options.
+	/// </summary>
+	/// <param name="shell">Current <see cref="Shell"/></param>
+	/// <param name="view">The <see cref="View"/> that will be displayed as the content in the popup.</param>
+	/// <param name="options">The <see cref="IPopupOptions"/> that enable support for customizing the display and behavior of the presented popup.</param>
+	/// <param name="shellParameters">Parameters that will be passed into the <paramref name="view"/> or its associated BindingContext if they implement <see cref="IQueryAttributable"/>.</param>
+	/// <param name="token">A <see cref="CancellationToken"/> providing support for canceling the wait for a result to be returned. This will <b>not</b> close the popup.</param>
+	/// <returns>An <see cref="IShowPopupResult{TResult}"/> when the popup is closed or the <paramref name="token"/> is canceled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup"/> value to determine how the popup was closed.</returns>
+	public static async Task<IShowPopupResult<TResult>> TryShowPopupAsync<TResult>(this Shell shell, View view, IPopupOptions? options = null, IDictionary<string, object>? shellParameters = null, CancellationToken token = default)
+	{
+		var result = await shell.TryShowPopupAsync(view, options, shellParameters, token);
+
+		var popupResult = GetPopupResult<TResult>(result);
+
+		return new ShowPopupResult<TResult>(popupResult, result.Exception); 
 	}
 
 	/// <summary>
@@ -93,12 +143,27 @@ public static class PopupExtensions
 	/// <param name="options">The <see cref="IPopupOptions"/> that enable support for customizing the display and behavior of the presented popup.</param>
 	/// <param name="shellParameters">Parameters that will be passed into the <paramref name="view"/> or its associated BindingContext if they implement <see cref="IQueryAttributable"/>.</param>
 	/// <param name="token">A <see cref="CancellationToken"/> providing support for canceling the wait for a result to be returned. This will <b>not</b> close the popup.</param>
-	/// <returns>An <see cref="IPopupResult{T}"/> when the popup is closed or the <paramref name="token"/> is canceled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup"/> value to determine how the popup was closed.</returns>
+	/// <returns>An <see cref="IPopupResult{TResult}"/> when the popup is closed or the <paramref name="token"/> is canceled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup"/> value to determine how the popup was closed.</returns>
 	public static async Task<IPopupResult<TResult>> ShowPopupAsync<TResult>(this Shell shell, View view, IPopupOptions? options = null, IDictionary<string, object>? shellParameters = null, CancellationToken token = default)
 	{
-		var result = await ShowPopupAsync(shell, view, options, shellParameters, token);
+		var result = await shell.ShowPopupAsync(view, options, shellParameters, token);
 
 		return GetPopupResult<TResult>(result);
+	}
+
+	/// <summary>
+	/// Shows a popup with the specified options.
+	/// </summary>
+	/// <param name="page">The current page that provides access to the <see cref="INavigation"/> implementation.</param>
+	/// <param name="view">The <see cref="View"/> that will be displayed as the content in the popup.</param>
+	/// <param name="options">The <see cref="IPopupOptions"/> that enable support for customizing the display and behavior of the presented popup.</param>
+	/// <param name="token">A <see cref="CancellationToken"/> providing support for canceling the wait for a result to be returned. This will <b>not</b> close the popup.</param>
+	/// <returns>An <see cref="IShowPopupResult"/> when the popup is closed or the <paramref name="token"/> is canceled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup"/> value to determine how the popup was closed.</returns>
+	public static Task<IShowPopupResult> TryShowPopupAsync(this Page page, View view, IPopupOptions? options = null, CancellationToken token = default)
+	{
+		ArgumentNullException.ThrowIfNull(page);
+		
+		return page.Navigation.TryShowPopupAsync(view, options, token);
 	}
 
 	/// <summary>
@@ -113,7 +178,31 @@ public static class PopupExtensions
 	{
 		ArgumentNullException.ThrowIfNull(page);
 
-		return ShowPopupAsync(page.Navigation, view, options, token);
+		return page.Navigation.ShowPopupAsync(view, options, token);
+	}
+
+	/// <summary>
+	/// Shows a popup with the specified options.
+	/// </summary>
+	/// <param name="navigation">The <see cref="INavigation"/> implementation responsible for displaying the popup. Make sure to use the one associated with the <see cref="Window"/> that you wish the popup to be displayed on.</param>
+	/// <param name="view">The <see cref="View"/> that will be displayed as the content in the popup.</param>
+	/// <param name="options">The <see cref="IPopupOptions"/> that enable support for customizing the display and behavior of the presented popup.</param>
+	/// <param name="token">A <see cref="CancellationToken"/> providing support for canceling the wait for a result to be returned. This will <b>not</b> close the popup.</param>
+	/// <returns>An <see cref="IPopupResult"/> when the popup is closed or the <paramref name="token"/> is canceled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup"/> value to determine how the popup was closed.</returns>
+	public static async Task<IShowPopupResult> TryShowPopupAsync(this INavigation navigation, View view, IPopupOptions? options, CancellationToken token = default)
+	{
+		ArgumentNullException.ThrowIfNull(navigation);
+		ArgumentNullException.ThrowIfNull(view);
+
+		try
+		{
+			var popupResult = await navigation.ShowPopupAsync(view, options, token);
+			return new ShowPopupResult(popupResult.WasDismissedByTappingOutsideOfPopup, null);
+		}
+		catch (Exception e)
+		{
+			return new ShowPopupResult(false, e);
+		}
 	}
 
 	/// <summary>
@@ -144,6 +233,31 @@ public static class PopupExtensions
 		{
 			popupPage.PopupClosed -= HandlePopupClosed;
 			taskCompletionSource.SetResult(e);
+		}
+	}
+
+	/// <summary>
+	/// Shows a popup with the specified options.
+	/// </summary>
+	/// <param name="shell">Current <see cref="Shell"/></param>
+	/// <param name="view">The <see cref="View"/> that will be displayed as the content in the popup.</param>
+	/// <param name="options">The <see cref="IPopupOptions"/> that enable support for customizing the display and behavior of the presented popup.</param>
+	/// <param name="shellParameters">Parameters that will be passed into the <paramref name="view"/> or its associated BindingContext if they implement <see cref="IQueryAttributable"/>.</param>
+	/// <param name="token">A <see cref="CancellationToken"/> providing support for canceling the wait for a result to be returned. This will <b>not</b> close the popup.</param>
+	/// <returns>An <see cref="IShowPopupResult"/> when the popup is closed or the <paramref name="token"/> is cancelled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup"/> value to determine how the popup was closed.</returns>
+	public static async Task<IShowPopupResult> TryShowPopupAsync(this Shell shell, View view, IPopupOptions? options, IDictionary<string, object>? shellParameters = null, CancellationToken token = default)
+	{
+		ArgumentNullException.ThrowIfNull(shell);
+		ArgumentNullException.ThrowIfNull(view);
+
+		try
+		{
+			var popupResult = await shell.ShowPopupAsync(view, options, shellParameters, token);
+			return new ShowPopupResult(popupResult.WasDismissedByTappingOutsideOfPopup, null);
+		}
+		catch (Exception e)
+		{
+			return new ShowPopupResult(false, e);
 		}
 	}
 
@@ -192,11 +306,39 @@ public static class PopupExtensions
 	/// <summary>
 	/// Closes the most recent popup and returns an <see cref="IPopupResult"/> that provides details about the closure.
 	/// </summary>
+	public static Task<IClosePopupResult> TryClosePopupAsync(this Page page, CancellationToken token = default)
+	{
+		ArgumentNullException.ThrowIfNull(page);
+
+		return page.Navigation.TryClosePopupAsync(token);
+	}
+
+	/// <summary>
+	/// Closes the most recent popup and returns an <see cref="IPopupResult"/> that provides details about the closure.
+	/// </summary>
 	public static Task<IPopupResult> ClosePopupAsync(this Page page, CancellationToken token = default)
 	{
 		ArgumentNullException.ThrowIfNull(page);
 
-		return ClosePopupAsync(page.Navigation, token);
+		return page.Navigation.ClosePopupAsync(token);
+	}
+	
+	/// <summary>
+	/// Closes the most recent popup and returns an <see cref="IClosePopupResult"/> that provides details about the closure.
+	/// </summary>
+	public static async Task<IClosePopupResult> TryClosePopupAsync(this INavigation navigation, CancellationToken token = default)
+	{
+		ArgumentNullException.ThrowIfNull(navigation);
+
+		try
+		{
+			var popupResult = await navigation.ClosePopupAsync(token);
+			return new ClosePopupResult(popupResult.WasDismissedByTappingOutsideOfPopup, null);
+		}
+		catch (Exception e)
+		{
+			return new ClosePopupResult(false, e);
+		}
 	}
 
 	/// <summary>
@@ -223,6 +365,16 @@ public static class PopupExtensions
 			popupClosedTCS.SetResult(e);
 		}
 	}
+	
+	/// <summary>
+	/// Closes the most recent popup and returns an <see cref="IClosePopupResult{TResult}"/> that provides details about the closure.
+	/// </summary>
+	public static Task<IClosePopupResult<TResult>> TryClosePopupAsync<TResult>(this Page page, TResult result, CancellationToken token = default)
+	{
+		ArgumentNullException.ThrowIfNull(page);
+
+		return page.Navigation.TryClosePopupAsync(result, token);
+	}
 
 	/// <summary>
 	/// Closes the most recent popup and returns an <see cref="IPopupResult{TResult}"/> that provides details about the closure.
@@ -231,7 +383,25 @@ public static class PopupExtensions
 	{
 		ArgumentNullException.ThrowIfNull(page);
 
-		return ClosePopupAsync(page.Navigation, result, token);
+		return page.Navigation.ClosePopupAsync(result, token);
+	}
+
+	/// <summary>
+	/// Closes the most recent popup and returns an <see cref="IClosePopupResult{TResult}"/> that provides details about the closure.
+	/// </summary>
+	public static async Task<IClosePopupResult<TResult>> TryClosePopupAsync<TResult>(this INavigation navigation, TResult result, CancellationToken token = default)
+	{
+		ArgumentNullException.ThrowIfNull(navigation);
+
+		try
+		{
+			var popupResult = await navigation.ClosePopupAsync(result, token);
+			return new ClosePopupResult<TResult>(popupResult, null);
+		}
+		catch (Exception e)
+		{
+			return new ClosePopupResult<TResult>(result, false, e);
+		}
 	}
 
 	/// <summary>

--- a/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
@@ -95,11 +95,18 @@ public static class PopupExtensions
 	/// <returns>An <see cref="IShowPopupResult{TResult}"/> when the popup is closed or the <paramref name="token"/> is canceled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup"/> value to determine how the popup was closed.</returns>
 	public static async Task<IShowPopupResult<TResult>> TryShowPopupAsync<TResult>(this INavigation navigation, View view, IPopupOptions? options = null, CancellationToken token = default)
 	{
-		var result = await navigation.TryShowPopupAsync(view, options, token);
+		ArgumentNullException.ThrowIfNull(navigation);
+		ArgumentNullException.ThrowIfNull(view);
 
-		var popupResult = GetPopupResult<TResult>(result);
-
-		return new ShowPopupResult<TResult>(popupResult, result.Exception); 
+		try
+		{
+			var popupResult = await navigation.ShowPopupAsync<TResult>(view, options, token);
+			return new ShowPopupResult<TResult>(popupResult, null);
+		}
+		catch (Exception e)
+		{
+			return new ShowPopupResult<TResult>(default(TResult), false, e);
+		}
 	}
 
 	/// <summary>
@@ -128,11 +135,18 @@ public static class PopupExtensions
 	/// <returns>An <see cref="IShowPopupResult{TResult}"/> when the popup is closed or the <paramref name="token"/> is canceled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup"/> value to determine how the popup was closed.</returns>
 	public static async Task<IShowPopupResult<TResult>> TryShowPopupAsync<TResult>(this Shell shell, View view, IPopupOptions? options = null, IDictionary<string, object>? shellParameters = null, CancellationToken token = default)
 	{
-		var result = await shell.TryShowPopupAsync(view, options, shellParameters, token);
+		ArgumentNullException.ThrowIfNull(shell);
+		ArgumentNullException.ThrowIfNull(view);
 
-		var popupResult = GetPopupResult<TResult>(result);
-
-		return new ShowPopupResult<TResult>(popupResult, result.Exception); 
+		try
+		{
+			var popupResult = await shell.ShowPopupAsync<TResult>(view, options, shellParameters, token);
+			return new ShowPopupResult<TResult>(popupResult, null);
+		}
+		catch (Exception e)
+		{
+			return new ShowPopupResult<TResult>(default(TResult), false, e);
+		}
 	}
 
 	/// <summary>

--- a/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
+++ b/src/CommunityToolkit.Maui/Extensions/PopupExtensions.shared.cs
@@ -202,7 +202,7 @@ public static class PopupExtensions
 	/// <param name="view">The <see cref="View"/> that will be displayed as the content in the popup.</param>
 	/// <param name="options">The <see cref="IPopupOptions"/> that enable support for customizing the display and behavior of the presented popup.</param>
 	/// <param name="token">A <see cref="CancellationToken"/> providing support for canceling the wait for a result to be returned. This will <b>not</b> close the popup.</param>
-	/// <returns>An <see cref="IPopupResult"/> when the popup is closed or the <paramref name="token"/> is canceled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup"/> value to determine how the popup was closed.</returns>
+	/// <returns>An <see cref="IShowPopupResult"/> when the popup is closed or the <paramref name="token"/> is canceled. Make sure to check the <see cref="IPopupResult.WasDismissedByTappingOutsideOfPopup"/> value to determine how the popup was closed.</returns>
 	public static async Task<IShowPopupResult> TryShowPopupAsync(this INavigation navigation, View view, IPopupOptions? options, CancellationToken token = default)
 	{
 		ArgumentNullException.ThrowIfNull(navigation);

--- a/src/CommunityToolkit.Maui/Primitives/ClosePopupResult.cs
+++ b/src/CommunityToolkit.Maui/Primitives/ClosePopupResult.cs
@@ -1,0 +1,26 @@
+using CommunityToolkit.Maui.Core;
+
+namespace CommunityToolkit.Maui;
+
+/// <inheritdoc cref="IClosePopupResult" />
+record ClosePopupResult(bool WasDismissedByTappingOutsideOfPopup, Exception? Exception)
+	: PopupResult(WasDismissedByTappingOutsideOfPopup), IClosePopupResult;
+
+record ClosePopupResult<T> : PopupResult<T>, IClosePopupResult<T>
+{
+	public ClosePopupResult(object? result, bool wasDismissedByTappingOutsideOfPopup, Exception? exception)
+		: base(result, wasDismissedByTappingOutsideOfPopup)
+	{
+		Exception = exception;
+	}
+
+	public ClosePopupResult(IPopupResult<T> popupResult, Exception? exception)
+		: this(popupResult.WasDismissedByTappingOutsideOfPopup ? null : popupResult.Result,
+			popupResult.WasDismissedByTappingOutsideOfPopup,
+			exception)
+	{
+		
+	}
+	
+	public Exception? Exception { get; }
+}

--- a/src/CommunityToolkit.Maui/Primitives/PopupResult.shared.cs
+++ b/src/CommunityToolkit.Maui/Primitives/PopupResult.shared.cs
@@ -13,7 +13,7 @@ record PopupResult(bool WasDismissedByTappingOutsideOfPopup) : IPopupResult;
 /// Represents the result of a popup when T is a reference type.
 /// </summary>
 /// <typeparam name="T">Popup result type</typeparam>
-sealed record PopupResult<T> : PopupResult, IPopupResult<T>
+record PopupResult<T> : PopupResult, IPopupResult<T>
 {
 	/// <summary>
 	/// Initialize <see cref="PopupResult{T}"/>.
@@ -28,7 +28,9 @@ sealed record PopupResult<T> : PopupResult, IPopupResult<T>
 	}
 
 	public T? Result => WasDismissedByTappingOutsideOfPopup && !typeof(T).IsNullable()
-		? throw new PopupResultException($"{nameof(Result)} is null, but {nameof(PopupResult)} type, {typeof(T)}, cannot be converted to null. Every time {nameof(WasDismissedByTappingOutsideOfPopup)} is {true}, {nameof(Result)} is always null. When using a non-nullable type (e.g. bool) be sure to first check if {nameof(WasDismissedByTappingOutsideOfPopup)} is {false} before getting the value of {nameof(Result)}")
+		? throw new PopupResultException($"{nameof(Result)} is null, but {nameof(PopupResult)} type, {typeof(T)}, cannot be converted to null. " +
+		                                 $"Every time {nameof(WasDismissedByTappingOutsideOfPopup)} is {true}, {nameof(Result)} is always null. " +
+		                                 $"When using a non-nullable type (e.g. bool) be sure to first check if {nameof(WasDismissedByTappingOutsideOfPopup)} is {false} before getting the value of {nameof(Result)}")
 		: field;
 }
 

--- a/src/CommunityToolkit.Maui/Primitives/ShowPopupResult.shared.cs
+++ b/src/CommunityToolkit.Maui/Primitives/ShowPopupResult.shared.cs
@@ -1,0 +1,31 @@
+using CommunityToolkit.Maui.Core;
+
+namespace CommunityToolkit.Maui;
+
+/// <summary>
+/// Result of TryShowPopup
+/// </summary>
+/// <param name="Exception">Exception if operation failed</param>
+record ShowPopupResult(bool WasDismissedByTappingOutsideOfPopup, Exception? Exception) : PopupResult(WasDismissedByTappingOutsideOfPopup), IShowPopupResult;
+
+/// <summary>
+/// Result of TryShowPopup
+/// </summary>
+record ShowPopupResult<T> : PopupResult<T>, IShowPopupResult<T>
+{
+	public ShowPopupResult(object? result, bool wasDismissedByTappingOutsideOfPopup, Exception? exception)
+		: base(result, wasDismissedByTappingOutsideOfPopup)
+	{
+		Exception = exception;
+	}
+
+	public ShowPopupResult(IPopupResult<T> popupResult, Exception? exception)
+		: this(popupResult.WasDismissedByTappingOutsideOfPopup ? null : popupResult.Result,
+			popupResult.WasDismissedByTappingOutsideOfPopup,
+			exception)
+	{
+		
+	}
+	
+	public Exception? Exception { get; }
+}

--- a/src/CommunityToolkit.Maui/Primitives/ShowPopupResult.shared.cs
+++ b/src/CommunityToolkit.Maui/Primitives/ShowPopupResult.shared.cs
@@ -5,6 +5,7 @@ namespace CommunityToolkit.Maui;
 /// <summary>
 /// Result of TryShowPopup
 /// </summary>
+/// <param name="WasDismissedByTappingOutsideOfPopup">True if Popup is closed by tapping outside popup</param>
 /// <param name="Exception">Exception if operation failed</param>
 record ShowPopupResult(bool WasDismissedByTappingOutsideOfPopup, Exception? Exception) : PopupResult(WasDismissedByTappingOutsideOfPopup), IShowPopupResult;
 
@@ -13,6 +14,9 @@ record ShowPopupResult(bool WasDismissedByTappingOutsideOfPopup, Exception? Exce
 /// </summary>
 record ShowPopupResult<T> : PopupResult<T>, IShowPopupResult<T>
 {
+	/// <param name="result">Popup result</param>
+	/// <param name="wasDismissedByTappingOutsideOfPopup">True if Popup is closed by tapping outside the popup</param>
+	/// <param name="exception">Exception if operation failed</param>
 	public ShowPopupResult(object? result, bool wasDismissedByTappingOutsideOfPopup, Exception? exception)
 		: base(result, wasDismissedByTappingOutsideOfPopup)
 	{

--- a/src/CommunityToolkit.Maui/Views/Popup/PopupPage.shared.cs
+++ b/src/CommunityToolkit.Maui/Views/Popup/PopupPage.shared.cs
@@ -97,7 +97,7 @@ partial class PopupPage : ContentPage, IQueryAttributable
 	public async Task ShowAsync(Shell shell, string shellRoute, IDictionary<string, object>? shellParameters = null, CancellationToken token = default)
 	{
 		ArgumentNullException.ThrowIfNull(shell);
-		ArgumentException.ThrowIfNullOrEmpty(shellRoute, nameof(shellRoute));
+		ArgumentException.ThrowIfNullOrEmpty(shellRoute);
 		await navigationSemaphoreSlim.WaitAsync(token);
 
 		try


### PR DESCRIPTION
 ### Description of Change ###

As discussed in the [June 2026 Standup](https://www.youtube.com/watch?v=-saluayXw6U), this Pull Request implements `TryShowPopupAsync` and `TryClosePopupAsync`.

This PR also adds `IResult` to standardize the Try/Result pattern across `FileSaverResult`, `FolderPickerResult`, `ShowPopupResult` and `ClosePopupResult`.

 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [x] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->


 ### Additional information ###

There is a breaking change in this PR: I removed the `CommunityToolkit.Maui.Core.Primitives` namespace. This should've never existed; `Folder` had been using the incorrect namespace.
