### PR TITLE
CameraView: Fixed crash on Windows when app has no camera access anymore

### DIFF
--- a/src/CommunityToolkit.Maui.Camera/CameraManager.shared.cs
+++ b/src/CommunityToolkit.Maui.Camera/CameraManager.shared.cs
@@ -32,8 +32,16 @@ sealed partial class CameraManager(
 		{
 			await cameraProvider.RefreshAvailableCameras(token);
 		}
-		cameraView.SelectedCamera ??= cameraProvider.AvailableCameras?.FirstOrDefault() ?? throw new CameraException("No camera available on device");
-		await PlatformConnectCamera(token);
+		cameraView.SelectedCamera ??= cameraProvider.AvailableCameras?.FirstOrDefault();
+
+		try
+		{
+			await PlatformConnectCamera(token);
+		}
+		catch
+		{
+			// can't init camera
+		}
 	}
 
 	/// <summary>

--- a/src/CommunityToolkit.Maui.Camera/CameraManager.windows.cs
+++ b/src/CommunityToolkit.Maui.Camera/CameraManager.windows.cs
@@ -141,7 +141,11 @@ partial class CameraManager
 
 		mediaCapture = new MediaCapture();
 
-		await mediaCapture.InitializeCameraForCameraView(cameraView.SelectedCamera.DeviceId, token);
+		bool success = await mediaCapture.InitializeCameraForCameraView(cameraView.SelectedCamera.DeviceId, token);
+		if (!success)
+		{
+			return;
+		}
 
 		frameSource = mediaCapture.FrameSources.FirstOrDefault(source => source.Value.Info.MediaStreamType == MediaStreamType.VideoRecord && source.Value.Info.SourceKind == MediaFrameSourceKind.Color).Value;
 

--- a/src/CommunityToolkit.Maui.Camera/CameraManager.windows.cs
+++ b/src/CommunityToolkit.Maui.Camera/CameraManager.windows.cs
@@ -141,9 +141,13 @@ partial class CameraManager
 
 		mediaCapture = new MediaCapture();
 
-		bool success = await mediaCapture.InitializeCameraForCameraView(cameraView.SelectedCamera.DeviceId, token);
-		if (!success)
+		try
 		{
+			await mediaCapture.InitializeCameraForCameraView(cameraView.SelectedCamera.DeviceId, token);
+		}
+		catch (Exception)
+		{
+			// can't use that camera
 			return;
 		}
 

--- a/src/CommunityToolkit.Maui.Camera/Extensions/CameraViewExtensions.windows.cs
+++ b/src/CommunityToolkit.Maui.Camera/Extensions/CameraViewExtensions.windows.cs
@@ -48,7 +48,7 @@ static class CameraViewExtensions
 		catch (System.Runtime.InteropServices.COMException)
 		{
 			// Camera already initialized
-			return false;
+			return true;
 		}
 		catch (UnauthorizedAccessException)
 		{

--- a/src/CommunityToolkit.Maui.Camera/Extensions/CameraViewExtensions.windows.cs
+++ b/src/CommunityToolkit.Maui.Camera/Extensions/CameraViewExtensions.windows.cs
@@ -14,7 +14,7 @@ static class CameraViewExtensions
 		cameraView.IsAvailable = videoCaptureDevices.Count > 0;
 	}
 
-	public static async Task InitializeCameraForCameraView(this MediaCapture mediaCapture, string deviceId, CancellationToken token)
+	public static async Task<bool> InitializeCameraForCameraView(this MediaCapture mediaCapture, string deviceId, CancellationToken token)
 	{
 		try
 		{
@@ -48,6 +48,14 @@ static class CameraViewExtensions
 		catch (System.Runtime.InteropServices.COMException)
 		{
 			// Camera already initialized
+			return false;
 		}
+		catch (UnauthorizedAccessException)
+		{
+			// Can't access the camera
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/src/CommunityToolkit.Maui.Camera/Extensions/CameraViewExtensions.windows.cs
+++ b/src/CommunityToolkit.Maui.Camera/Extensions/CameraViewExtensions.windows.cs
@@ -14,7 +14,7 @@ static class CameraViewExtensions
 		cameraView.IsAvailable = videoCaptureDevices.Count > 0;
 	}
 
-	public static async Task<bool> InitializeCameraForCameraView(this MediaCapture mediaCapture, string deviceId, CancellationToken token)
+	public static async Task InitializeCameraForCameraView(this MediaCapture mediaCapture, string deviceId, CancellationToken token)
 	{
 		try
 		{
@@ -48,14 +48,6 @@ static class CameraViewExtensions
 		catch (System.Runtime.InteropServices.COMException)
 		{
 			// Camera already initialized
-			return true;
 		}
-		catch (UnauthorizedAccessException)
-		{
-			// Can't access the camera
-			return false;
-		}
-
-		return true;
 	}
 }

--- a/src/CommunityToolkit.Maui.Camera/Providers/CameraProvider.windows.cs
+++ b/src/CommunityToolkit.Maui.Camera/Providers/CameraProvider.windows.cs
@@ -20,7 +20,12 @@ partial class CameraProvider
 		foreach (var sourceGroup in videoCaptureSourceGroup)
 		{
 			using var mediaCapture = new MediaCapture();
-			await mediaCapture.InitializeCameraForCameraView(sourceGroup.Id, token);
+			bool success = await mediaCapture.InitializeCameraForCameraView(sourceGroup.Id, token);
+
+			if (!success)
+			{
+				continue;
+			}
 
 			CameraPosition position = CameraPosition.Unknown;
 			var device = deviceInfoCollection.FirstOrDefault(deviceInfo => deviceInfo.Id == sourceGroup.Id);

--- a/src/CommunityToolkit.Maui.Camera/Providers/CameraProvider.windows.cs
+++ b/src/CommunityToolkit.Maui.Camera/Providers/CameraProvider.windows.cs
@@ -20,10 +20,14 @@ partial class CameraProvider
 		foreach (var sourceGroup in videoCaptureSourceGroup)
 		{
 			using var mediaCapture = new MediaCapture();
-			bool success = await mediaCapture.InitializeCameraForCameraView(sourceGroup.Id, token);
 
-			if (!success)
+			try
 			{
+				await mediaCapture.InitializeCameraForCameraView(sourceGroup.Id, token);
+			}
+			catch (Exception)
+			{
+				// can't use that camera
 				continue;
 			}
 


### PR DESCRIPTION
 ### Description of Change ###

The change handles the `UnauthorizedAccessException` in `InitializeCameraForCameraView` and the loop in `PlatformRefreshAvailableCameras()` is just `continue`'d.

 ### Linked Issues ###

 - Fixes #3292

 ### PR Checklist ###

 - [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
 - [ ] Has tests (if omitted, state reason in description)
 - [x] Has samples (if omitted, state reason in description)
 - [x] Rebased on top of `main` at time of PR
 - [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
 - [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls <!-- Replace this link to the direct link to your Pull Request in the MicrosoftDocs/CommunityToolkit repo  -->

 ### Additional information ###

I'm not sure if catching the exception and just returning a bool is OK here, or if the `PlatformRefreshAvailableCameras()` should catch the exceptions instead.

There's still an uncatchable `CameraException` in the `ConnectCamera()` handler, which should probably also be handled differently.
