### PR TITLE
Hardcode NuGet trusted publishing user

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -405,7 +405,7 @@ jobs:
                 id: login
                 uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1
                 with:
-                    user: ${{ secrets.NUGET_USER }}
+                    user: jfversluis_MSFT
 
             -   name: Push to NuGet.org
                 run: >


### PR DESCRIPTION
## ⚠️ Mandatory before the next release

**This PR must be merged before the next release. Otherwise, NuGet trusted publishing will fail at the `NuGet login (OIDC)` step because the environment-scoped `NUGET_USER` secret is being removed.**

### Description of Change ###

Uses the literal nuget.org username `jfversluis_MSFT` for `NuGet/login` instead of reading it from `secrets.NUGET_USER`.

The username is a public publisher identifier, not a credential. Trusted publishing remains unchanged: GitHub Actions OIDC still obtains the short-lived NuGet API key exposed through `steps.login.outputs.NUGET_API_KEY`, and the workflow continues to use that key for package publishing.

### Linked Issues ###

- N/A — focused release infrastructure follow-up

### PR Checklist ###

- [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal) — N/A; release infrastructure fix
- [ ] Has tests (if omitted, state reason in description) — N/A; one-line workflow configuration change
- [ ] Has samples (if omitted, state reason in description) — N/A; no product behavior change
- [x] Rebased on top of `main` at time of PR
- [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
- [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls — N/A; no public API or documentation change

### Additional information ###

Validation:

- Ruby YAML parser successfully parsed `.github/workflows/dotnet-build.yml`.
- `git diff --check` passed.
- The diff is limited to one insertion and one deletion in the `NuGet/login` `user` input; all OIDC permissions, action pinning, login output handling, and NuGet push behavior remain unchanged.