### PR TITLE
Align Windows App SDK version with .NET MAUI

### DIFF
--- a/src/CommunityToolkit.Maui.Core/CommunityToolkit.Maui.Core.csproj
+++ b/src/CommunityToolkit.Maui.Core/CommunityToolkit.Maui.Core.csproj
@@ -65,7 +65,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetVersion)-windows10.0.19041.0'">
     <PackageReference Include="System.Speech" Version="10.0.1" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/CommunityToolkit.Maui.Core/Essentials/FileSaver/FileSaverImplementation.windows.cs
+++ b/src/CommunityToolkit.Maui.Core/Essentials/FileSaver/FileSaverImplementation.windows.cs
@@ -33,7 +33,15 @@ public sealed partial class FileSaverImplementation : IFileSaver
 			SuggestedStartLocation = PickerLocationId.DocumentsLibrary,
 			SuggestedFileName = Path.GetFileNameWithoutExtension(fileName)
 		};
-		WinRT.Interop.InitializeWithWindow.Initialize(savePicker, Process.GetCurrentProcess().MainWindowHandle);
+
+		var hwnd = Process.GetCurrentProcess().MainWindowHandle;
+		if (hwnd == IntPtr.Zero)
+		{
+			throw new FileSaveException(
+				"Cannot present file picker: No active window found. Ensure the app is active with a visible window.");
+		}
+
+		WinRT.Interop.InitializeWithWindow.Initialize(savePicker, hwnd);
 #endif
 
 		var extension = Path.GetExtension(fileName);

--- a/src/CommunityToolkit.Maui.Core/Essentials/FileSaver/FileSaverImplementation.windows.cs
+++ b/src/CommunityToolkit.Maui.Core/Essentials/FileSaver/FileSaverImplementation.windows.cs
@@ -1,4 +1,9 @@
+#if NET11_0_OR_GREATER
 using Microsoft.Windows.Storage.Pickers;
+#else
+using System.Diagnostics;
+using Windows.Storage.Pickers;
+#endif
 
 namespace CommunityToolkit.Maui.Storage;
 
