### PR TITLE
Restore Windows notification registration compatibility

### DIFF
--- a/src/CommunityToolkit.Maui/Options.shared.cs
+++ b/src/CommunityToolkit.Maui/Options.shared.cs
@@ -92,12 +92,15 @@ public class Options : Core.Options
 						else if (Application.Current.Windows.Count is 1)
 						{
 							var notificationManager = Microsoft.Windows.AppNotifications.AppNotificationManager.Default;
+							var registrationSucceeded = false;
 
 							try
 							{
-								notificationManager.Register();
-								isSnackbarNotificationManagerRegistered = true;
+								// Windows App SDK requires event handlers to be subscribed before Register is called.
 								notificationManager.NotificationInvoked += OnSnackbarNotificationInvoked;
+								notificationManager.Register();
+								registrationSucceeded = true;
+								isSnackbarNotificationManagerRegistered = true;
 							}
 							// Windows App SDK can omit the Insights resource DLL from self-contained unpackaged apps.
 							// Registration then fails, but notifications can still be shown without action callbacks. See https://github.com/microsoft/WindowsAppSDK/issues/6071.
@@ -105,6 +108,13 @@ public class Options : Core.Options
 							{
 								System.Diagnostics.Trace.WriteLine(
 									$"{nameof(Alerts.Snackbar)} action callbacks could not be registered because a Windows App Runtime module is unavailable. Snackbar notifications remain enabled. {exception}");
+							}
+							finally
+							{
+								if (registrationSucceeded is false)
+								{
+									notificationManager.NotificationInvoked -= OnSnackbarNotificationInvoked;
+								}
 							}
 						}
 					})


### PR DESCRIPTION
### Description of Change ###

PR #3301 made Snackbar notification initialization work on .NET 11, but its review-driven event subscription ordering broke .NET 10 with Windows App SDK 1.8. Subscribing to `NotificationInvoked` after `Register()` throws `COMException` `0x80070490` because Windows App SDK requires event handlers to be subscribed before registration.

This restores the required subscribe-before-`Register()` ordering. A local registration-success flag is set only after `Register()` succeeds, and a `finally` block removes the handler whenever registration fails, including the already-handled .NET 11 `0x8007007E` Insights resource DLL failure and unexpected exceptions. Successful registrations retain the handler and existing shutdown cleanup.

The ordering behavior was verified in isolation on both .NET 10 and .NET 11. The focused `AppBuilderExtensionsTests` suite passes, and the .NET 10 Windows library target builds successfully.

This PR remains **draft** while our testers verify the fix before it is marked ready for review.

### Linked Issues ###

- Follow-up to #3301

### PR Checklist ###

- [ ] Has a linked Issue, and the Issue has been `approved`(bug) or `Championed` (feature/proposal) — follow-up regression fix for #3301
- [x] Has tests (existing focused AppBuilderExtensions tests pass; platform registration ordering was verified in isolation)
- [ ] Has samples (not applicable; lifecycle registration fix only)
- [x] Rebased on top of `main` at time of PR
- [x] Changes adhere to [coding standard](https://github.com/CommunityToolkit/Maui/blob/main/CONTRIBUTING.md#contributing-code---best-practices)
- [ ] Documentation created or updated: https://github.com/MicrosoftDocs/CommunityToolkit/pulls — not applicable; no public API or behavior documentation change

### Additional information ###

The regression reproduces on .NET 10 / Windows App SDK 1.8 as `Element not found. Must register event handlers before calling Register()`. On .NET 11, the known missing Insights resource DLL registration failure remains handled, while the pre-registration event subscription is now reliably removed.