### PR TITLE
Handle missing Windows notification runtime module

### DIFF
--- a/src/CommunityToolkit.Maui.UnitTests/Extensions/AppBuilderExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Extensions/AppBuilderExtensionsTests.cs
@@ -145,11 +145,12 @@ public class AppBuilderExtensionsTests : BaseTest
 	}
 
 	[Theory]
-	[InlineData(unchecked((int)0x8007007E), true)]
-	[InlineData(unchecked((int)0x80004005), false)]
-	public void IsWindowsAppRuntimeModuleUnavailableReturnsExpectedResult(int hresult, bool expected)
+	[InlineData(unchecked((int)0x8007007E), "Unable to load resource dll. Microsoft.WindowsAppRuntime.Insights.Resource.dll", true)]
+	[InlineData(unchecked((int)0x8007007E), "Unable to load resource dll. Other.Resource.dll", false)]
+	[InlineData(unchecked((int)0x80004005), "Unable to load resource dll. Microsoft.WindowsAppRuntime.Insights.Resource.dll", false)]
+	public void IsWindowsAppRuntimeModuleUnavailableReturnsExpectedResult(int hresult, string message, bool expected)
 	{
-		var exception = new System.Runtime.InteropServices.COMException(string.Empty, hresult);
+		var exception = new System.Runtime.InteropServices.COMException(message, hresult);
 
 		Assert.Equal(expected, Options.IsWindowsAppRuntimeModuleUnavailable(exception));
 	}

--- a/src/CommunityToolkit.Maui.UnitTests/Extensions/AppBuilderExtensionsTests.cs
+++ b/src/CommunityToolkit.Maui.UnitTests/Extensions/AppBuilderExtensionsTests.cs
@@ -144,6 +144,16 @@ public class AppBuilderExtensionsTests : BaseTest
 		}
 	}
 
+	[Theory]
+	[InlineData(unchecked((int)0x8007007E), true)]
+	[InlineData(unchecked((int)0x80004005), false)]
+	public void IsWindowsAppRuntimeModuleUnavailableReturnsExpectedResult(int hresult, bool expected)
+	{
+		var exception = new System.Runtime.InteropServices.COMException(string.Empty, hresult);
+
+		Assert.Equal(expected, Options.IsWindowsAppRuntimeModuleUnavailable(exception));
+	}
+
 	[Fact]
 	public void UseMauiCommunityToolkitMediaElement_ShouldUseSurfaceViewByDefault()
 	{

--- a/src/CommunityToolkit.Maui/Options.shared.cs
+++ b/src/CommunityToolkit.Maui/Options.shared.cs
@@ -13,6 +13,10 @@ namespace CommunityToolkit.Maui;
 /// </summary>
 public class Options : Core.Options
 {
+	const int moduleNotFoundHResult = unchecked((int)0x8007007E);
+#if WINDOWS
+	static bool isSnackbarNotificationManagerRegistered;
+#endif
 	readonly MauiAppBuilder? builder;
 
 	internal Options(in MauiAppBuilder builder) : this()
@@ -86,8 +90,22 @@ public class Options : Core.Options
 
 						else if (Application.Current.Windows.Count is 1)
 						{
-							Microsoft.Windows.AppNotifications.AppNotificationManager.Default.NotificationInvoked += OnSnackbarNotificationInvoked;
-							Microsoft.Windows.AppNotifications.AppNotificationManager.Default.Register();
+							var notificationManager = Microsoft.Windows.AppNotifications.AppNotificationManager.Default;
+							notificationManager.NotificationInvoked += OnSnackbarNotificationInvoked;
+
+							try
+							{
+								notificationManager.Register();
+								isSnackbarNotificationManagerRegistered = true;
+							}
+							// Windows App SDK can omit the Insights resource DLL from self-contained unpackaged apps.
+							// Registration then fails, but notifications can still be shown without action callbacks. See https://github.com/microsoft/WindowsAppSDK/issues/6071.
+							catch (System.Runtime.InteropServices.COMException exception) when (IsWindowsAppRuntimeModuleUnavailable(exception))
+							{
+								notificationManager.NotificationInvoked -= OnSnackbarNotificationInvoked;
+								System.Diagnostics.Trace.WriteLine(
+									$"{nameof(Alerts.Snackbar)} action callbacks could not be registered because a Windows App Runtime module is unavailable. Snackbar notifications remain enabled. {exception}");
+							}
 						}
 					})
 					.OnClosed((_, _) =>
@@ -96,10 +114,11 @@ public class Options : Core.Options
 						{
 							throw new InvalidOperationException($"{nameof(Application)}.{nameof(Application.Current)} cannot be null when Windows are closed");
 						}
-						else if (Application.Current.Windows.Count is 0)
+						else if (Application.Current.Windows.Count is 0 && isSnackbarNotificationManagerRegistered)
 						{
 							Microsoft.Windows.AppNotifications.AppNotificationManager.Default.NotificationInvoked -= OnSnackbarNotificationInvoked;
 							Microsoft.Windows.AppNotifications.AppNotificationManager.Default.Unregister();
+							isSnackbarNotificationManagerRegistered = false;
 						}
 					}));
 			});
