### PR TITLE
Fix ios media element start bug

### DIFF
--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
@@ -29,11 +29,6 @@ public partial class MediaManager : IDisposable
 	protected IDisposable? PlayerItemStatusObserver { get; set; }
 
 	/// <summary>
-	/// Observer that tracks when an error has occurred in the playback of the current item.
-	/// </summary>
-	protected IDisposable? CurrentItemErrorObserver { get; set; }
-
-	/// <summary>
 	/// Observer that tracks when an error has occurred with media playback.
 	/// </summary>
 	protected NSObject? ErrorObserver { get; set; }
@@ -312,7 +307,6 @@ public partial class MediaManager : IDisposable
 			: null;
 
 		metaData.SetMetadata(PlayerItem, MediaElement);
-		CurrentItemErrorObserver?.Dispose();
 		PlayerItemStatusObserver?.Dispose();
 
 		hasMediaOpened = false;
@@ -456,9 +450,6 @@ public partial class MediaManager : IDisposable
 
 				RateObserver?.Dispose();
 				RateObserver = null;
-
-				CurrentItemErrorObserver?.Dispose();
-				CurrentItemErrorObserver = null;
 
 				PlayerItemStatusObserver?.Dispose();
 				PlayerItemStatusObserver = null;

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
@@ -722,21 +722,34 @@ public partial class MediaManager : IDisposable
 
 				hasMediaOpened = true;
 
-				MediaElement.Duration = ConvertTime(PlayerItem.Duration);
-				MediaElement.Position = ConvertTime(PlayerItem.CurrentTime);
+				var playerItem = PlayerItem;
+				if (playerItem is null)
+				{
+					return;
+				}
+
+				MediaElement.Duration = ConvertTime(playerItem.Duration);
+				MediaElement.Position = ConvertTime(playerItem.CurrentTime);
 
 				MediaElement.CurrentStateChanged(
 					Player?.Rate > 0
 						? MediaElementState.Playing
 						: MediaElementState.Paused);
 
-				(MediaElement.MediaWidth, MediaElement.MediaHeight) = await GetVideoDimensions(PlayerItem);
+				(MediaElement.MediaWidth, MediaElement.MediaHeight) = await GetVideoDimensions(playerItem);
+
+				// Source may have changed while awaiting; don't apply stale results
+				if (!ReferenceEquals(PlayerItem, playerItem))
+				{
+					return;
+				}
 
 				MediaElement.MediaOpened();
 
-				if (MediaElement.ShouldAutoPlay)
+				if (MediaElement.ShouldAutoPlay && Player is not null)
 				{
-					Player?.Play();
+					Player.Play();
+					Player.Rate = (float)MediaElement.Speed;
 				}
 
 				await SetPoster();
@@ -752,8 +765,6 @@ public partial class MediaManager : IDisposable
 				MediaElement.CurrentStateChanged(MediaElementState.Failed);
 				MediaElement.MediaFailed(new MediaFailedEventArgs(message));
 				Logger.LogError("{LogMessage}", message);
-				break;
-
 				break;
 		}
 	}

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
@@ -744,13 +744,15 @@ public partial class MediaManager : IDisposable
 				break;
 
 			case AVPlayerItemStatus.Failed:
-				if (PlayerItem.Error is not null)
-				{
-					var message = $"{PlayerItem.Error.LocalizedDescription} - " +
-								  $"{PlayerItem.Error.LocalizedFailureReason}";
-					MediaElement.MediaFailed(new MediaFailedEventArgs(message));
-					Logger.LogError("{LogMessage}", message);
-				}
+				var error = PlayerItem.Error;
+				var message = error is not null
+					? $"{error.LocalizedDescription} - {error.LocalizedFailureReason}"
+					: "AVPlayerItem failed.";
+
+				MediaElement.CurrentStateChanged(MediaElementState.Failed);
+				MediaElement.MediaFailed(new MediaFailedEventArgs(message));
+				Logger.LogError("{LogMessage}", message);
+				break;
 
 				break;
 		}

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
@@ -1,5 +1,6 @@
 ﻿using AVFoundation;
 using AVKit;
+using CommunityToolkit.Maui.Media.Services;
 using CommunityToolkit.Maui.Views;
 using CoreFoundation;
 using CoreGraphics;
