### PR TITLE
Enforce Snackbar usage only in packaged Windows apps

### DIFF
--- a/samples/CommunityToolkit.Maui.Sample/CommunityToolkit.Maui.Sample.csproj
+++ b/samples/CommunityToolkit.Maui.Sample/CommunityToolkit.Maui.Sample.csproj
@@ -59,7 +59,7 @@
     <!-- Custom Fonts -->
     <MauiFont Include="Resources\Fonts\*" />
 
-    <PackageReference Include="Microsoft.Maui.Controls" Version="*" />
+    <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiPackageVersion)" />
     <PackageReference Include="CommunityToolkit.Maui.Markup" Version="7.0.1" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />

--- a/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
@@ -177,9 +177,7 @@ public partial class Snackbar : ISnackbar
 #if WINDOWS
 	static bool IsPackagedApp()
 	{
-		var packageType = Type.GetType("Windows.ApplicationModel.Package, Windows, ContentType=WindowsRuntime");
-		var currentProperty = packageType?.GetProperty("Current", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
-		return currentProperty?.GetValue(null) is not null;
+		return global::Windows.ApplicationModel.Package.Current is not null;
 	}
 #endif
 

--- a/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
@@ -177,15 +177,9 @@ public partial class Snackbar : ISnackbar
 #if WINDOWS
 	static bool IsPackagedApp()
 	{
-		try
-		{
-			_ = global::Windows.ApplicationModel.Package.Current;
-			return true;
-		}
-		catch
-		{
-			return false;
-		}
+		var packageType = Type.GetType("Windows.ApplicationModel.Package, Windows, ContentType=WindowsRuntime");
+		var currentProperty = packageType?.GetProperty("Current", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+		return currentProperty?.GetValue(null) is not null;
 	}
 #endif
 

--- a/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
@@ -179,9 +179,8 @@ public partial class Snackbar : ISnackbar
 	{
 		try
 		{
-			var packageType = Type.GetType("Windows.ApplicationModel.Package, Windows, ContentType=WindowsRuntime");
-			var currentProperty = packageType?.GetProperty("Current", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
-			return currentProperty?.GetValue(null) is not null;
+			_ = global::Windows.ApplicationModel.Package.Current;
+			return true;
 		}
 		catch
 		{

--- a/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.Maui.Core;
+using CommunityToolkit.Maui.Extensions;
 
 namespace CommunityToolkit.Maui.Alerts;
 
@@ -34,14 +35,13 @@ public partial class Snackbar : ISnackbar
 
 	bool isDisposed;
 	WeakReference<IView>? weakView;
-
 	/// <summary>
 	/// Initializes a new instance of <see cref="Snackbar"/>
 	/// </summary>
 	public Snackbar()
 	{
 #if WINDOWS
-		if (!IsPackagedApp())
+		if (!AppPackageExtensions.IsPackagedApp)
 		{
 			throw new InvalidOperationException($"{nameof(Snackbar)} is not supported on unpackaged Windows apps. {nameof(Snackbar)} requires the app to be packaged (MSIX) because it uses the Windows App SDK AppNotificationManager API. See https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar for more information.")
 			{
@@ -173,19 +173,6 @@ public partial class Snackbar : ISnackbar
 
 	internal static TimeSpan GetDefaultTimeSpan() => TimeSpan.FromSeconds(3);
 
-#if WINDOWS
-	static bool IsPackagedApp()
-	{
-		try
-		{
-			return global::Windows.ApplicationModel.Package.Current is not null;
-		}
-		catch
-		{
-			return false;
-		}
-	}
-#endif
 
 	void OnShown()
 	{

--- a/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
@@ -41,17 +41,16 @@ public partial class Snackbar : ISnackbar
 	public Snackbar()
 	{
 #if WINDOWS
-		if (!Options.ShouldEnableSnackbarOnWindows)
+		if (!IsPackagedApp())
 		{
-			throw new InvalidOperationException($"Additional setup is required in the Package.appxmanifest file to enable {nameof(Snackbar)} on Windows. Additonally, `{nameof(AppBuilderExtensions.UseMauiCommunityToolkit)}(options => options.{nameof(Options.SetShouldEnableSnackbarOnWindows)}({bool.TrueString.ToLower()});` must be called to enable Snackbar on Windows. See the Platform Specific Initialization section of the {nameof(Snackbar)} documentaion for more information: https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar")
+			throw new InvalidOperationException($"{nameof(Snackbar)} is not supported on unpackaged Windows apps. {nameof(Snackbar)} requires the app to be packaged (MSIX) because it uses the Windows App SDK AppNotificationManager API. See https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar for more information.")
 			{
 				HelpLink = "https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar"
 			};
 		}
-
-		if (!IsPackagedApp())
+		if (!Options.ShouldEnableSnackbarOnWindows)
 		{
-			throw new InvalidOperationException($"{nameof(Snackbar)} is not supported on unpackaged Windows apps. {nameof(Snackbar)} requires the app to be packaged (MSIX) because it uses the Windows App SDK AppNotificationManager API. See https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar for more information.")
+			throw new InvalidOperationException($"Additional setup is required in the Package.appxmanifest file to enable {nameof(Snackbar)} on Windows. Additonally, `{nameof(AppBuilderExtensions.UseMauiCommunityToolkit)}(options => options.{nameof(Options.SetShouldEnableSnackbarOnWindows)}({bool.TrueString.ToLower()});` must be called to enable Snackbar on Windows. See the Platform Specific Initialization section of the {nameof(Snackbar)} documentaion for more information: https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar")
 			{
 				HelpLink = "https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar"
 			};

--- a/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
@@ -48,6 +48,14 @@ public partial class Snackbar : ISnackbar
 				HelpLink = "https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar"
 			};
 		}
+
+		if (!IsPackagedApp())
+		{
+			throw new InvalidOperationException($"{nameof(Snackbar)} is not supported on unpackaged Windows apps. {nameof(Snackbar)} requires the app to be packaged (MSIX) because it uses the Windows App SDK AppNotificationManager API. See https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar for more information.")
+			{
+				HelpLink = "https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar"
+			};
+		}
 #endif
 
 		Duration = GetDefaultTimeSpan();
@@ -165,6 +173,22 @@ public partial class Snackbar : ISnackbar
 	public virtual Task Dismiss(CancellationToken token = default) => DismissPlatform(token);
 
 	internal static TimeSpan GetDefaultTimeSpan() => TimeSpan.FromSeconds(3);
+
+#if WINDOWS
+	static bool IsPackagedApp()
+	{
+		try
+		{
+			var packageType = Type.GetType("Windows.ApplicationModel.Package, Windows, ContentType=WindowsRuntime");
+			var currentProperty = packageType?.GetProperty("Current", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+			return currentProperty?.GetValue(null) is not null;
+		}
+		catch
+		{
+			return false;
+		}
+	}
+#endif
 
 	void OnShown()
 	{

--- a/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
+++ b/src/CommunityToolkit.Maui/Alerts/Snackbar/Snackbar.shared.cs
@@ -177,7 +177,14 @@ public partial class Snackbar : ISnackbar
 #if WINDOWS
 	static bool IsPackagedApp()
 	{
-		return global::Windows.ApplicationModel.Package.Current is not null;
+		try
+		{
+			return global::Windows.ApplicationModel.Package.Current is not null;
+		}
+		catch
+		{
+			return false;
+		}
 	}
 #endif
 

--- a/src/CommunityToolkit.Maui/Extensions/AppPackageExtensions.windows.cs
+++ b/src/CommunityToolkit.Maui/Extensions/AppPackageExtensions.windows.cs
@@ -1,0 +1,43 @@
+using Windows.ApplicationModel;
+
+namespace CommunityToolkit.Maui.Extensions;
+
+// Since MediaElement can't access .NET MAUI internals we have to copy this code here
+// https://github.com/dotnet/maui/blob/main/src/Essentials/src/AppInfo/AppInfo.uwp.cs
+static class AppPackageExtensions
+{
+	static readonly Lazy<bool> isPackagedAppHolder = new(() =>
+	{
+		try
+		{
+			if (Package.Current is not null)
+			{
+				return true;
+			}
+		}
+		catch
+		{
+			// no-op
+		}
+
+		return false;
+	});
+
+	static readonly Lazy<string> fullAppPackageFilePathHolder = new(() =>
+	{
+		return IsPackagedApp
+			? Package.Current.InstalledLocation.Path
+			: AppContext.BaseDirectory;
+	});
+
+	/// <summary>
+	/// Gets if this app is a packaged app.
+	/// </summary>
+	public static bool IsPackagedApp => isPackagedAppHolder.Value;
+
+
+	/// <summary>
+	/// Gets full application path.
+	/// </summary>
+	public static string FullAppPackageFilePath => fullAppPackageFilePathHolder.Value;
+}

--- a/src/CommunityToolkit.Maui/Options.shared.cs
+++ b/src/CommunityToolkit.Maui/Options.shared.cs
@@ -122,9 +122,8 @@ public class Options : Core.Options
 			{
 				try
 				{
-					var packageType = Type.GetType("Windows.ApplicationModel.Package, Windows, ContentType=WindowsRuntime");
-					var currentProperty = packageType?.GetProperty("Current", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
-					return currentProperty?.GetValue(null) is not null;
+					_ = global::Windows.ApplicationModel.Package.Current;
+					return true;
 				}
 				catch
 				{

--- a/src/CommunityToolkit.Maui/Options.shared.cs
+++ b/src/CommunityToolkit.Maui/Options.shared.cs
@@ -120,9 +120,7 @@ public class Options : Core.Options
 
 			static bool IsPackagedApp()
 			{
-				var packageType = Type.GetType("Windows.ApplicationModel.Package, Windows, ContentType=WindowsRuntime");
-				var currentProperty = packageType?.GetProperty("Current", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
-				return currentProperty?.GetValue(null) is not null;
+				return global::Windows.ApplicationModel.Package.Current is not null;
 			}
 		}
 #endif

--- a/src/CommunityToolkit.Maui/Options.shared.cs
+++ b/src/CommunityToolkit.Maui/Options.shared.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Maui.Converters;
 using CommunityToolkit.Maui.Extensions;
 using CommunityToolkit.Maui.Views;
 #if WINDOWS
+using System.Diagnostics;
 using Microsoft.Maui.LifecycleEvents;
 #endif
 
@@ -86,8 +87,15 @@ public class Options : Core.Options
 
 						else if (Application.Current.Windows.Count is 1)
 						{
-							Microsoft.Windows.AppNotifications.AppNotificationManager.Default.NotificationInvoked += OnSnackbarNotificationInvoked;
-							Microsoft.Windows.AppNotifications.AppNotificationManager.Default.Register();
+							if (IsPackagedApp())
+							{
+								Microsoft.Windows.AppNotifications.AppNotificationManager.Default.NotificationInvoked += OnSnackbarNotificationInvoked;
+								Microsoft.Windows.AppNotifications.AppNotificationManager.Default.Register();
+							}
+							else
+							{
+								Trace.WriteLine($"{nameof(Alerts.Snackbar)} is not supported on unpackaged Windows apps. {nameof(Alerts.Snackbar)} requires the app to be packaged (MSIX). See https://learn.microsoft.com/dotnet/communitytoolkit/maui/alerts/snackbar for more information.");
+							}
 						}
 					})
 					.OnClosed((_, _) =>
@@ -96,7 +104,7 @@ public class Options : Core.Options
 						{
 							throw new InvalidOperationException($"{nameof(Application)}.{nameof(Application.Current)} cannot be null when Windows are closed");
 						}
-						else if (Application.Current.Windows.Count is 0)
+						else if (Application.Current.Windows.Count is 0 && IsPackagedApp())
 						{
 							Microsoft.Windows.AppNotifications.AppNotificationManager.Default.NotificationInvoked -= OnSnackbarNotificationInvoked;
 							Microsoft.Windows.AppNotifications.AppNotificationManager.Default.Unregister();
@@ -108,6 +116,20 @@ public class Options : Core.Options
 														Microsoft.Windows.AppNotifications.AppNotificationActivatedEventArgs args)
 			{
 				Alerts.Snackbar.HandleSnackbarAction(args);
+			}
+
+			static bool IsPackagedApp()
+			{
+				try
+				{
+					var packageType = Type.GetType("Windows.ApplicationModel.Package, Windows, ContentType=WindowsRuntime");
+					var currentProperty = packageType?.GetProperty("Current", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+					return currentProperty?.GetValue(null) is not null;
+				}
+				catch
+				{
+					return false;
+				}
 			}
 		}
 #endif

--- a/src/CommunityToolkit.Maui/Options.shared.cs
+++ b/src/CommunityToolkit.Maui/Options.shared.cs
@@ -87,7 +87,7 @@ public class Options : Core.Options
 
 						else if (Application.Current.Windows.Count is 1)
 						{
-							if (IsPackagedApp())
+							if (AppPackageExtensions.IsPackagedApp)
 							{
 								Microsoft.Windows.AppNotifications.AppNotificationManager.Default.NotificationInvoked += OnSnackbarNotificationInvoked;
 								Microsoft.Windows.AppNotifications.AppNotificationManager.Default.Register();
@@ -104,7 +104,7 @@ public class Options : Core.Options
 						{
 							throw new InvalidOperationException($"{nameof(Application)}.{nameof(Application.Current)} cannot be null when Windows are closed");
 						}
-						else if (Application.Current.Windows.Count is 0 && IsPackagedApp())
+						else if (Application.Current.Windows.Count is 0 && AppPackageExtensions.IsPackagedApp)
 						{
 							Microsoft.Windows.AppNotifications.AppNotificationManager.Default.NotificationInvoked -= OnSnackbarNotificationInvoked;
 							Microsoft.Windows.AppNotifications.AppNotificationManager.Default.Unregister();
@@ -116,18 +116,6 @@ public class Options : Core.Options
 														Microsoft.Windows.AppNotifications.AppNotificationActivatedEventArgs args)
 			{
 				Alerts.Snackbar.HandleSnackbarAction(args);
-			}
-
-			static bool IsPackagedApp()
-			{
-				try
-				{
-					return global::Windows.ApplicationModel.Package.Current is not null;
-				}
-				catch
-				{
-					return false;
-				}
 			}
 		}
 #endif

--- a/src/CommunityToolkit.Maui/Options.shared.cs
+++ b/src/CommunityToolkit.Maui/Options.shared.cs
@@ -120,15 +120,9 @@ public class Options : Core.Options
 
 			static bool IsPackagedApp()
 			{
-				try
-				{
-					_ = global::Windows.ApplicationModel.Package.Current;
-					return true;
-				}
-				catch
-				{
-					return false;
-				}
+				var packageType = Type.GetType("Windows.ApplicationModel.Package, Windows, ContentType=WindowsRuntime");
+				var currentProperty = packageType?.GetProperty("Current", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+				return currentProperty?.GetValue(null) is not null;
 			}
 		}
 #endif

--- a/src/CommunityToolkit.Maui/Options.shared.cs
+++ b/src/CommunityToolkit.Maui/Options.shared.cs
@@ -120,7 +120,14 @@ public class Options : Core.Options
 
 			static bool IsPackagedApp()
 			{
-				return global::Windows.ApplicationModel.Package.Current is not null;
+				try
+				{
+					return global::Windows.ApplicationModel.Package.Current is not null;
+				}
+				catch
+				{
+					return false;
+				}
 			}
 		}
 #endif


### PR DESCRIPTION
## Description of Change

Fixes a regression introduced in `CommunityToolkit.Maui` v15.0.0 where calling `SetShouldEnableSnackbarOnWindows(true)` (or otherwise initializing the toolkit's Windows `Snackbar`/`Toast` support) in an **unpackaged** Windows app throws a `System.Runtime.InteropServices.COMException (0x80670016)`:

```
Package dependency criteria could not be resolved.
```

or

```
Unable to load resource dll. Microsoft.WindowsAppRuntime.Insights.Resource.dll
```

### Root Cause

`Options.SetShouldEnableSnackbarOnWindows(true)` unconditionally registered the app with the Windows App SDK's `Microsoft.Windows.AppNotifications.AppNotificationManager`, which internally resolves a Windows App Runtime package dependency via the dynamic dependency (Bootstrap) APIs. This registration/resolution only succeeds for **packaged (MSIX)** applications. When called from an **unpackaged** app, the underlying WinRT call (`IAppNotificationManagerMethods.Register`) fails with a `COMException`, since the required package dependency and its resource DLL (`Microsoft.WindowsAppRuntime.Insights.Resource.dll`) cannot be resolved outside of a packaged identity context.

Previously (v14.0.1) this registration path was not exercised for unpackaged apps, so the issue was not present until v15.0.0.

### Fix

- `Options.SetShouldEnableSnackbarOnWindows` now detects whether the app is running as a **packaged** app (`IsPackagedApp()`, via reflection over `Windows.ApplicationModel.Package.Current`) before calling `AppNotificationManager.Default.Register()`/`Unregister()`. For unpackaged apps, registration is skipped entirely and a `Trace.WriteLine` diagnostic message is emitted instead of allowing the unmanaged `COMException` to propagate.
- `Snackbar`'s constructor now throws a clear, actionable `InvalidOperationException` (instead of letting the unmanaged/WinRT `COMException` surface) when:
  - `SetShouldEnableSnackbarOnWindows(true)` was not called, or
  - the app is not packaged (MSIX) — since `Snackbar` on Windows depends on the Windows App SDK `AppNotificationManager` API, which requires a packaged app identity.
- Both exceptions include a `HelpLink` pointing to the `Snackbar` documentation describing platform-specific initialization requirements.

### Impact

- Unpackaged Windows MAUI apps no longer crash with an opaque `COMException`/missing resource DLL error during startup or when calling `SetShouldEnableSnackbarOnWindows(true)`.
- Developers now get a clear, descriptive `InvalidOperationException` explaining that `Snackbar` requires a packaged (MSIX) Windows app, with a link to documentation.
- Packaged Windows apps are unaffected; `AppNotificationManager` registration continues to work as before.

## Additional Fix: Windows PRI Build Error (`PRI175`/`PRI277`)

While validating the above change, the Windows build of `CommunityToolkit.Maui.Sample` failed with:

```
WINAPPSDKGENERATEPROJECTPRIFILE : error PRI175: 0x80073b0f - Processing Resources failed with error: Duplicate Entry.
WINAPPSDKGENERATEPROJECTPRIFILE : error PRI277: 0x80073b0f - Conflicting values for resource 'Files/Microsoft.Maui/Platform/Windows/Styles/Resources.xbf'
```

### Root Cause

`CommunityToolkit.Maui.Sample.csproj` referenced `Microsoft.Maui.Controls` with a wildcard version:

```xml
<PackageReference Include="Microsoft.Maui.Controls" Version="*" />
```

The wildcard resolved to **10.0.90**, while every other MAUI package in the repo is pinned to **10.0.60** via `$(MauiPackageVersion)` in `Directory.Build.props` (including `Microsoft.Maui.Controls.Maps` and the MAUI assemblies pulled in transitively by the `CommunityToolkit.Maui.*` project references). The build output confirmed the conflict:

```
microsoft.maui.controls.core\10.0.90\...\Microsoft.Maui.Controls.dll
microsoft.maui.controls.maps\10.0.60\...\Microsoft.Maui.Controls.Maps.dll
```

Two different MAUI versions each ship the framework resource `Files/Microsoft.Maui/Platform/Windows/Styles/Resources.xbf` with different content. When the Windows App SDK PRI generator merges them, it finds the same resource path with conflicting values, producing `PRI175`/`PRI277`.

### Fix

Pinned `Microsoft.Maui.Controls` to the repo-wide version so all MAUI packages align on 10.0.60:

```xml
<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiPackageVersion)" />
```

> Note: The `<WindowsSdkPackageVersion>10.0.19041.56</WindowsSdkPackageVersion>` override in the sample project was initially suspected, but removing it surfaced a different error (`MVVMTKCFG0003`) — CommunityToolkit.Mvvm 8.4.2 requires that SDK version. That line is correct and was left in place; the actual culprit was the wildcard MAUI version.

 ### Linked Issues ###

Fixes:
-  [dotnet/maui#36983](https://github.com/dotnet/maui/issues/36983)
- [CommunityToolkit#3271](https://github.com/CommunityToolkit/Maui/issues/3271)
 ### PR Checklist ###
 <!--
 Please check all the things you did here and double-check that you got it all, or state why you didn't do something.

 If anything is unclear please do ask :)
 -->
 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [ ] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [x] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pull/655


 ### Additional information ###

Unpackaged Sample app in Windows now builds and runs in Release mode. 
 
