### PR TITLE
Use trusted publishing for NuGet release

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -382,6 +382,9 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         needs: [ sign ]
         environment: nuget-release-gate # This gates this job until manually approved
+        permissions:
+            id-token: write
+            contents: read
         runs-on: ubuntu-latest
         
         steps:
@@ -397,10 +400,16 @@ jobs:
                     name: signed-packages
                     path: ./packages
 
+            -   name: NuGet login (OIDC)
+                id: login
+                uses: NuGet/login@v1
+                with:
+                    user: ${{ secrets.NUGET_USER }}
+
             -   name: Push to NuGet.org
                 run: >
                     dotnet nuget push
                     **/*.nupkg
                     --source https://api.nuget.org/v3/index.json
-                    --api-key ${{ secrets.NUGET_PACKAGE_PUSH_TOKEN }}
+                    --api-key ${{ steps.login.outputs.NUGET_API_KEY }}
                     --skip-duplicate

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -385,6 +385,7 @@ jobs:
         permissions:
             id-token: write
             contents: read
+            actions: read
         runs-on: ubuntu-latest
         
         steps:

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -402,7 +402,7 @@ jobs:
 
             -   name: NuGet login (OIDC)
                 id: login
-                uses: NuGet/login@v1
+                uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
                 with:
                     user: ${{ secrets.NUGET_USER }}
 


### PR DESCRIPTION
### Description of Change ###

This moves the NuGet.org release job (`release-nuget` in `.github/workflows/dotnet-build.yml`) to NuGet trusted publishing, matching the approach from CommunityToolkit/Aspire#1452:

- grants the job `id-token: write`, `contents: read`, and `actions: read`
- logs in with pinned `NuGet/login@v1`
- pushes packages with `${{ steps.login.outputs.NUGET_API_KEY }}` instead of the long-lived `${{ secrets.NUGET_PACKAGE_PUSH_TOKEN }}`

This repo was not already using trusted publishing for the NuGet.org publish path; the signing job requested an OIDC token, but the `release-nuget` job still pushed with the long-lived NuGet API key.

Reviewers should note that this workflow change also requires external configuration before the first trusted-publishing release can succeed:

- Add a `NUGET_USER` secret to the `nuget-release-gate` GitHub environment. The value should be the nuget.org profile/owner used for the trusted publishing policy, not an email address.
- Create a matching nuget.org trusted publishing policy for the package owner. The current pushed packages are owned by both `Microsoft.Toolkit` and `dotnetfoundation`, so the policy and `NUGET_USER` secret should use whichever of those nuget.org owners is intended to publish these packages.
- Configure the policy with repository owner `CommunityToolkit`, repository `Maui`, workflow file `dotnet-build.yml`, and environment `nuget-release-gate`.

### Linked Issues ###

- N/A

### PR Checklist ###

- [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal) - N/A, workflow infrastructure change
- [ ] Has tests (if omitted, state reason in description) - N/A, workflow-only change
- [ ] Has samples (if omitted, state reason in description) - N/A, workflow-only change
- [x] Rebased on top of `main` at time of PR
- [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
- [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls - N/A, workflow-only change

### Additional information ###

No product code changes; this only updates the NuGet.org release publishing workflow.