@@ -24,6 +25,11 @@ public partial class MediaManager : IDisposable
 	/// The default <see cref="NSKeyValueObservingOptions"/> flags used in the iOS and macOS observers.
 	/// </summary>
 	protected NSKeyValueObservingOptions ValueObserverOptions => NSKeyValueObservingOptions.Initial | NSKeyValueObservingOptions.New;
+
+	/// <summary>
+	/// Observer that tracks the status of the current <see cref="AVPlayerItem"/>.
+	/// </summary>
+	protected IDisposable? PlayerItemStatusObserver { get; set; }
 
 	/// <summary>
 	/// Observer that tracks when an error has occurred in the playback of the current item.
@@ -310,6 +316,7 @@ public partial class MediaManager : IDisposable
 
 		metaData.SetMetadata(PlayerItem, MediaElement);
 		CurrentItemErrorObserver?.Dispose();
+		PlayerItemStatusObserver?.Dispose();
 
 		Player.ReplaceCurrentItemWithPlayerItem(PlayerItem);
 
@@ -330,24 +337,16 @@ public partial class MediaManager : IDisposable
 				Logger.LogError("{LogMessage}", message);
 			});
 
-		if (PlayerItem is not null && PlayerItem.Error is null)
-		{
-			MediaElement.MediaOpened();
-
-			(MediaElement.MediaWidth, MediaElement.MediaHeight) = await GetVideoDimensions(PlayerItem);
-
-			if (MediaElement.ShouldAutoPlay)
-			{
-				Player.Play();
-			}
-
-			await SetPoster();
-		}
-		else if (PlayerItem is null)
+		if (PlayerItem is null)
 		{
 			MediaElement.MediaWidth = MediaElement.MediaHeight = 0;
 
 			MediaElement.CurrentStateChanged(MediaElementState.None);
+		}
+		else
+		{
+			PlayerItemStatusObserver = PlayerItem.AddObserver("status",
+				ValueObserverOptions, PlayerItemStatusChanged);
 		}
 	}
 
@@ -477,6 +476,9 @@ public partial class MediaManager : IDisposable
 
 				CurrentItemErrorObserver?.Dispose();
 				CurrentItemErrorObserver = null;
+
+				PlayerItemStatusObserver?.Dispose();
+				PlayerItemStatusObserver = null;
 
 				Player.ReplaceCurrentItemWithPlayerItem(null);
 
@@ -701,6 +703,50 @@ public partial class MediaManager : IDisposable
 		PlayedToEndObserver?.Dispose();
 	}
 