@@ -9,6 +14,7 @@ public sealed partial class FileSaverImplementation : IFileSaver
 
 	async Task<string> InternalSaveAsync(string initialPath, string fileName, Stream stream, IProgress<double>? progress, CancellationToken cancellationToken)
 	{
+#if NET11_0_OR_GREATER
 		if (IPlatformApplication.Current?.Application.Windows[0].Handler?.PlatformView is not MauiWinUIWindow window)
 		{
 			throw new FileSaveException(
@@ -21,6 +27,14 @@ public sealed partial class FileSaverImplementation : IFileSaver
 			SuggestedFolder = initialPath,
 			SuggestedFileName = Path.GetFileNameWithoutExtension(fileName)
 		};
+#else
+		var savePicker = new FileSavePicker
+		{
+			SuggestedStartLocation = PickerLocationId.DocumentsLibrary,
+			SuggestedFileName = Path.GetFileNameWithoutExtension(fileName)
+		};
+		WinRT.Interop.InitializeWithWindow.Initialize(savePicker, Process.GetCurrentProcess().MainWindowHandle);
+#endif
 
 		var extension = Path.GetExtension(fileName);
 		if (!string.IsNullOrEmpty(extension))

--- a/src/CommunityToolkit.Maui.Core/Essentials/FolderPicker/FolderPickerImplementation.windows.cs
+++ b/src/CommunityToolkit.Maui.Core/Essentials/FolderPicker/FolderPickerImplementation.windows.cs
@@ -1,8 +1,14 @@
+#if NET11_0_OR_GREATER
 using CommunityToolkit.Maui.Core.Primitives;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.UI;
 using Microsoft.Windows.AppLifecycle;
 using Microsoft.Windows.Storage.Pickers;
+#else
+using System.Diagnostics;
+using CommunityToolkit.Maui.Core.Primitives;
+using Windows.Storage.Pickers;
+#endif
 
 namespace CommunityToolkit.Maui.Storage;
 
@@ -12,6 +18,7 @@ public sealed partial class FolderPickerImplementation : IFolderPicker
 	async Task<Folder> InternalPickAsync(string initialPath, CancellationToken cancellationToken)
 	{
 		cancellationToken.ThrowIfCancellationRequested();
+#if NET11_0_OR_GREATER
 		if (IPlatformApplication.Current?.Application.Windows[0].Handler?.PlatformView is not MauiWinUIWindow window)
 		{
 			throw new FolderPickerException(
@@ -23,6 +30,14 @@ public sealed partial class FolderPickerImplementation : IFolderPicker
 			SuggestedStartLocation = PickerLocationId.DocumentsLibrary,
 			SuggestedFolder = initialPath
 		};
+#else
+		var folderPicker = new Windows.Storage.Pickers.FolderPicker
+		{
+			SuggestedStartLocation = PickerLocationId.DocumentsLibrary
+		};
+		WinRT.Interop.InitializeWithWindow.Initialize(folderPicker, Process.GetCurrentProcess().MainWindowHandle);
+		folderPicker.FileTypeFilter.Add("*");
+#endif
 
 		var folderPickerOperation = folderPicker.PickSingleFolderAsync();
 

--- a/src/CommunityToolkit.Maui.Core/Essentials/FolderPicker/FolderPickerImplementation.windows.cs
+++ b/src/CommunityToolkit.Maui.Core/Essentials/FolderPicker/FolderPickerImplementation.windows.cs
@@ -35,7 +35,15 @@ public sealed partial class FolderPickerImplementation : IFolderPicker
 		{
 			SuggestedStartLocation = PickerLocationId.DocumentsLibrary
 		};
-		WinRT.Interop.InitializeWithWindow.Initialize(folderPicker, Process.GetCurrentProcess().MainWindowHandle);
+
+		var hwnd = Process.GetCurrentProcess().MainWindowHandle;
+		if (hwnd == IntPtr.Zero)
+		{
+			throw new FolderPickerException(
+				"Cannot present folder picker: No active window found. Ensure the app is active with a visible window.");
+		}
+
+		WinRT.Interop.InitializeWithWindow.Initialize(folderPicker, hwnd);
 		folderPicker.FileTypeFilter.Add("*");
 #endif
 


### PR DESCRIPTION
### Description of Change ###

Removes the Toolkit's hard-coded `Microsoft.WindowsAppSDK` 2.2.0 dependency so each target framework uses the version selected and supported by .NET MAUI.

Windows picker implementations are split by target framework:

- .NET 10 uses the legacy `Windows.Storage.Pickers` APIs compatible with MAUI's Windows App SDK 1.8.x dependency.
- .NET 11 and later use `Microsoft.Windows.Storage.Pickers`, retaining initial-folder support with MAUI's Windows App SDK 2.3.1 dependency.

This prevents `AppNotificationManager.Register()` from failing at startup on .NET 10 because of the mismatched Windows App SDK runtime.

No tests were added because the affected picker and notification registration behavior requires a running Windows application. No sample changes are required; the existing sample enables Windows snackbar registration and was used for validation.

### Linked Issues ###

- Fixes #3271

### PR Checklist ###

- [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
- [ ] Has tests (if omitted, state reason in description)
- [x] Has samples (if omitted, state reason in description)
- [x] Rebased on top of `main` at time of PR
- [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
- [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls

### Additional information ###

Validated on Windows ARM64:

- `CommunityToolkit.Maui.Core` builds for `net10.0-windows10.0.19041.0` without warnings or errors.
- The full sample builds against MAUI 10.0.90 and resolves `Microsoft.WindowsAppSDK` 1.8.260508005.
- The sample launches and remains responsive with `SetShouldEnableSnackbarOnWindows(true)` enabled.
- .NET 10 cannot honor the picker `initialPath` because `SuggestedFolder` is available only through the Windows App SDK 2.x picker APIs; .NET 11 retains that functionality.