@@ -134,4 +153,7 @@ public class Options : Core.Options
 	{
 		DefaultPopupOptionsSettings = globalPopupOptionsSettings;
 	}
+
+	internal static bool IsWindowsAppRuntimeModuleUnavailable(System.Runtime.InteropServices.COMException exception)
+		=> exception.HResult is moduleNotFoundHResult;
 }

--- a/src/CommunityToolkit.Maui/Options.shared.cs
+++ b/src/CommunityToolkit.Maui/Options.shared.cs
@@ -13,6 +13,7 @@ namespace CommunityToolkit.Maui;
 /// </summary>
 public class Options : Core.Options
 {
+	const string windowsAppRuntimeInsightsResourceDll = "Microsoft.WindowsAppRuntime.Insights.Resource.dll";
 	const int moduleNotFoundHResult = unchecked((int)0x8007007E);
 #if WINDOWS
 	static bool isSnackbarNotificationManagerRegistered;
@@ -91,18 +92,17 @@ public class Options : Core.Options
 						else if (Application.Current.Windows.Count is 1)
 						{
 							var notificationManager = Microsoft.Windows.AppNotifications.AppNotificationManager.Default;
-							notificationManager.NotificationInvoked += OnSnackbarNotificationInvoked;
 
 							try
 							{
 								notificationManager.Register();
 								isSnackbarNotificationManagerRegistered = true;
+								notificationManager.NotificationInvoked += OnSnackbarNotificationInvoked;
 							}
 							// Windows App SDK can omit the Insights resource DLL from self-contained unpackaged apps.
 							// Registration then fails, but notifications can still be shown without action callbacks. See https://github.com/microsoft/WindowsAppSDK/issues/6071.
 							catch (System.Runtime.InteropServices.COMException exception) when (IsWindowsAppRuntimeModuleUnavailable(exception))
 							{
-								notificationManager.NotificationInvoked -= OnSnackbarNotificationInvoked;
 								System.Diagnostics.Trace.WriteLine(
 									$"{nameof(Alerts.Snackbar)} action callbacks could not be registered because a Windows App Runtime module is unavailable. Snackbar notifications remain enabled. {exception}");
 							}
@@ -155,5 +155,6 @@ public class Options : Core.Options
 	}
 
 	internal static bool IsWindowsAppRuntimeModuleUnavailable(System.Runtime.InteropServices.COMException exception)
-		=> exception.HResult is moduleNotFoundHResult;
+		=> exception.HResult is moduleNotFoundHResult
+			&& exception.Message.Contains(windowsAppRuntimeInsightsResourceDll, StringComparison.OrdinalIgnoreCase);
 }


### PR DESCRIPTION
### Description of Change ###

.NET 11 MAUI uses Windows App SDK 2.3.1. In self-contained unpackaged Windows apps, `AppNotificationManager.Register()` can throw `COMException` (`0x8007007E`) because `Microsoft.WindowsAppRuntime.Insights.Resource.dll` is missing. This currently crashes app startup when `SetShouldEnableSnackbarOnWindows(true)` is enabled.

This change handles only that known module-not-found failure. Snackbar notifications can still be displayed, but action callbacks are disabled for the affected runtime configuration. The failure is written to `Trace`, the event handler is removed, and shutdown skips `Unregister()` when registration did not succeed. Other registration failures continue to propagate.

The behavior is tracked upstream by microsoft/WindowsAppSDK#6071 and remains reproducible with Windows App SDK 2.3.1.

### Linked Issues ###

- Related to #3271
- Upstream: https://github.com/microsoft/WindowsAppSDK/issues/6071

### PR Checklist ###

- [x] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal)
- [x] Has tests
- [ ] Has samples (no sample changes are required; the existing sample already enables Windows Snackbar registration)
- [x] Rebased on top of `main` at time of PR
- [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
- [ ] Documentation created or updated (no public API or setup changes)

### Additional information ###

Verified on Windows ARM64 with .NET 11 Preview 7 using an isolated self-contained unpackaged reproduction:

- `Register()` reproduces the reported `0x8007007E` exception and missing Insights resource message.
- `Show()` succeeds after that registration failure.
- Applying the filtered fallback allows the process to exit normally while retaining notification display.
- The .NET 10 Windows Toolkit target builds successfully.
- All 14 `AppBuilderExtensionsTests` pass.