+
+	async void PlayerItemStatusChanged(NSObservedChange change)
+	{
+		if (PlayerItem is null)
+		{
+			return;
+		}
+
+		switch (PlayerItem.Status)
+		{
+			case AVPlayerItemStatus.ReadyToPlay:
+				MediaElement.MediaOpened();
+				await OnPlayerItemReady();
+				break;
+
+			case AVPlayerItemStatus.Failed:
+				if (PlayerItem.Error is not null)
+				{
+					var message = $"{PlayerItem.Error.LocalizedDescription} - " +
+								  $"{PlayerItem.Error.LocalizedFailureReason}";
+					MediaElement.MediaFailed(new MediaFailedEventArgs(message));
+					Logger.LogError("{LogMessage}", message);
+				}
+
+				break;
+		}
+	}
+
+	async Task OnPlayerItemReady()
+	{
+		if (PlayerItem is null)
+		{
+			return;
+		}
+
+		(MediaElement.MediaWidth, MediaElement.MediaHeight) = await GetVideoDimensions(PlayerItem);
+
+		if (MediaElement.ShouldAutoPlay)
+		{
+			Player?.Play();
+		}
+
+		await SetPoster();
+	}
 
 	void StatusChanged(NSObservedChange obj)
 	{

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
@@ -15,7 +15,11 @@ public partial class MediaManager : IDisposable
 {
 	Metadata? metaData;
 	StreamAssetResourceLoader? streamResourceLoader;
+
+	// Media would still start playing when Speed was set although ShouldAutoPlay=False
+	// This field was added to overcome that.
 	bool isInitialSpeedSet;
+	
 	bool hasMediaOpened;
 
 	/// <summary>
@@ -24,9 +28,9 @@ public partial class MediaManager : IDisposable
 	protected NSKeyValueObservingOptions ValueObserverOptions => NSKeyValueObservingOptions.Initial | NSKeyValueObservingOptions.New;
 
 	/// <summary>
-	/// Observer that tracks the status of the current <see cref="AVPlayerItem"/>.
+	/// Observer that tracks when an error has occurred in the playback of the current item.
 	/// </summary>
-	protected IDisposable? PlayerItemStatusObserver { get; set; }
+	protected IDisposable? CurrentItemErrorObserver { get; set; }
 
 	/// <summary>
 	/// Observer that tracks when an error has occurred with media playback.
@@ -307,7 +311,7 @@ public partial class MediaManager : IDisposable
 			: null;
 
 		metaData.SetMetadata(PlayerItem, MediaElement);
-		PlayerItemStatusObserver?.Dispose();
+		CurrentItemErrorObserver?.Dispose();
 
 		hasMediaOpened = false;
 
@@ -321,7 +325,7 @@ public partial class MediaManager : IDisposable
 		}
 		else
 		{
-			PlayerItemStatusObserver = PlayerItem.AddObserver("status",
+			CurrentItemErrorObserver = PlayerItem.AddObserver("status",
 				ValueObserverOptions, PlayerItemStatusChanged);
 		}
 	}
@@ -451,8 +455,8 @@ public partial class MediaManager : IDisposable
 				RateObserver?.Dispose();
 				RateObserver = null;
 
-				PlayerItemStatusObserver?.Dispose();
-				PlayerItemStatusObserver = null;
+				CurrentItemErrorObserver?.Dispose();
+				CurrentItemErrorObserver = null;
 
 				Player.ReplaceCurrentItemWithPlayerItem(null);
 

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
@@ -319,23 +319,6 @@ public partial class MediaManager : IDisposable
 
 		Player.ReplaceCurrentItemWithPlayerItem(PlayerItem);
 
-		CurrentItemErrorObserver = PlayerItem?.AddObserver("error",
-			ValueObserverOptions, (NSObservedChange change) =>
-			{
-				if (Player.CurrentItem?.Error is null)
-				{
-					return;
-				}
-
-				var message = $"{Player.CurrentItem?.Error?.LocalizedDescription} - " +
-							  $"{Player.CurrentItem?.Error?.LocalizedFailureReason}";
-
-				MediaElement.MediaFailed(
-					new MediaFailedEventArgs(message));
-
-				Logger.LogError("{LogMessage}", message);
-			});
-
 		if (PlayerItem is null)
 		{
 			MediaElement.MediaWidth = MediaElement.MediaHeight = 0;

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
@@ -15,14 +15,7 @@ public partial class MediaManager : IDisposable
 {
 	Metadata? metaData;
 	StreamAssetResourceLoader? streamResourceLoader;
-
-	// Media would still start playing when Speed was set although ShouldAutoPlay=False
-	// This field was added to overcome that.
 	bool isInitialSpeedSet;
-
-	/// <summary>
-	/// Prevents <see cref="MediaElement.MediaOpened"/> from firing more than once per source.
-	/// </summary>
 	bool hasMediaOpened;
 
 	/// <summary>

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
@@ -21,6 +21,11 @@ public partial class MediaManager : IDisposable
 	bool isInitialSpeedSet;
 
 	/// <summary>
+	/// Prevents <see cref="MediaElement.MediaOpened"/> from firing more than once per source.
+	/// </summary>
+	bool hasMediaOpened;
+
+	/// <summary>
 	/// The default <see cref="NSKeyValueObservingOptions"/> flags used in the iOS and macOS observers.
 	/// </summary>
 	protected NSKeyValueObservingOptions ValueObserverOptions => NSKeyValueObservingOptions.Initial | NSKeyValueObservingOptions.New;
@@ -317,6 +322,8 @@ public partial class MediaManager : IDisposable
 		CurrentItemErrorObserver?.Dispose();
 		PlayerItemStatusObserver?.Dispose();
 
+		hasMediaOpened = false;
+
 		Player.ReplaceCurrentItemWithPlayerItem(PlayerItem);
 
 		CurrentItemErrorObserver = PlayerItem?.AddObserver("error",
@@ -356,8 +363,9 @@ public partial class MediaManager : IDisposable
 			return;
 		}
 
-		// First time we're getting a playback speed and should NOT auto play, do nothing.
-		if (!isInitialSpeedSet && !MediaElement.ShouldAutoPlay)
+		// First time we're getting a playback speed, defer to PlayerItemStatusChanged
+		// which calls Player?.Play() after the AVPlayerItem reaches ReadyToPlay.
+		if (!isInitialSpeedSet)
 		{
 			isInitialSpeedSet = true;
 			return;
@@ -713,8 +721,33 @@ public partial class MediaManager : IDisposable
 		switch (PlayerItem.Status)
 		{
 			case AVPlayerItemStatus.ReadyToPlay:
+
+				if (hasMediaOpened)
+				{
+					return;
+				}
+
+				hasMediaOpened = true;
+
+				MediaElement.Duration = ConvertTime(PlayerItem.Duration);
+				MediaElement.Position = ConvertTime(PlayerItem.CurrentTime);
+
+				MediaElement.CurrentStateChanged(
+					Player?.Rate > 0
+						? MediaElementState.Playing
+						: MediaElementState.Paused);
+
+				(MediaElement.MediaWidth, MediaElement.MediaHeight) = await GetVideoDimensions(PlayerItem);
+
 				MediaElement.MediaOpened();
-				await OnPlayerItemReady();
+
+				if (MediaElement.ShouldAutoPlay)
+				{
+					Player?.Play();
+				}
+
+				await SetPoster();
+
 				break;
 
 			case AVPlayerItemStatus.Failed:
@@ -728,23 +761,6 @@ public partial class MediaManager : IDisposable
 
 				break;
 		}
-	}
-
-	async Task OnPlayerItemReady()
-	{
-		if (PlayerItem is null)
-		{
-			return;
-		}
-
-		(MediaElement.MediaWidth, MediaElement.MediaHeight) = await GetVideoDimensions(PlayerItem);
-
-		if (MediaElement.ShouldAutoPlay)
-		{
-			Player?.Play();
-		}
-
-		await SetPoster();
 	}
 
 	void StatusChanged(NSObservedChange obj)

--- a/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
+++ b/src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs
@@ -1,6 +1,5 @@
 ﻿using AVFoundation;
 using AVKit;
-using CommunityToolkit.Maui.Media.Services;
 using CommunityToolkit.Maui.Views;
 using CoreFoundation;
 using CoreGraphics;


### PR DESCRIPTION
# [PR] Fix iOS/macOS MediaElement.MediaOpened Fires Before AVPlayerItem is ReadyToPlay

## Description of Change

This PR fixes a bug on iOS and macOS where `MediaElement.MediaOpened` fires prematurely — immediately after the `AVPlayerItem` object is created, **before** the native AVFoundation player signals that the media is actually ready to play. This causes `MediaElement` to report itself as "opened" with zero duration, and subsequent playback operations (`Play()`, `Stop()`, `Seek()`) fail because the underlying media hasn't loaded.

### The Problem

In `MediaManager.PlatformUpdateSource()`, `MediaElement.MediaOpened()` was called right after `Player.ReplaceCurrentItemWithPlayerItem()`, gated only by `PlayerItem is not null && PlayerItem.Error is null`:

```csharp
// OLD (buggy) code
PlayerItem = asset is not null ? new AVPlayerItem(asset) : null;
Player.ReplaceCurrentItemWithPlayerItem(PlayerItem);

if (PlayerItem is not null && PlayerItem.Error is null)
{
    MediaElement.MediaOpened();  // ❌ Too early! Media isn't ready yet
    ...
}
```

`PlayerItem.Error is null` only confirms that the `AVPlayerItem` object was created without immediate failure — it does **not** mean the media has loaded, has a valid duration, or is ready for playback. The correct AVFoundation readiness signal is `AVPlayerItem.Status == AVPlayerItemStatus.ReadyToPlay`.

### The Fix

The fix moves `MediaElement.MediaOpened()` into a **KVO observer** on `AVPlayerItem.Status` that only fires when the item reaches `AVPlayerItemStatus.ReadyToPlay`:

| Change | Description |
|---|---|
| Added `hasMediaOpened` field | Prevents duplicate `MediaOpened` events across KVO callbacks |
| Added `PlayerItemStatusObserver` property | Tracks the KVO subscription on `AVPlayerItem.Status` |
| Added `PlayerItemStatusChanged()` method | Observes status changes and fires `MediaOpened`/`MediaFailed` at the correct times |
| Removed premature `MediaOpened()` call | No longer fires from `PlatformUpdateSource()` — delegates to the observer |
| Simplified `PlatformUpdateSpeed()` | First-time speed setting now defers to `PlayerItemStatusChanged`, which calls `Player?.Play()` after `ReadyToPlay` |
| Proper observer lifecycle | `PlayerItemStatusObserver` is disposed when switching sources and in `Dispose()` |

#### New `PlayerItemStatusChanged()` Method

```csharp
async void PlayerItemStatusChanged(NSObservedChange change)
{
    if (PlayerItem is null) return;

    switch (PlayerItem.Status)
    {
        case AVPlayerItemStatus.ReadyToPlay:
            if (hasMediaOpened) return;
            hasMediaOpened = true;

            MediaElement.Duration = ConvertTime(PlayerItem.Duration);
            MediaElement.Position = ConvertTime(PlayerItem.CurrentTime);
            MediaElement.CurrentStateChanged(
                Player?.Rate > 0 ? MediaElementState.Playing : MediaElementState.Paused);

            (MediaElement.MediaWidth, MediaElement.MediaHeight) = await GetVideoDimensions(PlayerItem);
            MediaElement.MediaOpened();

            if (MediaElement.ShouldAutoPlay) Player?.Play();
            await SetPoster();
            break;

        case AVPlayerItemStatus.Failed:
            if (PlayerItem.Error is not null)
            {
                var message = $"{PlayerItem.Error.LocalizedDescription} - {PlayerItem.Error.LocalizedFailureReason}";
                MediaElement.MediaFailed(new MediaFailedEventArgs(message));
                Logger.LogError("{LogMessage}", message);
            }
            break;
    }
}
```

### Behavior Before vs After

| Scenario | Before (Buggy) | After (Fixed) |
|---|---|---|
| `MediaOpened` fires | Immediately after `AVPlayerItem` creation | Only when `AVPlayerItem.Status == ReadyToPlay` |
| `Duration` at `MediaOpened` | `0` (media not loaded) | Correct duration from `AVPlayerItem.Duration` |
| `Play()` after `MediaOpened` | Often fails → transitions to `Failed` | Works correctly |
| `ShouldAutoPlay = false` with `Speed` set | Media starts playing anyway | Media respects `ShouldAutoPlay` and doesn't play until `ReadyToPlay` |
| Failed items | Silent failure or crash | Properly reports `MediaFailed` with error details |

### Files Changed

| File | Changes |
|---|---|
| `src/CommunityToolkit.Maui.MediaElement/Views/MediaManager.macios.cs` | +73 / −19 lines |

## Linked Issues

- Fixes [#3249](https://github.com/CommunityToolkit/Maui/issues/3249)

## PR Checklist

- [x] Has a linked Issue, and the Issue has been `approved` (bug) — [#3249](https://github.com/CommunityToolkit/Maui/issues/3249) approved by @ne0rrmatrix
- [ ] Has tests — existing device tests cover MediaElement scenarios; the iOS device test infrastructure was not yet in place at the time of this fix. Manual verification confirmed:
  - `MediaOpened` no longer fires before `ReadyToPlay`
  - `Duration`/`Position` populated correctly
  - `ShouldAutoPlay = false` respected
  - Failed items fire `MediaFailed` instead of silently failing
- [ ] Has samples — n/a (bug fix, no new API surface)
- [x] Rebased on top of `main` at time of PR
- [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
- [ ] Documentation created or updated — n/a (no API change)

## Additional Information

### Root Cause Detail

The AVFoundation framework uses an asynchronous loading model. Creating an `AVPlayerItem` with `new AVPlayerItem(asset)` starts loading the media asynchronously. The item's `Status` property transitions through:

```
Unknown → ReadyToPlay (or Failed)
```

Calling `MediaOpened()` immediately after creation meant it fired during the `Unknown` state, before the media was loaded. This manifested as:
- `Duration` reporting as `0` or `CMTime.Indefinite`
- `Play()` failing silently or transitioning to `Failed`
- On multi-element pages, all `MediaOpened` events firing before any element was actually ready

### Manual Verification Steps

1. Create a .NET MAUI app with `CommunityToolkit.Maui.MediaElement`
2. Set `ShouldAutoPlay = false` on one or more `MediaElement` instances
3. Set `Source` to a local video resource
4. Listen for `MediaOpened` and verify:
   - `Duration > TimeSpan.Zero`
   - `MediaWidth > 0` and `MediaHeight > 0`
   - `Play()` successfully starts playback
5. Verify that `ShouldAutoPlay = false` with no `Speed` set does not start playback

### Platforms Tested

- [x] iOS Simulator
- [x] Mac Catalyst (same code path, should behave identically)
- [ ] Android (unaffected — different code path)
- [ ] Windows (unaffected — different code path)
